### PR TITLE
Consolidate panel UI, clock icon, and Sparkle updates

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -4,11 +4,13 @@ import Cocoa
 import CoreLocation
 import CoreLoggerKit
 import CoreModelKit
+import Sparkle
 
 @main
 open class AppDelegate: NSObject, NSApplicationDelegate {
     internal lazy var panelController = PanelController(windowNibName: .panel)
     private var statusBarHandler: StatusItemHandler!
+    let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
 
     public func applicationDidFinishLaunching(_: Notification) {
         AppDefaults.initialize(with: DataStore.shared(), defaults: UserDefaults.standard)
@@ -20,9 +22,11 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
 
         let toggleMenuItem = NSMenuItem(title: "Toggle Panel", action: #selector(AppDelegate.togglePanel(_:)), keyEquivalent: "")
         let openPreferences = NSMenuItem(title: "Settings", action: #selector(AppDelegate.openPreferencesWindow), keyEquivalent: ",")
+        let checkForUpdates = NSMenuItem(title: "Check for Updates…", action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)), keyEquivalent: "")
+        checkForUpdates.target = updaterController
         let hideFromDockMenuItem = NSMenuItem(title: "Hide from Dock", action: #selector(AppDelegate.hideFromDock), keyEquivalent: "")
 
-        [toggleMenuItem, openPreferences, hideFromDockMenuItem].forEach {
+        [toggleMenuItem, openPreferences, checkForUpdates, hideFromDockMenuItem].forEach {
             $0.isEnabled = true
             menu.addItem($0)
         }

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -31,7 +31,7 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc private func openPreferencesWindow() {
-        panelController.openPreferences(NSButton())
+        panelController.openPreferencesWindow()
     }
 
     @objc func hideFromDock() {

--- a/Meridian/Clocker/Clocker-Info.plist
+++ b/Meridian/Clocker/Clocker-Info.plist
@@ -40,5 +40,9 @@
 	<true/>
 	<key>RequestsOpenAccess</key>
 	<string>YES</string>
+	<key>SUFeedURL</key>
+	<string>https://raw.githubusercontent.com/tpak/meridian/main/appcast.xml</string>
+	<key>SUPublicEDKey</key>
+	<string></string>
 </dict>
 </plist>

--- a/Meridian/Clocker/Clocker-Info.plist
+++ b/Meridian/Clocker/Clocker-Info.plist
@@ -43,6 +43,6 @@
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/tpak/meridian/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>
-	<string></string>
+	<string>6aLwQvjUe74RhVN1IVlf9IIIAc6kwbQF74tC8CBifqU=</string>
 </dict>
 </plist>

--- a/Meridian/Clocker/en.lproj/Panel.xib
+++ b/Meridian/Clocker/en.lproj/Panel.xib
@@ -16,11 +16,9 @@
                 <outlet property="modernContainerView" destination="8W7-rS-Uob" id="qgZ-SS-ayy"/>
                 <outlet property="modernSlider" destination="lxA-64-3QU" id="kS5-ub-7gV"/>
                 <outlet property="modernSliderLabel" destination="e2d-EI-Dm0" id="eby-rL-B21"/>
-                <outlet property="pinButton" destination="YXE-4J-5cn" id="k6V-HK-7XG"/>
-                <outlet property="preferencesButton" destination="Ctq-BV-GPN" id="cdL-5h-qmx"/>
                 <outlet property="resetModernSliderButton" destination="TK5-db-7bd" id="Mie-WC-5YN"/>
                 <outlet property="scrollViewHeight" destination="dff-DX-W1o" id="vYe-lb-h9x"/>
-                <outlet property="shutdownButton" destination="1cR-pI-osG" id="ZFz-9l-yNi"/>
+                <outlet property="settingsButton" destination="1cR-pI-osG" id="ZFz-9l-yNi"/>
                 <outlet property="stackView" destination="OZA-6o-SbE" id="lIT-4b-8WZ"/>
 
                 <outlet property="window" destination="5" id="7"/>
@@ -371,62 +369,28 @@
                             <customView wantsLayer="YES" focusRingType="none" translatesAutoresizingMaskIntoConstraints="NO" id="B8X-sx-cjT">
                                 <rect key="frame" x="0.0" y="0.0" width="379" height="40"/>
                                 <subviews>
-                                    <button toolTip="Options" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1cR-pI-osG">
-                                        <rect key="frame" x="339" y="7" width="30" height="26"/>
-                                        <buttonCell key="cell" type="recessed" bezelStyle="recessed" image="PowerIcon" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Fp1-89-Nwm">
-                                            <behavior key="behavior" lightByContents="YES"/>
-                                            <font key="font" metaFont="systemBold" size="12"/>
-                                        </buttonCell>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="25" id="WSi-Xj-Kfl"/>
-                                            <constraint firstAttribute="width" constant="30" id="j2s-C4-pK5"/>
-                                        </constraints>
-                                        <accessibility identifier="Close"/>
-                                        <connections>
-                                            <action selector="showMoreOptions:" target="-2" id="xl5-rm-4JK"/>
-                                        </connections>
-                                    </button>
-                                    <button toolTip="Switch between Menubar/Floating mode." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YXE-4J-5cn">
-                                        <rect key="frame" x="180" y="10" width="30" height="19"/>
-                                        <buttonCell key="cell" type="recessed" bezelStyle="recessed" image="Float-White" imagePosition="only" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="iwC-c9-CBS">
-                                            <behavior key="behavior" lightByContents="YES"/>
-                                            <font key="font" metaFont="systemBold" size="12"/>
-                                        </buttonCell>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="30" id="fWo-31-i3M"/>
-                                            <constraint firstAttribute="height" constant="18" id="v7I-PR-eTK"/>
-                                        </constraints>
-                                        <accessibility identifier="Pin"/>
-                                        <connections>
-                                            <action selector="convertToFloatingWindow:" target="-2" id="cuu-WJ-Sd9"/>
-                                        </connections>
-                                    </button>
-                                    <button toolTip="Add Location" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ctq-BV-GPN">
-                                        <rect key="frame" x="10" y="10" width="30" height="19"/>
-                                        <buttonCell key="cell" type="recessed" bezelStyle="recessed" imagePosition="only" alignment="center" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="SIv-Ve-UkG">
+                                    <button toolTip="Settings" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1cR-pI-osG">
+                                        <rect key="frame" x="10" y="7" width="30" height="26"/>
+                                        <buttonCell key="cell" type="recessed" bezelStyle="recessed" imagePosition="only" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Fp1-89-Nwm">
                                             <behavior key="behavior" lightByContents="YES"/>
                                             <font key="font" metaFont="systemBold" size="12"/>
                                             <string key="keyEquivalent">,</string>
                                             <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                                         </buttonCell>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="30" id="oaD-Rr-qht"/>
-                                            <constraint firstAttribute="height" constant="18" id="t4M-6L-Vqi"/>
+                                            <constraint firstAttribute="height" constant="25" id="WSi-Xj-Kfl"/>
+                                            <constraint firstAttribute="width" constant="30" id="j2s-C4-pK5"/>
                                         </constraints>
-                                        <accessibility identifier="Preferences"/>
+                                        <accessibility identifier="Settings"/>
                                         <connections>
-                                            <action selector="openPreferences:" target="-2" id="Wwy-xc-psI"/>
+                                            <action selector="showSettingsMenu:" target="-2" id="xl5-rm-4JK"/>
                                         </connections>
                                     </button>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="Ctq-BV-GPN" firstAttribute="centerY" secondItem="B8X-sx-cjT" secondAttribute="centerY" id="6Q7-jc-cTL"/>
-                                    <constraint firstItem="YXE-4J-5cn" firstAttribute="centerY" secondItem="B8X-sx-cjT" secondAttribute="centerY" id="OHe-Tc-b0V"/>
-                                    <constraint firstItem="YXE-4J-5cn" firstAttribute="leading" secondItem="Ctq-BV-GPN" secondAttribute="trailing" constant="55" id="bL5-Kt-zaC"/>
                                     <constraint firstAttribute="height" constant="40" id="iYW-fj-EE2"/>
                                     <constraint firstItem="1cR-pI-osG" firstAttribute="centerY" secondItem="B8X-sx-cjT" secondAttribute="centerY" id="oVJ-Xa-cTw"/>
-                                    <constraint firstAttribute="trailing" secondItem="1cR-pI-osG" secondAttribute="trailing" constant="10" id="rb9-gW-QZS"/>
-                                    <constraint firstItem="Ctq-BV-GPN" firstAttribute="leading" secondItem="B8X-sx-cjT" secondAttribute="leading" constant="10" id="ydm-oF-sVc"/>
+                                    <constraint firstItem="1cR-pI-osG" firstAttribute="leading" secondItem="B8X-sx-cjT" secondAttribute="leading" constant="10" id="ydm-oF-sVc"/>
                                 </constraints>
                             </customView>
                         </subviews>

--- a/Meridian/Meridian.xcodeproj/project.pbxproj
+++ b/Meridian/Meridian.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		SP000001SPARKLE00000001 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = SP000002SPARKLE00000002 /* Sparkle */; };
 		AA000001SWIFTUI00000001 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002SWIFTUI00000001 /* AboutView.swift */; };
 		3508CC942599FFEC000E3530 /* MenubarTitleProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3508CC932599FFEC000E3530 /* MenubarTitleProvider.swift */; };
 		3508CC9A259A0001000E3530 /* StatusItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3508CC99259A0001000E3530 /* StatusItemView.swift */; };
@@ -271,6 +272,7 @@
 				9ACF469D1DCBD45200C49B51 /* Quartz.framework in Frameworks */,
 				9AC678E41C1ABAB9003B4F6B /* QuartzCore.framework in Frameworks */,
 				35B2FEF1259A2DB1005DA84D /* CoreModelKit in Frameworks */,
+				SP000001SPARKLE00000001 /* Sparkle in Frameworks */,
 				35B2FEDD259A2291005DA84D /* CoreLoggerKit in Frameworks */,
 				9A6D93371CF3E82F005A8690 /* CoreImage.framework in Frameworks */,
 				9A9E876A1C1FEDDB00A7A2DF /* SystemConfiguration.framework in Frameworks */,
@@ -667,6 +669,7 @@
 			packageProductDependencies = (
 				35B2FEDC259A2291005DA84D /* CoreLoggerKit */,
 				35B2FEF0259A2DB1005DA84D /* CoreModelKit */,
+				SP000002SPARKLE00000002 /* Sparkle */,
 			);
 			productName = Popup;
 			productReference = DD4F7C0413C30F9F00825C6E /* Clocker.app */;
@@ -713,6 +716,9 @@
 				Base,
 			);
 			mainGroup = DD4F7BF913C30F9F00825C6E;
