### PR TITLE
Fix slow startup and Misc tab layout

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -77,23 +77,16 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
 
         guard !idsToBackfill.isEmpty else { return }
 
-        // Geocode all in parallel, then write a single store update
-        Task {
-            let coordinates = await withTaskGroup(
-                of: (String, CLLocationCoordinate2D)?.self
-            ) { group in
-                for id in idsToBackfill {
-                    group.addTask { await Self.geocodeTimezone(id) }
+        // Geocode sequentially to avoid CLGeocoder rate limiting
+        Task.detached(priority: .utility) {
+            var results: [String: CLLocationCoordinate2D] = [:]
+            for id in idsToBackfill {
+                if let (resolvedID, coord) = await Self.geocodeTimezone(id) {
+                    results[resolvedID] = coord
                 }
-                var results: [String: CLLocationCoordinate2D] = [:]
-                for await result in group {
-                    if let (id, coord) = result {
-                        results[id] = coord
-                    }
-                }
-                return results
             }
 
+            let coordinates = results
             guard !coordinates.isEmpty else { return }
 
             await MainActor.run {

--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -756,13 +756,13 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="AxB-VD-lXm" firstAttribute="centerY" secondItem="pZd-Wg-YPL" secondAttribute="centerY" id="5wa-d2-jaz"/>
-                                                <constraint firstItem="fTA-lS-4wJ" firstAttribute="top" secondItem="mF4-bp-EID" secondAttribute="top" constant="50" id="7tO-Cp-OiK"/>
+                                                <constraint firstItem="fTA-lS-4wJ" firstAttribute="top" secondItem="mF4-bp-EID" secondAttribute="top" constant="40" id="7tO-Cp-OiK"/>
                                                 <constraint firstItem="Axn-Tb-Cdx" firstAttribute="centerY" secondItem="fTA-lS-4wJ" secondAttribute="centerY" id="A5h-9Z-lkQ"/>
                                                 <constraint firstItem="KeW-e2-uQE" firstAttribute="centerY" secondItem="bhJ-MT-NBP" secondAttribute="centerY" id="B1W-4F-zAU"/>
                                                 <constraint firstItem="KeW-e2-uQE" firstAttribute="leading" secondItem="AxB-VD-lXm" secondAttribute="leading" id="DYk-jT-Swc"/>
                                                 <constraint firstItem="Q3M-Kz-XV3" firstAttribute="top" secondItem="mF4-bp-EID" secondAttribute="top" constant="7" id="Gaf-bX-kgP"/>
-                                                <constraint firstItem="bhJ-MT-NBP" firstAttribute="top" secondItem="pZd-Wg-YPL" secondAttribute="bottom" constant="20" id="IoV-WF-2Ka"/>
-                                                <constraint firstItem="8Jv-Cf-blJ" firstAttribute="top" secondItem="GaR-Qm-7u4" secondAttribute="bottom" constant="20" id="JEu-wF-GfU"/>
+                                                <constraint firstItem="bhJ-MT-NBP" firstAttribute="top" secondItem="pZd-Wg-YPL" secondAttribute="bottom" constant="14" id="IoV-WF-2Ka"/>
+                                                <constraint firstItem="8Jv-Cf-blJ" firstAttribute="top" secondItem="GaR-Qm-7u4" secondAttribute="bottom" constant="14" id="JEu-wF-GfU"/>
                                                 <constraint firstItem="fTA-lS-4wJ" firstAttribute="leading" secondItem="mF4-bp-EID" secondAttribute="leading" constant="80" id="MkT-cl-OdZ"/>
                                                 <constraint firstItem="8Jv-Cf-blJ" firstAttribute="trailing" secondItem="GaR-Qm-7u4" secondAttribute="trailing" id="NUW-UR-fQ1"/>
                                                 <constraint firstItem="ffU-Ce-sfU" firstAttribute="centerX" secondItem="mF4-bp-EID" secondAttribute="centerX" id="NtD-tv-DLi"/>
@@ -775,33 +775,33 @@
                                                 <constraint firstAttribute="trailing" secondItem="Wj2-aw-ZDm" secondAttribute="trailing" id="c7U-11-oja"/>
                                                 <constraint firstItem="Axn-Tb-Cdx" firstAttribute="leading" secondItem="fTA-lS-4wJ" secondAttribute="trailing" constant="25" id="cpc-PS-JXb"/>
                                                 <constraint firstItem="Wj2-aw-ZDm" firstAttribute="bottom" secondItem="XeT-rJ-1io" secondAttribute="bottom" id="d1X-nE-5Z1"/>
-                                                <constraint firstItem="XeT-rJ-1io" firstAttribute="top" secondItem="Mai-SZ-AEi" secondAttribute="bottom" constant="20" id="dK0-pf-XzU"/>
-                                                <constraint firstItem="HNj-dh-8gr" firstAttribute="top" secondItem="ffU-Ce-sfU" secondAttribute="bottom" constant="20" id="e9q-JE-9cD"/>
-                                                <constraint firstItem="ffU-Ce-sfU" firstAttribute="top" secondItem="XeT-rJ-1io" secondAttribute="bottom" constant="20" id="ed3-Oa-Uso"/>
+                                                <constraint firstItem="XeT-rJ-1io" firstAttribute="top" secondItem="Mai-SZ-AEi" secondAttribute="bottom" constant="14" id="dK0-pf-XzU"/>
+                                                <constraint firstItem="HNj-dh-8gr" firstAttribute="top" secondItem="ffU-Ce-sfU" secondAttribute="bottom" constant="12" id="e9q-JE-9cD"/>
+                                                <constraint firstItem="ffU-Ce-sfU" firstAttribute="top" secondItem="XeT-rJ-1io" secondAttribute="bottom" constant="12" id="ed3-Oa-Uso"/>
                                                 <constraint firstItem="DjV-qq-hr9" firstAttribute="centerY" secondItem="HNj-dh-8gr" secondAttribute="centerY" id="ezB-Gf-m1M"/>
                                                 <constraint firstItem="Wj2-aw-ZDm" firstAttribute="top" secondItem="mF4-bp-EID" secondAttribute="top" id="g9Z-bG-q6C"/>
                                                 <constraint firstItem="Mai-SZ-AEi" firstAttribute="centerY" secondItem="Utg-yF-Rso" secondAttribute="centerY" id="gaG-hL-cPZ"/>
                                                 <constraint firstItem="bhJ-MT-NBP" firstAttribute="trailing" secondItem="pZd-Wg-YPL" secondAttribute="trailing" id="glb-jO-783"/>
-                                                <constraint firstItem="Utg-yF-Rso" firstAttribute="top" secondItem="bhJ-MT-NBP" secondAttribute="bottom" constant="20" id="i0V-V6-4Ry"/>
+                                                <constraint firstItem="Utg-yF-Rso" firstAttribute="top" secondItem="bhJ-MT-NBP" secondAttribute="bottom" constant="14" id="i0V-V6-4Ry"/>
                                                 <constraint firstItem="8Nx-Xq-XDU" firstAttribute="leading" secondItem="DjV-qq-hr9" secondAttribute="leading" constant="-2" id="n70-Hh-rVD"/>
                                                 <constraint firstItem="GaR-Qm-7u4" firstAttribute="trailing" secondItem="HNj-dh-8gr" secondAttribute="trailing" id="rdt-gt-K0k"/>
                                                 <constraint firstItem="8Nx-Xq-XDU" firstAttribute="centerY" secondItem="GaR-Qm-7u4" secondAttribute="centerY" id="s0m-wC-dVO"/>
                                                 <constraint firstItem="Wj2-aw-ZDm" firstAttribute="leading" secondItem="mF4-bp-EID" secondAttribute="leading" id="wTr-VP-p2w"/>
-                                                <constraint firstItem="pZd-Wg-YPL" firstAttribute="top" secondItem="fTA-lS-4wJ" secondAttribute="bottom" constant="20" id="whe-Ex-bIB"/>
+                                                <constraint firstItem="pZd-Wg-YPL" firstAttribute="top" secondItem="fTA-lS-4wJ" secondAttribute="bottom" constant="14" id="whe-Ex-bIB"/>
                                                 <constraint firstItem="AxB-VD-lXm" firstAttribute="leading" secondItem="Axn-Tb-Cdx" secondAttribute="leading" id="x1o-YB-Aes"/>
                                                 <constraint firstItem="pk6-co-N73" firstAttribute="leading" secondItem="DjV-qq-hr9" secondAttribute="leading" id="y9n-Tk-GUK"/>
                                                 <constraint firstItem="Q3M-Kz-XV3" firstAttribute="centerX" secondItem="mF4-bp-EID" secondAttribute="centerX" id="yKZ-7i-UKv"/>
                                                 <constraint firstItem="HNj-dh-8gr" firstAttribute="trailing" secondItem="Utg-yF-Rso" secondAttribute="trailing" id="yPE-hM-Mbb"/>
                                                 <constraint firstItem="DjV-qq-hr9" firstAttribute="leading" secondItem="Mai-SZ-AEi" secondAttribute="leading" id="ykI-Ig-kwf"/>
-                                                <constraint firstItem="GaR-Qm-7u4" firstAttribute="top" secondItem="HNj-dh-8gr" secondAttribute="bottom" constant="20" id="z8z-AY-l8y"/>
+                                                <constraint firstItem="GaR-Qm-7u4" firstAttribute="top" secondItem="HNj-dh-8gr" secondAttribute="bottom" constant="14" id="z8z-AY-l8y"/>
                                                 <constraint firstItem="sep-SL-2nd" firstAttribute="leading" secondItem="mF4-bp-EID" secondAttribute="leading" constant="-3" id="sep-l-cst"/>
                                                 <constraint firstAttribute="trailing" secondItem="sep-SL-2nd" secondAttribute="trailing" constant="-3" id="sep-r-cst"/>
-                                                <constraint firstItem="sep-SL-2nd" firstAttribute="top" secondItem="pk6-co-N73" secondAttribute="bottom" constant="20" id="sep-t-cst"/>
-                                                <constraint firstItem="sal-CB-new" firstAttribute="top" secondItem="sep-SL-2nd" secondAttribute="bottom" constant="15" id="sal-t-cst"/>
+                                                <constraint firstItem="sep-SL-2nd" firstAttribute="top" secondItem="pk6-co-N73" secondAttribute="bottom" constant="14" id="sep-t-cst"/>
+                                                <constraint firstItem="sal-CB-new" firstAttribute="top" secondItem="sep-SL-2nd" secondAttribute="bottom" constant="12" id="sal-t-cst"/>
                                                 <constraint firstItem="sal-CB-new" firstAttribute="leading" secondItem="DjV-qq-hr9" secondAttribute="leading" id="sal-l-cst"/>
                                                 <constraint firstItem="sal-LB-new" firstAttribute="leading" secondItem="sal-CB-new" secondAttribute="trailing" constant="8" id="sal-lb-l"/>
                                                 <constraint firstItem="sal-LB-new" firstAttribute="centerY" secondItem="sal-CB-new" secondAttribute="centerY" constant="-1.5" id="sal-lb-cy"/>
-                                                <constraint firstItem="uci-LB-new" firstAttribute="top" secondItem="sal-CB-new" secondAttribute="bottom" constant="20" id="uci-lb-t"/>
+                                                <constraint firstItem="uci-LB-new" firstAttribute="top" secondItem="sal-CB-new" secondAttribute="bottom" constant="14" id="uci-lb-t"/>
                                                 <constraint firstItem="uci-LB-new" firstAttribute="trailing" secondItem="GaR-Qm-7u4" secondAttribute="trailing" id="uci-lb-tr"/>
                                                 <constraint firstItem="uci-PU-new" firstAttribute="centerY" secondItem="uci-LB-new" secondAttribute="centerY" id="uci-pu-cy"/>
                                                 <constraint firstItem="uci-PU-new" firstAttribute="leading" secondItem="DjV-qq-hr9" secondAttribute="leading" constant="-2" id="uci-pu-l"/>


### PR DESCRIPTION
## Summary
- **Fix slow startup**: Serialize geocoding requests sequentially instead of firing them all in parallel — CLGeocoder rate-limits concurrent requests causing 30+ second delays
- **Fix Misc tab layout**: Tighten vertical spacing so Start at Login and Check for Updates controls are fully visible within the tab bounds

## Test plan
- [x] Build succeeds
- [x] 112 unit tests pass
- [ ] App appears in menu bar within ~1 second of launch
- [ ] Misc tab: all controls visible including Check for Updates row
- [ ] Check Now button triggers Sparkle update check
- [ ] Update frequency popup (Daily/Weekly/Monthly) changes persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)