### PR TITLE
Bump version to 2.1.0

### DIFF
--- a/Clocker/Clocker.xcodeproj/project.pbxproj
+++ b/Clocker/Clocker.xcodeproj/project.pbxproj
@@ -1030,7 +1030,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tpak.Meridian;
@@ -1486,7 +1486,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-D DEBUG";
@@ -1565,7 +1565,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.0.0;
+				MARKETING_VERSION = 2.1.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-D RELEASE";


### PR DESCRIPTION
## Summary
- Bump MARKETING_VERSION from 2.0.0 to 2.1.0 across all build configurations

Includes housekeeping cleanup, CodeQL security scanning, and startup performance fix since 2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)