+			packageReferences = (
+				SP000003SPARKLE00000003 /* XCRemoteSwiftPackageReference "Sparkle" */,
+			);
 			productRefGroup = DD4F7C0513C30F9F00825C6E /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -1634,6 +1640,17 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		SP000003SPARKLE00000003 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/sparkle-project/Sparkle";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.6.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		35B2FEDC259A2291005DA84D /* CoreLoggerKit */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -1642,6 +1659,11 @@
 		35B2FEF0259A2DB1005DA84D /* CoreModelKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CoreModelKit;
+		};
+		SP000002SPARKLE00000002 /* Sparkle */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = SP000003SPARKLE00000003 /* XCRemoteSwiftPackageReference "Sparkle" */;
+			productName = Sparkle;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Meridian/MeridianUITests/AboutUsTests.swift
+++ b/Meridian/MeridianUITests/AboutUsTests.swift
@@ -16,10 +16,7 @@ class AboutUsTests: XCTestCase {
         app.launchArguments.append(CLUITestingLaunchArgument)
         app.launch()
 
-        if app.tables["FloatingTableView"].exists {
-            app.tapMenubarIcon()
-            app.buttons["FloatingPin"].click()
-        }
+        app.tapMenubarIcon()
     }
 
     private func tapAboutTab() {
@@ -32,8 +29,7 @@ class AboutUsTests: XCTestCase {
     // We verify the button exists and is clickable; actual URL opening
     // cannot be validated in a UI test.
     func testPrivateFeedbackButtonExists() {
-        app.tapMenubarIcon()
-        app.buttons["Preferences"].click()
+        app.tables["mainTableView"].typeKey(",", modifierFlags: .command)
 
         tapAboutTab()
 

--- a/Meridian/MeridianUITests/CopyToClipboardTests.swift
+++ b/Meridian/MeridianUITests/CopyToClipboardTests.swift
@@ -9,11 +9,6 @@ class CopyToClipboardTests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launch()
-
-        if app.tables["FloatingTableView"].exists == false {
-            app.tapMenubarIcon()
-            app.buttons["Pin"].click()
-        }
     }
 
     override func tearDownWithError() throws {
@@ -21,7 +16,9 @@ class CopyToClipboardTests: XCTestCase {
     }
 
     func testFullCopy() throws {
-        let cell = app.tables["FloatingTableView"].cells.firstMatch
+        app.tapMenubarIcon()
+
+        let cell = app.tables["mainTableView"].cells.firstMatch
         let customLabel = cell.staticTexts["CustomNameLabelForCell"]
         guard let value = customLabel.value else { return }
         let time = cell.staticTexts["ActualTime"].value ?? "Nil Value"
@@ -35,27 +32,21 @@ class CopyToClipboardTests: XCTestCase {
                   "Clipboard value (\(actualValue)) doesn't match expected result: \(expectedValue)")
 
         // Test full copy
-        let cellCount = app.tables["FloatingTableView"].cells.count
+        let cellCount = app.tables["mainTableView"].cells.count
         var clipboardValue: [String] = []
         for cellIndex in 0 ..< cellCount {
-            let cell = app.tables["FloatingTableView"].cells.element(boundBy: cellIndex)
+            let cell = app.tables["mainTableView"].cells.element(boundBy: cellIndex)
             let time = cell.staticTexts["ActualTime"].value ?? "Nil Value"
             clipboardValue.append("\(time)")
         }
-        
-        
 
         app.buttons["Share"].click()
     }
 
     func testModernSlider() {
-        if app.buttons["FloatingPin"].exists {
-            app.buttons["FloatingPin"].click()
-        }
-
         app.tapMenubarIcon()
         let modernSliderExists = app.collectionViews["ModernSlider"].exists
-        app.buttons["Preferences"].click()
+        app.tables["mainTableView"].typeKey(",", modifierFlags: .command)
 
         let appearanceTab = app.toolbars.buttons.element(boundBy: 1)
         appearanceTab.click()

--- a/Meridian/MeridianUITests/PanelTests.swift
+++ b/Meridian/MeridianUITests/PanelTests.swift
@@ -46,28 +46,10 @@ class PanelTests: XCTestCase {
         continueAfterFailure = false
         app = XCUIApplication()
         app.launch()
-
-        if app.tables["FloatingTableView"].exists {
-            app.buttons["FloatingPin"].click()
-        }
     }
 
     override func tearDown() {
         super.tearDown()
-    }
-
-    func testPinningPanelAndBack() {
-        app.tapMenubarIcon()
-
-        app.buttons["Pin"].click()
-
-        XCTAssertTrue(app.tables["FloatingTableView"].exists, "Floating Table unexpectedly doesn't exist.")
-
-        app.buttons["FloatingPin"].click()
-
-        app.tapMenubarIcon()
-
-        XCTAssertTrue(app.tables["mainTableView"].exists, "Main Table unexpectedly doesn't exist")
     }
 
     func testChangingLabelFromPopover() {
@@ -106,7 +88,7 @@ class PanelTests: XCTestCase {
         let upcomingView = app.collectionViews["UpcomingEventCollectionView"]
         let beforeUpcomingEventViewExist = upcomingView.exists
 
-        app.buttons["Preferences"].click()
+        app.tables["mainTableView"].typeKey(",", modifierFlags: .command)
 
         let clockerWindow = app.windows["Meridian"]
         let toolbarsQuery = clockerWindow.toolbars.buttons

--- a/Meridian/MeridianUITests/PreferencesTest.swift
+++ b/Meridian/MeridianUITests/PreferencesTest.swift
@@ -15,10 +15,7 @@ class PreferencesTest: XCTestCase {
         app = XCUIApplication()
         app.launchArguments.append(CLUITestingLaunchArgument)
         app.launch()
-        if app.tables["FloatingTableView"].exists {
-            app.tapMenubarIcon()
-            app.buttons["FloatingPin"].click()
-        }
+        app.tapMenubarIcon()
     }
 
     func testRemovingButtonVisibility() {
@@ -267,7 +264,7 @@ class PreferencesTest: XCTestCase {
 
     func testNoTimezone() {
         app.tapMenubarIcon()
-        app.buttons["Preferences"].click()
+        app.tables["mainTableView"].typeKey(",", modifierFlags: .command)
 
         deleteAllTimezones()
 
@@ -291,7 +288,7 @@ class PreferencesTest: XCTestCase {
 
     func testWarningIfMoreThanOneMenubarIsSelected() {
         app.tapMenubarIcon()
-        app.buttons["Preferences"].click()
+        app.tables["mainTableView"].typeKey(",", modifierFlags: .command)
 
         let preferencesTable = app.tables["TimezoneTableView"]
         XCTAssertTrue(preferencesTable.exists)

--- a/Meridian/MeridianUITests/ShortcutTests.swift
+++ b/Meridian/MeridianUITests/ShortcutTests.swift
@@ -15,7 +15,6 @@ class ShortcutTests: XCTestCase {
         app.tapMenubarIcon()
 
         if !app.tables["mainTableView"].exists {
-            app.buttons["FloatingPin"].click()
             app.tapMenubarIcon()
         }
     }

--- a/Meridian/MeridianUnitTests/AppDelegateTests.swift
+++ b/Meridian/MeridianUnitTests/AppDelegateTests.swift
@@ -38,14 +38,15 @@ class AppDelegateTests: XCTestCase {
         let items = dockMenu?.items ?? []
 
         XCTAssertEqual(dockMenu?.title, "Quick Access")
-        XCTAssertEqual(items.first?.title, "Toggle Panel")
+        XCTAssertEqual(items[0].title, "Toggle Panel")
         XCTAssertEqual(items[1].title, "Settings")
         XCTAssertEqual(items[1].keyEquivalent, ",")
-        XCTAssertEqual(items[2].title, "Hide from Dock")
+        XCTAssertEqual(items[2].title, "Check for Updates…")
+        XCTAssertEqual(items[3].title, "Hide from Dock")
 
         // Test selections
-        XCTAssertEqual(items.first?.action, #selector(AppDelegate.togglePanel(_:)))
-        XCTAssertEqual(items[2].action, #selector(AppDelegate.hideFromDock))
+        XCTAssertEqual(items[0].action, #selector(AppDelegate.togglePanel(_:)))
+        XCTAssertEqual(items[3].action, #selector(AppDelegate.hideFromDock))
 
         items.forEach { menuItem in
             XCTAssertTrue(menuItem.isEnabled)

--- a/Meridian/Panel/PanelContextMenu.swift
+++ b/Meridian/Panel/PanelContextMenu.swift
@@ -1,6 +1,7 @@
 // Copyright © 2015 Abhishek Banthia
 
 import Cocoa
+import Sparkle
 
 /// Builds the "More Options" context menu for the panel.
 /// Extracted from ParentPanelController to reduce god-class complexity.
@@ -14,6 +15,19 @@ enum PanelContextMenu {
                                       action: #selector(ParentPanelController.rate), keyEquivalent: "")
         let sendFeedback = NSMenuItem(title: "Send Feedback...",
                                       action: #selector(ParentPanelController.reportIssue), keyEquivalent: "")
+
+        // Check for Updates via Sparkle
+        let checkForUpdates: NSMenuItem
+        if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
+            checkForUpdates = NSMenuItem(title: "Check for Updates…",
+                                         action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
+                                         keyEquivalent: "")
+            checkForUpdates.target = appDelegate.updaterController
+        } else {
+            checkForUpdates = NSMenuItem(title: "Check for Updates…", action: nil, keyEquivalent: "")
+            checkForUpdates.isEnabled = false
+        }
+
         let terminateOption = NSMenuItem(title: "Quit Meridian",
                                          action: #selector(ParentPanelController.terminateClocker), keyEquivalent: "")
 
@@ -25,6 +39,8 @@ enum PanelContextMenu {
         clockerVersionInfo.isEnabled = false
 
         menu.addItem(openPreferences)
+        menu.addItem(checkForUpdates)
+        menu.addItem(NSMenuItem.separator())
         menu.addItem(rateMeridian)
         menu.addItem(withTitle: "FAQs", action: #selector(ParentPanelController.openFAQs), keyEquivalent: "")
         menu.addItem(sendFeedback)

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -38,11 +38,7 @@ class ParentPanelController: NSWindowController {
 
     @IBOutlet var scrollViewHeight: NSLayoutConstraint!
 
-    @IBOutlet var shutdownButton: NSButton!
-
-    @IBOutlet var preferencesButton: NSButton!
-
-    @IBOutlet var pinButton: NSButton!
+    @IBOutlet var settingsButton: NSButton!
 
     @IBOutlet var roundedDateView: NSView!
 
@@ -104,10 +100,8 @@ class ParentPanelController: NSWindowController {
         mainTableView.enclosingScrollView?.hasVerticalScroller = false
         mainTableView.style = .plain
 
-        // Setup images using system symbols
-        shutdownButton.image = NSImage(systemSymbolName: "power", accessibilityDescription: "Quit")!
-        preferencesButton.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")!
-        pinButton.image = NSImage(systemSymbolName: "pin", accessibilityDescription: "Pin")!
+        // Setup settings button
+        settingsButton.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")!
 
         // Setup KVO observers for user default changes
         setupObservers()
@@ -327,12 +321,7 @@ class ParentPanelController: NSWindowController {
         .baselineOffset: 0.1
     ]
 
-    @IBAction func openPreferences(_: NSButton) {
-        updatePopoverDisplayState()
-        openPreferencesWindow()
-    }
-
-    @IBAction func showMoreOptions(_ sender: NSButton) {
+    @IBAction func showSettingsMenu(_ sender: NSButton) {
         guard let event = NSApp.currentEvent else { return }
         let menu = PanelContextMenu.build(target: self)
         NSMenu.popUpContextMenu(menu,

--- a/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
@@ -319,7 +319,7 @@ class StatusItemHandler: NSObject {
         }
 
         statusItem.button?.title = UserDefaultKeys.emptyString
-        statusItem.button?.image = NSImage(systemSymbolName: "globe", accessibilityDescription: "Meridian")
+        statusItem.button?.image = NSImage(systemSymbolName: "clock.fill", accessibilityDescription: "Meridian")
         statusItem.button?.imagePosition = .imageOnly
         statusItem.button?.toolTip = "Meridian"
     }

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>Meridian Updates</title>
+        <description>Most recent changes with links to updates.</description>
+        <language>en</language>
+    </channel>
+</rss>


### PR DESCRIPTION
## Summary
- **Consolidate panel buttons**: Remove broken pin button (floating mode had no implementation) and redundant gear button. Single gear icon now opens context menu with Settings, Check for Updates, Support, FAQs, Feedback, and Quit.
- **Menubar icon**: Replace SF Symbol `globe` with `clock.fill` for a more recognizable clock app icon.
- **Sparkle auto-updates**: Integrate Sparkle 2.x via SPM. "Check for Updates…" added to panel settings menu and dock menu. Empty `appcast.xml` at repo root ready for releases.

## Remaining setup for Sparkle
- [ ] Generate EdDSA key pair: `./Sparkle.framework/bin/generate_keys`
- [ ] Add public key to `SUPublicEDKey` in Info.plist
- [ ] Set up code signing + notarization
- [ ] Populate appcast.xml when publishing a release

## Test plan
- [x] Build succeeds (Debug)
- [x] 112 unit tests pass
- [x] SwiftLint clean (only pre-existing generated file warnings)
- [ ] Launch app — verify single gear button at bottom-left of panel
- [ ] Click gear — verify context menu shows Settings, Check for Updates…, Support, FAQs, Feedback, version, Quit
- [ ] Verify `clock.fill` icon appears in menu bar (when no timezones are favourited)
- [ ] Verify Cmd+, opens preferences from panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)