### PR TITLE
Bump version to 2.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,7 +96,7 @@ All in `Clocker/Dependencies/`.
 
 ## Test Notes
 
-- Unit tests in `Clocker/ClockerUnitTests/` (102 tests)
+- Unit tests in `Clocker/ClockerUnitTests/` (112 tests)
 - `MockDataStore` available for DI; `MockURLProtocol` for network mocking
 - UI tests in `Clocker/ClockerUITests/` (panel interactions)
 - `@testable import Meridian` (module follows PRODUCT_NAME)

--- a/Clocker/Clocker.xcodeproj/project.pbxproj
+++ b/Clocker/Clocker.xcodeproj/project.pbxproj
@@ -1037,7 +1037,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.2.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tpak.Meridian;
@@ -1493,7 +1493,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.2.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-D DEBUG";
@@ -1572,7 +1572,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.1.0;
+				MARKETING_VERSION = 2.2.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-D RELEASE";


### PR DESCRIPTION
## Summary

- Bump `MARKETING_VERSION` from 2.1.0 to 2.2.0 across all build configurations
- Update CLAUDE.md test count (102 → 112)

## Test plan

- [x] Build succeeds locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)