### PR TITLE
Geocode coordinates at add-time, remove startup backfill

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -1,7 +1,6 @@
 // Copyright © 2015 Abhishek Banthia
 
 import Cocoa
-import CoreLocation
 import CoreLoggerKit
 import CoreModelKit
 import Sparkle
@@ -55,69 +54,6 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
         assignShortcut()
 
         setActivationPolicy()
-
-        // Backfill coordinates for timezone entries that lack them (needed for sunrise/sunset)
-        backfillMissingCoordinates()
-    }
-
-    private func backfillMissingCoordinates() {
-        let store = DataStore.shared()
-        let timezones = store.timezones()
-
-        // Collect timezone IDs that need coordinate backfill
-        var idsToBackfill: [String] = []
-        for data in timezones {
-            guard let tz = TimezoneData.customObject(from: data),
-                  tz.selectionType == .timezone,
-                  tz.latitude == nil || tz.longitude == nil,
-                  let timezoneID = tz.timezoneID
-            else { continue }
-            idsToBackfill.append(timezoneID)
-        }
-
-        guard !idsToBackfill.isEmpty else { return }
-
-        // Geocode sequentially to avoid CLGeocoder rate limiting
-        Task.detached(priority: .utility) {
-            var results: [String: CLLocationCoordinate2D] = [:]
-            for id in idsToBackfill {
-                if let (resolvedID, coord) = await Self.geocodeTimezone(id) {
-                    results[resolvedID] = coord
-                }
-            }
-
-            let coordinates = results
-            guard !coordinates.isEmpty else { return }
-
-            await MainActor.run {
-                let allTimezones = store.timezones()
-                let updated: [Data] = allTimezones.compactMap { data in
-                    guard let tz = TimezoneData.customObject(from: data),
-                          tz.selectionType == .timezone,
-                          tz.latitude == nil || tz.longitude == nil,
-                          let id = tz.timezoneID,
-                          let coord = coordinates[id]
-                    else { return data }
-                    tz.latitude = coord.latitude
-                    tz.longitude = coord.longitude
-                    return NSKeyedArchiver.clocker_archive(with: tz)
-                }
-                store.setTimezones(updated)
-            }
-        }
-    }
-
-    private static func geocodeTimezone(_ timezoneID: String) async -> (String, CLLocationCoordinate2D)? {
-        let components = timezoneID.components(separatedBy: "/")
-        guard let city = components.last else { return nil }
-        let cityName = city.replacingOccurrences(of: "_", with: " ")
-        do {
-            let placemark = try await NetworkManager.geocodeAddress(cityName)
-            guard let location = placemark.location else { return nil }
-            return (timezoneID, location.coordinate)
-        } catch {
-            return nil
-        }
     }
 
     // Should we have a dock icon or just stay in the menubar?

