### PR TITLE
Change CodeQL to daily schedule only

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,12 +1,9 @@
 name: CodeQL
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   schedule:
-    - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
+    - cron: '0 6 * * *'  # Daily at 6am UTC
+  workflow_dispatch: # Allow manual runs
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary
- Remove push/PR triggers from CodeQL workflow — no longer runs on every commit or PR
- Change schedule from weekly (Monday) to daily (6am UTC) for faster feedback
- Add `workflow_dispatch` trigger for manual runs when needed

This avoids blocking PRs on long CodeQL analysis runs while we're making frequent changes, while still catching security issues within 24 hours.

## Test plan
- [x] Verify workflow YAML is valid
- [ ] Confirm next scheduled run triggers correctly (tomorrow 6am UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)