### PR TITLE
Reorganize Preferences and simplify context menu

### DIFF
--- a/Meridian/Overall App/AppDefaults.swift
+++ b/Meridian/Overall App/AppDefaults.swift
@@ -29,7 +29,7 @@ class AppDefaults {
                 UserDefaultKeys.sunriseSunsetTime: 1,
                 UserDefaultKeys.userFontSizePreference: 4,
                 UserDefaultKeys.showAppInForeground: 0,
-                UserDefaultKeys.futureSliderRange: 0,
+                UserDefaultKeys.futureSliderRange: 6,
                 UserDefaultKeys.truncateTextLength: 30,
                 UserDefaultKeys.appDisplayOptions: 0,
                 UserDefaultKeys.menubarCompactMode: 1]

--- a/Meridian/Panel/PanelContextMenu.swift
+++ b/Meridian/Panel/PanelContextMenu.swift
@@ -1,7 +1,6 @@
 // Copyright © 2015 Abhishek Banthia
 
 import Cocoa
-import Sparkle
 
 /// Builds the "More Options" context menu for the panel.
 /// Extracted from ParentPanelController to reduce god-class complexity.
@@ -11,39 +10,17 @@ enum PanelContextMenu {
 
         let openPreferences = NSMenuItem(title: "Settings",
                                          action: #selector(ParentPanelController.openPreferencesWindow), keyEquivalent: "")
-        let rateMeridian = NSMenuItem(title: "Support Meridian...",
-                                      action: #selector(ParentPanelController.rate), keyEquivalent: "")
-        let sendFeedback = NSMenuItem(title: "Send Feedback...",
-                                      action: #selector(ParentPanelController.reportIssue), keyEquivalent: "")
-
-        // Check for Updates via Sparkle
-        let checkForUpdates: NSMenuItem
-        if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
-            checkForUpdates = NSMenuItem(title: "Check for Updates…",
-                                         action: #selector(SPUStandardUpdaterController.checkForUpdates(_:)),
-                                         keyEquivalent: "")
-            checkForUpdates.target = appDelegate.updaterController
-        } else {
-            checkForUpdates = NSMenuItem(title: "Check for Updates…", action: nil, keyEquivalent: "")
-            checkForUpdates.isEnabled = false
-        }
 
         let terminateOption = NSMenuItem(title: "Quit Meridian",
                                          action: #selector(ParentPanelController.terminateClocker), keyEquivalent: "")
 
         let appDisplayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") ?? "Meridian"
         let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") ?? "N/A"
-        let longVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") ?? "N/A"
-        let versionInfo = "\(appDisplayName) \(shortVersion) (\(longVersion))"
+        let versionInfo = "\(appDisplayName) \(shortVersion)"
         let clockerVersionInfo = NSMenuItem(title: versionInfo, action: nil, keyEquivalent: "")
         clockerVersionInfo.isEnabled = false
 
         menu.addItem(openPreferences)
-        menu.addItem(checkForUpdates)
-        menu.addItem(NSMenuItem.separator())
-        menu.addItem(rateMeridian)
-        menu.addItem(withTitle: "FAQs", action: #selector(ParentPanelController.openFAQs), keyEquivalent: "")
-        menu.addItem(sendFeedback)
         menu.addItem(NSMenuItem.separator())
         menu.addItem(clockerVersionInfo)
         menu.addItem(NSMenuItem.separator())

--- a/Meridian/Panel/ParentPanelController+ModernSlider.swift
+++ b/Meridian/Panel/ParentPanelController+ModernSlider.swift
@@ -6,8 +6,8 @@ import Foundation
 
 extension ParentPanelController: NSCollectionViewDataSource {
     func collectionView(_: NSCollectionView, numberOfItemsInSection _: Int) -> Int {
-        let futureSliderDayPreference = DataStore.shared().retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 5
-        let futureSliderDayRange = (futureSliderDayPreference.intValue + 1)
+        let futureSliderDayPreference = DataStore.shared().retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
+        let futureSliderDayRange = futureSliderDayPreference.intValue
         return (PanelConstants.modernSliderPointsInADay * futureSliderDayRange * 2) + 1
     }
 
@@ -147,8 +147,8 @@ extension ParentPanelController {
     }
 
     public func setDefaultDateLabel(_ index: Int) -> Int {
-        let futureSliderDayPreference = DataStore.shared().retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 5
-        let futureSliderDayRange = (futureSliderDayPreference.intValue + 1)
+        let futureSliderDayPreference = DataStore.shared().retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
+        let futureSliderDayRange = futureSliderDayPreference.intValue
         let totalCount = (PanelConstants.modernSliderPointsInADay * futureSliderDayRange * 2) + 1
         let centerPoint = Int(ceil(Double(totalCount / 2)))
         if index >= (centerPoint + 1) {

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -7,8 +7,7 @@ struct AboutView: View {
     private let versionString: String = {
         let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") ?? "Meridian"
         let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") ?? "N/A"
-        let buildVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") ?? "N/A"
-        return "\(appName) \(shortVersion) (\(buildVersion))"
+        return "\(appName) \(shortVersion)"
     }()
 
     var body: some View {

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -3,6 +3,7 @@
 import Cocoa
 import CoreLoggerKit
 import CoreModelKit
+import Sparkle
 
 class AppearanceViewController: ParentViewController {
     @IBOutlet var timeFormat: NSPopUpButton!
@@ -17,6 +18,16 @@ class AppearanceViewController: ParentViewController {
     @IBOutlet var appearanceTab: NSTabView!
     @IBOutlet var appDisplayControl: NSSegmentedControl!
 
+    // Start at Login
+    @IBOutlet var startAtLoginLabel: NSTextField!
+    @IBOutlet var startupCheckbox: NSButton!
+
+    // Sparkle Update Controls
+    @IBOutlet var updateCheckIntervalPopup: NSPopUpButton!
+
+    private lazy var startupManager = StartupManager()
+    private static let sliderDayValues = [1, 2, 3, 4, 5, 6, 7, 14, 30, 90]
+
     private var previewTimezones: [TimezoneData] = []
 
     override func viewDidLoad() {
@@ -29,7 +40,14 @@ class AppearanceViewController: ParentViewController {
         setupTimeFormatPopup()
 
         sliderDayRangePopup.removeAllItems()
-        sliderDayRangePopup.addItems(withTitles: (1...7).map { $0 == 1 ? "1 day" : "\($0) days" })
+        sliderDayRangePopup.addItems(withTitles: Self.sliderDayValues.map { days in
+            switch days {
+            case 1: return "1 day"
+            case 30: return "1 month"
+            case 90: return "3 months"
+            default: return "\(days) days"
+            }
+        })
 
         setup()
 
@@ -84,8 +102,18 @@ class AppearanceViewController: ParentViewController {
             informationLabel.isHidden = menubarFavourites.isEmpty ? false : true
         }
 
-        if let selectedIndex = dataStore.retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber {
-            sliderDayRangePopup.selectItem(at: selectedIndex.intValue)
+        if let storedValue = dataStore.retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber {
+            let dayValue = storedValue.intValue
+            if let index = Self.sliderDayValues.firstIndex(of: dayValue) {
+                sliderDayRangePopup.selectItem(at: index)
+            } else {
+                // Legacy: stored value was an index (0-6), migrate to day value
+                let legacyDays = dayValue + 1
+                if let index = Self.sliderDayValues.firstIndex(of: legacyDays) {
+                    sliderDayRangePopup.selectItem(at: index)
+                    UserDefaults.standard.set(legacyDays, forKey: UserDefaultKeys.futureSliderRange)
+                }
+            }
         }
 
         let shouldDisplayCompact = dataStore.shouldDisplay(.menubarCompactMode)
@@ -94,6 +122,12 @@ class AppearanceViewController: ParentViewController {
         // True is Menubar Only and False is Menubar + Dock
         let appDisplayOptions = dataStore.shouldDisplay(.appDisplayOptions)
         appDisplayControl.setSelected(true, forSegment: appDisplayOptions ? 0 : 1)
+
+        // Start at Login
+        startupCheckbox?.integerValue = dataStore.retrieve(key: UserDefaultKeys.startAtLogin) as? Int ?? 0
+
+        // Sparkle update check interval
+        setupUpdateCheckIntervalPopup()
     }
 
     @IBOutlet var timeFormatLabel: NSTextField!
@@ -128,12 +162,14 @@ class AppearanceViewController: ParentViewController {
         menubarModeLabel.stringValue = "Menubar Mode".localized()
         previewLabel.stringValue = "Preview".localized()
         miscelleaneousLabel.stringValue = "Miscellaneous".localized()
+        startAtLoginLabel?.stringValue = NSLocalizedString("Start at Login",
+                                                           comment: "Start at Login")
 
         [timeFormatLabel, panelTheme,
          dayDisplayOptionsLabel, showSliderLabel,
          showSunriseLabel, largerTextLabel, futureSliderRangeLabel,
          includeDayLabel, includeDateLabel, includePlaceLabel, appDisplayLabel, menubarModeLabel,
-         previewLabel, miscelleaneousLabel].forEach {
+         previewLabel, miscelleaneousLabel, startAtLoginLabel].forEach {
             $0?.textColor = NSColor.labelColor
         }
 
@@ -285,6 +321,53 @@ class AppearanceViewController: ParentViewController {
 
     @IBAction func fontSliderChanged(_: Any) {
         previewPanelTableView.reloadData()
+    }
+
+    // MARK: - Start at Login
+
+    @IBAction func loginPreferenceChanged(_ sender: NSButton) {
+        startupManager.toggleLogin(sender.state == .on)
+    }
+
+    // MARK: - Slider Day Range
+
+    @IBAction func sliderDayRangeChanged(_ sender: NSPopUpButton) {
+        let index = sender.indexOfSelectedItem
+        guard index >= 0, index < Self.sliderDayValues.count else { return }
+        let dayValue = Self.sliderDayValues[index]
+        UserDefaults.standard.set(dayValue, forKey: UserDefaultKeys.futureSliderRange)
+    }
+
+    // MARK: - Sparkle Update Check Interval
+
+    private static let updateIntervalValues: [TimeInterval] = [86400, 604800, 2592000]
+    private static let updateIntervalLabels = ["Daily", "Weekly", "Monthly"]
+
+    private func setupUpdateCheckIntervalPopup() {
+        guard let popup = updateCheckIntervalPopup else { return }
+        popup.removeAllItems()
+        popup.addItems(withTitles: Self.updateIntervalLabels)
+
+        guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+        let currentInterval = appDelegate.updaterController.updater.updateCheckInterval
+        if let index = Self.updateIntervalValues.firstIndex(of: currentInterval) {
+            popup.selectItem(at: index)
+        } else {
+            // Default to weekly if no match
+            popup.selectItem(at: 1)
+        }
+    }
+
+    @IBAction func checkForUpdatesNow(_: NSButton) {
+        guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+        appDelegate.updaterController.checkForUpdates(self)
+    }
+
+    @IBAction func updateCheckIntervalChanged(_ sender: NSPopUpButton) {
+        let index = sender.indexOfSelectedItem
+        guard index >= 0, index < Self.updateIntervalValues.count else { return }
+        guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+        appDelegate.updaterController.updater.updateCheckInterval = Self.updateIntervalValues[index]
     }
 }
 

--- a/Meridian/Preferences/General/PreferencesViewController.swift
+++ b/Meridian/Preferences/General/PreferencesViewController.swift
@@ -39,9 +39,6 @@ class PreferencesViewController: ParentViewController {
 
     @IBOutlet private var tableview: NSView!
     @IBOutlet private var additionalSortOptions: NSView!
-    @IBOutlet var startAtLoginLabel: NSTextField!
-
-    @IBOutlet var startupCheckbox: NSButton!
 
     // Sorting
     private var arePlacesSortedInAscendingOrder = false
@@ -56,8 +53,6 @@ class PreferencesViewController: ParentViewController {
     private var selectionsDataSource: PreferencesDataSource!
     // Search Results Data Source Handler
     var searchResultsDataSource: SearchDataSource!
-    private lazy var startupManager = StartupManager()
-
     private lazy var notimezoneView: NoTimezoneView? = NoTimezoneView(frame: tableview.frame)
 
     private var timezoneAdditionHandler: TimezoneAdditionHandler!
@@ -90,8 +85,6 @@ class PreferencesViewController: ParentViewController {
     }
 
     private func setupLocalizedText() {
-        startAtLoginLabel.stringValue = NSLocalizedString("Start at Login",
-                                                          comment: "Start at Login")
         timezoneSortButton.title = NSLocalizedString("Sort by Time Difference",
                                                      comment: "Start at Login")
         timezoneNameSortButton.title = NSLocalizedString("Sort by Name",
@@ -178,14 +171,10 @@ class PreferencesViewController: ParentViewController {
 
         setupColor()
 
-        startupCheckbox.integerValue = dataStore.retrieve(key: UserDefaultKeys.startAtLogin) as? Int ?? 0
-
         searchField.bezelStyle = .roundedBezel
     }
 
     private func setupColor() {
-        startAtLoginLabel.textColor = NSColor.labelColor
-
         [timezoneNameSortButton, labelSortButton, timezoneSortButton].forEach {
             $0?.attributedTitle = NSAttributedString(string: $0?.title ?? UserDefaultKeys.emptyString, attributes: [
                 NSAttributedString.Key.foregroundColor: NSColor.labelColor,
@@ -380,12 +369,6 @@ extension PreferencesViewController {
         }
 
         statusItem.setupStatusItem()
-    }
-}
-
-extension PreferencesViewController {
-    @IBAction func loginPreferenceChanged(_ sender: NSButton) {
-        startupManager.toggleLogin(sender.state == .on)
     }
 }
 

--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -33,8 +33,8 @@
             <objects>
                 <tabViewController selectedTabViewItemIndex="0" tabStyle="toolbar" id="SH5-GG-x4O" customClass="CenteredTabViewController" customModule="Meridian" customModuleProvider="target" sceneMemberID="viewController">
                     <tabViewItems>
-                        <tabViewItem label="General" identifier="Preferences Tab" image="NSPreferencesGeneral" id="KX2-eQ-kpC"/>
-                        <tabViewItem label=" Appearance " identifier="Appearance Tab" image="Appearance Dynamic" id="UFb-Xx-XzY"/>
+                        <tabViewItem label="Time Zones" identifier="Preferences Tab" image="NSPreferencesGeneral" id="KX2-eQ-kpC"/>
+                        <tabViewItem label=" General " identifier="Appearance Tab" image="Appearance Dynamic" id="UFb-Xx-XzY"/>
                         <tabViewItem label=" About  " identifier="About Tab" image="NSInfo" id="H6X-F4-LIW"/>
                     </tabViewItems>
                     <viewControllerTransitionOptions key="transitionOptions" crossfade="YES" slideRight="YES" slideBackward="YES" allowUserInteraction="YES"/>
@@ -70,7 +70,7 @@
         <!--Appearance-->
         <scene sceneID="C6j-xv-fqV">
             <objects>
-                <viewController title=" Appearance " id="1aL-zR-8L4" userLabel="Appearance" customClass="AppearanceViewController" customModule="Meridian" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController title=" General " id="1aL-zR-8L4" userLabel="General" customClass="AppearanceViewController" customModule="Meridian" customModuleProvider="target" sceneMemberID="viewController">
                     <customView key="view" wantsLayer="YES" id="7EQ-1G-xRP" customClass="ParentView" customModule="Meridian" customModuleProvider="target">
                         <rect key="frame" x="0.0" y="0.0" width="586" height="502"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
@@ -79,7 +79,7 @@
                                 <rect key="frame" x="13" y="10" width="560" height="478"/>
                                 <font key="font" metaFont="system"/>
                                 <tabViewItems>
-                                    <tabViewItem label="Panel" identifier="" id="vnW-vq-Ote">
+                                    <tabViewItem label="Appearance" identifier="" id="vnW-vq-Ote">
                                         <view key="view" id="zFb-Gb-3dB">
                                             <rect key="frame" x="10" y="33" width="540" height="432"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -656,7 +656,7 @@
                                                         <constraint firstAttribute="width" constant="218" id="0qW-So-4cc"/>
                                                     </constraints>
                                                     <connections>
-                                                        <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.sliderDayRange" id="pnp-PO-t4w"/>
+                                                        <action selector="sliderDayRangeChanged:" target="1aL-zR-8L4" id="pnp-PO-t4w"/>
                                                     </connections>
                                                 </popUpButton>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="120" translatesAutoresizingMaskIntoConstraints="NO" id="8Jv-Cf-blJ">
@@ -670,6 +670,77 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
+                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="sep-SL-2nd">
+                                                    <rect key="frame" x="-3" y="50" width="546" height="5"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="1" id="sep-h1-cst"/>
+                                                    </constraints>
+                                                </box>
+                                                <button translatesAutoresizingMaskIntoConstraints="NO" id="sal-CB-new">
+                                                    <rect key="frame" x="242" y="25" width="18" height="18"/>
+                                                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="center" inset="2" id="sal-BC-cel">
+                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                        <font key="font" size="13" name="Avenir-Book"/>
+                                                    </buttonCell>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="14" id="sal-h-cst"/>
+                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="20" id="sal-w-cst"/>
+                                                    </constraints>
+                                                    <accessibility identifier="StartAtLogin"/>
+                                                    <connections>
+                                                        <action selector="loginPreferenceChanged:" target="1aL-zR-8L4" id="sal-act-1"/>
+                                                        <binding destination="Gpv-Gr-MxZ" name="value" keyPath="values.startAtLogin" id="sal-bnd-1"/>
+                                                    </connections>
+                                                </button>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sal-LB-new">
+                                                    <rect key="frame" x="264" y="27" width="84" height="18"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="sal-lb-w"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Start at Login" id="sal-LB-cel">
+                                                        <font key="font" size="13" name="Avenir-Book"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="120" translatesAutoresizingMaskIntoConstraints="NO" id="uci-LB-new">
+                                                    <rect key="frame" x="17" y="-10" width="204" height="18"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="uci-LB-wc"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Check for Updates" id="uci-LB-cel">
+                                                        <font key="font" size="13" name="Avenir-Light"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uci-PU-new">
+                                                    <rect key="frame" x="239" y="-15" width="100" height="25"/>
+                                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="uci-PU-cel">
+                                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                        <font key="font" size="12" name="Avenir-Light"/>
+                                                        <menu key="menu" id="uci-PU-mnu">
+                                                            <items>
+                                                                <menuItem title="Daily" id="uci-MI-d"/>
+                                                                <menuItem title="Weekly" id="uci-MI-w"/>
+                                                                <menuItem title="Monthly" id="uci-MI-m"/>
+                                                            </items>
+                                                        </menu>
+                                                    </popUpButtonCell>
+                                                    <connections>
+                                                        <action selector="updateCheckIntervalChanged:" target="1aL-zR-8L4" id="uci-act-1"/>
+                                                    </connections>
+                                                </popUpButton>
+                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cfu-BT-new">
+                                                    <rect key="frame" x="360" y="-15" width="150" height="25"/>
+                                                    <buttonCell key="cell" type="push" title="Check Now" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="cfu-BT-cel">
+                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                        <font key="font" size="12" name="Avenir-Light"/>
+                                                    </buttonCell>
+                                                    <connections>
+                                                        <action selector="checkForUpdatesNow:" target="1aL-zR-8L4" id="cfu-act-1"/>
+                                                    </connections>
+                                                </button>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ffU-Ce-sfU">
                                                     <rect key="frame" x="214" y="185" width="112" height="22"/>
                                                     <constraints>
@@ -723,6 +794,19 @@
                                                 <constraint firstItem="HNj-dh-8gr" firstAttribute="trailing" secondItem="Utg-yF-Rso" secondAttribute="trailing" id="yPE-hM-Mbb"/>
                                                 <constraint firstItem="DjV-qq-hr9" firstAttribute="leading" secondItem="Mai-SZ-AEi" secondAttribute="leading" id="ykI-Ig-kwf"/>
                                                 <constraint firstItem="GaR-Qm-7u4" firstAttribute="top" secondItem="HNj-dh-8gr" secondAttribute="bottom" constant="20" id="z8z-AY-l8y"/>
+                                                <constraint firstItem="sep-SL-2nd" firstAttribute="leading" secondItem="mF4-bp-EID" secondAttribute="leading" constant="-3" id="sep-l-cst"/>
+                                                <constraint firstAttribute="trailing" secondItem="sep-SL-2nd" secondAttribute="trailing" constant="-3" id="sep-r-cst"/>
+                                                <constraint firstItem="sep-SL-2nd" firstAttribute="top" secondItem="pk6-co-N73" secondAttribute="bottom" constant="20" id="sep-t-cst"/>
+                                                <constraint firstItem="sal-CB-new" firstAttribute="top" secondItem="sep-SL-2nd" secondAttribute="bottom" constant="15" id="sal-t-cst"/>
+                                                <constraint firstItem="sal-CB-new" firstAttribute="leading" secondItem="DjV-qq-hr9" secondAttribute="leading" id="sal-l-cst"/>
+                                                <constraint firstItem="sal-LB-new" firstAttribute="leading" secondItem="sal-CB-new" secondAttribute="trailing" constant="8" id="sal-lb-l"/>
+                                                <constraint firstItem="sal-LB-new" firstAttribute="centerY" secondItem="sal-CB-new" secondAttribute="centerY" constant="-1.5" id="sal-lb-cy"/>
+                                                <constraint firstItem="uci-LB-new" firstAttribute="top" secondItem="sal-CB-new" secondAttribute="bottom" constant="20" id="uci-lb-t"/>
+                                                <constraint firstItem="uci-LB-new" firstAttribute="trailing" secondItem="GaR-Qm-7u4" secondAttribute="trailing" id="uci-lb-tr"/>
+                                                <constraint firstItem="uci-PU-new" firstAttribute="centerY" secondItem="uci-LB-new" secondAttribute="centerY" id="uci-pu-cy"/>
+                                                <constraint firstItem="uci-PU-new" firstAttribute="leading" secondItem="DjV-qq-hr9" secondAttribute="leading" constant="-2" id="uci-pu-l"/>
+                                                <constraint firstItem="cfu-BT-new" firstAttribute="centerY" secondItem="uci-PU-new" secondAttribute="centerY" id="cfu-bt-cy"/>
+                                                <constraint firstItem="cfu-BT-new" firstAttribute="leading" secondItem="uci-PU-new" secondAttribute="trailing" constant="8" id="cfu-bt-l"/>
                                             </constraints>
                                         </view>
                                     </tabViewItem>
@@ -763,6 +847,9 @@
                         <outlet property="timeFormat" destination="iiG-Xu-4id" id="oM3-1Y-fAF"/>
                         <outlet property="timeFormatLabel" destination="wtO-uL-QBf" id="udS-d6-Tep"/>
                         <outlet property="visualEffectView" destination="Wj2-aw-ZDm" id="TZy-V2-JFS"/>
+                        <outlet property="startAtLoginLabel" destination="sal-LB-new" id="sal-out-lb"/>
+                        <outlet property="startupCheckbox" destination="sal-CB-new" id="sal-out-cb"/>
+                        <outlet property="updateCheckIntervalPopup" destination="uci-PU-new" id="uci-out-pu"/>
                     </connections>
                 </viewController>
                 <customObject id="u7K-hb-gdM" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
@@ -1161,22 +1248,6 @@ CA
                                                     <action selector="removeFromFavourites:" target="ZT5-cA-xLj" id="T60-na-pMd"/>
                                                 </connections>
                                             </button>
-                                            <button translatesAutoresizingMaskIntoConstraints="NO" id="aGE-ap-6NE">
-                                                <rect key="frame" x="119" y="17" width="18" height="18"/>
-                                                <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="center" inset="2" id="W5n-gG-wDG">
-                                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                    <font key="font" size="13" name="Avenir-Book"/>
-                                                </buttonCell>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="14" id="nRz-2k-dFx"/>
-                                                    <constraint firstAttribute="width" relation="lessThanOrEqual" constant="20" id="sIw-f5-Tv7"/>
-                                                </constraints>
-                                                <accessibility identifier="StartAtLogin"/>
-                                                <connections>
-                                                    <action selector="loginPreferenceChanged:" target="ZT5-cA-xLj" id="ufi-Mp-Peg"/>
-                                                    <binding destination="3tb-nb-dV1" name="value" keyPath="values.startAtLogin" id="b3h-OK-4dO"/>
-                                                </connections>
-                                            </button>
                                             <customView focusRingType="none" appearanceType="aqua" translatesAutoresizingMaskIntoConstraints="NO" id="PbD-dt-goz" customClass="ShortcutRecorderButton" customModule="Meridian" customModuleProvider="target">
                                                 <rect key="frame" x="426" y="14" width="180" height="25"/>
                                                 <constraints>
@@ -1188,30 +1259,15 @@ CA
                                                 </userDefinedRuntimeAttributes>
                                                 <accessibility identifier="ShortcutControl"/>
                                             </customView>
-                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aCf-xC-UkE">
-                                                <rect key="frame" x="141" y="19" width="84" height="18"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="2Qq-l4-Jmc"/>
-                                                </constraints>
-                                                <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Start at Login" id="FFD-8V-sL0">
-                                                    <font key="font" size="13" name="Avenir-Book"/>
-                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                </textFieldCell>
-                                            </textField>
                                         </subviews>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="52" id="1gN-si-Y7a"/>
                                             <constraint firstItem="48a-Zz-oQg" firstAttribute="height" secondItem="1FY-Nb-ZXb" secondAttribute="height" id="33y-ga-IUI"/>
-                                            <constraint firstItem="aGE-ap-6NE" firstAttribute="centerY" secondItem="348-wa-XEI" secondAttribute="centerY" id="4Zi-tv-iUg"/>
                                             <constraint firstItem="48a-Zz-oQg" firstAttribute="leading" secondItem="1FY-Nb-ZXb" secondAttribute="trailing" id="AUY-7G-gep"/>
-                                            <constraint firstItem="aCf-xC-UkE" firstAttribute="leading" secondItem="aGE-ap-6NE" secondAttribute="trailing" constant="8" id="Axm-NL-Rlj"/>
                                             <constraint firstItem="1FY-Nb-ZXb" firstAttribute="centerY" secondItem="348-wa-XEI" secondAttribute="centerY" id="Iua-hE-fSo"/>
                                             <constraint firstAttribute="trailing" secondItem="PbD-dt-goz" secondAttribute="trailing" constant="12" id="K40-ee-cJc"/>
                                             <constraint firstItem="48a-Zz-oQg" firstAttribute="centerY" secondItem="348-wa-XEI" secondAttribute="centerY" id="PDX-dP-7OB"/>
-                                            <constraint firstItem="aGE-ap-6NE" firstAttribute="leading" secondItem="48a-Zz-oQg" secondAttribute="trailing" constant="40" id="Qy7-CH-mDD"/>
-                                            <constraint firstItem="PbD-dt-goz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="aCf-xC-UkE" secondAttribute="trailing" constant="20" id="S7R-11-bgf"/>
-                                            <constraint firstItem="aCf-xC-UkE" firstAttribute="centerY" secondItem="aGE-ap-6NE" secondAttribute="centerY" constant="-1.5" id="d8V-v9-JrU"/>
+                                            <constraint firstItem="PbD-dt-goz" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="48a-Zz-oQg" secondAttribute="trailing" constant="20" id="S7R-11-bgf"/>
                                             <constraint firstItem="PbD-dt-goz" firstAttribute="centerY" secondItem="348-wa-XEI" secondAttribute="centerY" id="ffh-fE-ZH9"/>
                                             <constraint firstItem="48a-Zz-oQg" firstAttribute="width" secondItem="1FY-Nb-ZXb" secondAttribute="width" id="vJp-oF-8uC"/>
                                             <constraint firstItem="1FY-Nb-ZXb" firstAttribute="leading" secondItem="348-wa-XEI" secondAttribute="leading" constant="1" id="zPT-mb-aTY"/>
@@ -1256,8 +1312,6 @@ CA
                         <outlet property="progressIndicator" destination="0A5-gp-lay" id="Ssa-ht-IvM"/>
                         <outlet property="recorderControl" destination="PbD-dt-goz" id="ZH4-DH-X0L"/>
                         <outlet property="searchField" destination="Dha-h9-Nd0" id="SNI-zE-aNT"/>
-                        <outlet property="startAtLoginLabel" destination="aCf-xC-UkE" id="dZk-TD-VBU"/>
-                        <outlet property="startupCheckbox" destination="aGE-ap-6NE" id="G1Q-Rq-gYE"/>
                         <outlet property="tableview" destination="eI7-Vb-R7J" id="vgV-nN-mEQ"/>
                         <outlet property="timezoneNameSortButton" destination="6fs-Mx-NcG" id="eqp-Lf-h2G"/>
                         <outlet property="timezonePanel" destination="YHn-dh-3ug" id="GDG-fQ-lp1"/>


### PR DESCRIPTION
## Summary
- **Rename tabs**: General → Time Zones, Appearance → General, Panel sub-tab → Appearance
- **Move Start at Login** from Time Zones tab to General/Misc sub-tab
- **Add Sparkle update controls** to Misc: check interval popup (Daily/Weekly/Monthly) + Check Now button
- **Extend future slider range**: adds 14 days, 1 month, 3 months options; stores day value directly instead of index (with legacy migration)
- **Remove build number** from version string in About view and context menu
- **Simplify context menu**: remove Check for Updates, Support Meridian, FAQs, Send Feedback (available under Settings/About)

## Test plan
- [x] Build succeeds
- [x] 112 unit tests pass
- [ ] Open Preferences → confirm tabs read "Time Zones", "General", "About"
- [ ] General tab → sub-tabs read "Appearance" and "Misc"
- [ ] Misc has: Start at Login, Check for Updates controls, future slider range with extended options
- [ ] Time Zones tab no longer has Start at Login
- [ ] About shows version without build number
- [ ] Context menu shows only: Settings, version, Quit Meridian
- [ ] Slider range 14d/1mo/3mo works with modern slider

🤖 Generated with [Claude Code](https://claude.com/claude-code)