--- a/Meridian/Preferences/General/TimezoneAdditionHandler.swift
+++ b/Meridian/Preferences/General/TimezoneAdditionHandler.swift
@@ -352,29 +352,38 @@ class TimezoneAdditionHandler: NSObject {
         data.selectionType = .timezone
         data.isSystemTimezone = metaInfo.0.name == NSTimeZone.system.identifier
 
-        let operationObject = TimezoneDataOperations(with: data, store: dataStore)
-        operationObject.saveObject()
-
-        // Geocode coordinates for sunrise/sunset display
+        // Geocode coordinates before saving so sunrise/sunset works immediately
         let timezoneID = metaInfo.0.name
+        let store = self.dataStore
         Task { @MainActor in
-            await TimezoneAdditionHandler.backfillCoordinates(for: timezoneID, in: self.dataStore)
+            let components = timezoneID.split(separator: "/")
+            if let cityComponent = components.last {
+                let cityName = cityComponent.replacingOccurrences(of: "_", with: " ")
+                if let placemark = try? await NetworkManager.geocodeAddress(cityName),
+                   let location = placemark.location {
+                    data.latitude = location.coordinate.latitude
+                    data.longitude = location.coordinate.longitude
+                }
+            }
+
+            let operationObject = TimezoneDataOperations(with: data, store: store)
+            operationObject.saveObject()
+
+            host.searchResultsDataSource.cleanupFilterArray()
+            host.searchResultsDataSource.timezoneFilteredArray = []
+            host.placeholderLabel.placeholderString = UserDefaultKeys.emptyString
+            host.searchField.stringValue = UserDefaultKeys.emptyString
+
+            self.reloadSearchResults()
+            host.refreshTimezoneTableView(true)
+            host.refreshMainTable()
+
+            host.timezonePanel.close()
+            host.searchField.placeholderString = NSLocalizedString("Search Field Placeholder",
+                                                                   comment: "Search Field Placeholder")
+            host.availableTimezoneTableView.isHidden = false
+            self.isActivityInProgress = false
         }
-
-        host.searchResultsDataSource.cleanupFilterArray()
-        host.searchResultsDataSource.timezoneFilteredArray = []
-        host.placeholderLabel.placeholderString = UserDefaultKeys.emptyString
-        host.searchField.stringValue = UserDefaultKeys.emptyString
-
-        reloadSearchResults()
-        host.refreshTimezoneTableView(true)
-        host.refreshMainTable()
-
-        host.timezonePanel.close()
-        host.searchField.placeholderString = NSLocalizedString("Search Field Placeholder",
-                                                               comment: "Search Field Placeholder")
-        host.availableTimezoneTableView.isHidden = false
-        isActivityInProgress = false
     }
 
     private func metadata(for selection: TimezoneMetadata) -> (NSTimeZone, TimezoneMetadata) {
@@ -442,38 +451,3 @@ extension TimezoneAdditionHandler {
     }
 }
 
-// MARK: - Coordinate Backfill
-
-extension TimezoneAdditionHandler {
-    /// Geocode coordinates for a timezone entry and update the stored data.
-    /// Extracts city name from IANA timezone ID (e.g. "America/New_York" → "New York").
-    static func backfillCoordinates(for timezoneID: String, in store: DataStoring) async {
-        let components = timezoneID.split(separator: "/")
-        guard let cityComponent = components.last else { return }
-        let cityName = cityComponent.replacingOccurrences(of: "_", with: " ")
-
-        do {
-            let placemark = try await NetworkManager.geocodeAddress(cityName)
-            guard let location = placemark.location else { return }
-
-            let allTimezones = store.timezones()
-            var updated = false
-            let newTimezones: [Data] = allTimezones.compactMap { data in
-                guard let tz = TimezoneData.customObject(from: data) else { return data }
-                guard tz.timezoneID == timezoneID,
-                      tz.latitude == nil || tz.longitude == nil else { return data }
-
-                tz.latitude = location.coordinate.latitude
-                tz.longitude = location.coordinate.longitude
-                updated = true
-                return NSKeyedArchiver.clocker_archive(with: tz)
-            }
-
-            if updated {
-                store.setTimezones(newTimezones)
-            }
-        } catch {
-            Logger.info("Failed to geocode coordinates for \(timezoneID): \(error.localizedDescription)")
-        }
-    }
-}


### PR DESCRIPTION
## Summary
- Geocode timezone coordinates *before* saving (instead of async backfill after), so sunrise/sunset data is available immediately
- Remove startup `backfillMissingCoordinates()` from AppDelegate that was hitting CLGeocoder rate limits and causing 30+ second startup delays
- Remove the now-unnecessary `backfillCoordinates(for:in:)` static method and `geocodeTimezone()` helper

## Test plan
- [x] Build succeeds
- [x] All 112 unit tests pass
- [ ] Manual: app appears in menubar instantly on launch (no geocoding delay)
- [ ] Manual: add a timezone by IANA ID → sunrise/sunset displays immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)