### PR TITLE
Move Start at Login and Check for Updates to About tab

### DIFF
--- a/Meridian/Meridian.xcodeproj/project.pbxproj
+++ b/Meridian/Meridian.xcodeproj/project.pbxproj
@@ -1043,7 +1043,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.5.1;
+				MARKETING_VERSION = 2.6.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tpak.Meridian;
@@ -1499,7 +1499,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.5.1;
+				MARKETING_VERSION = 2.6.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-D DEBUG";
@@ -1578,7 +1578,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 13.0;
-				MARKETING_VERSION = 2.5.1;
+				MARKETING_VERSION = 2.6.0;
 				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = "-ObjC";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-D RELEASE";

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -2,6 +2,7 @@
 
 import SwiftUI
 import CoreLoggerKit
+import Sparkle
 
 struct AboutView: View {
     private let versionString: String = {
@@ -9,6 +10,12 @@ struct AboutView: View {
         let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") ?? "N/A"
         return "\(appName) \(shortVersion)"
     }()
+
+    @AppStorage(UserDefaultKeys.startAtLogin) private var startAtLogin = false
+    private let startupManager = StartupManager()
+
+    fileprivate static let updateIntervalValues: [TimeInterval] = [86400, 604800, 2592000]
+    fileprivate static let updateIntervalLabels = ["Daily", "Weekly", "Monthly"]
 
     var body: some View {
         VStack(spacing: 15) {
@@ -41,6 +48,23 @@ struct AboutView: View {
             ) {
                 openURL(AboutUsConstants.GitHubURL, logEvent: "Opened GitHub",
                         metadata: ["Country": Locale.autoupdatingCurrent.region?.identifier ?? ""])
+            }
+
+            Divider()
+                .padding(.horizontal, 20)
+
+            Toggle("Start at Login", isOn: $startAtLogin)
+                .font(.custom("Avenir-Book", size: 13))
+                .toggleStyle(.checkbox)
+                .accessibilityIdentifier("StartAtLogin")
+                .onChange(of: startAtLogin) { newValue in
+                    startupManager.toggleLogin(newValue)
+                }
+
+            HStack(spacing: 8) {
+                Text("Check for Updates")
+                    .font(.custom("Avenir-Light", size: 13))
+                UpdateCheckControls()
             }
         }
         .padding(20)
@@ -88,6 +112,37 @@ struct AboutView: View {
         guard let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)
         Logger.log(object: metadata, for: logEvent as NSString)
+    }
+}
+
+private struct UpdateCheckControls: View {
+    @State private var selectedIndex: Int
+
+    init() {
+        let updater = (NSApplication.shared.delegate as? AppDelegate)?.updaterController.updater
+        let currentInterval = updater?.updateCheckInterval ?? 604800
+        let index = AboutView.updateIntervalValues.firstIndex(of: currentInterval) ?? 1
+        _selectedIndex = State(initialValue: index)
+    }
+
+    var body: some View {
+        Picker("", selection: $selectedIndex) {
+            ForEach(0..<AboutView.updateIntervalLabels.count, id: \.self) { index in
+                Text(AboutView.updateIntervalLabels[index]).tag(index)
+            }
+        }
+        .labelsHidden()
+        .frame(width: 100)
+        .onChange(of: selectedIndex) { newValue in
+            guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+            appDelegate.updaterController.updater.updateCheckInterval = AboutView.updateIntervalValues[newValue]
+        }
+
+        Button("Check Now") {
+            guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+            appDelegate.updaterController.checkForUpdates(nil)
+        }
+        .font(.custom("Avenir-Light", size: 12))
     }
 }
 

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -3,7 +3,6 @@
 import Cocoa
 import CoreLoggerKit
 import CoreModelKit
-import Sparkle
 
 class AppearanceViewController: ParentViewController {
     @IBOutlet var timeFormat: NSPopUpButton!
@@ -18,14 +17,6 @@ class AppearanceViewController: ParentViewController {
     @IBOutlet var appearanceTab: NSTabView!
     @IBOutlet var appDisplayControl: NSSegmentedControl!
 
-    // Start at Login
-    @IBOutlet var startAtLoginLabel: NSTextField!
-    @IBOutlet var startupCheckbox: NSButton!
-
-    // Sparkle Update Controls
-    @IBOutlet var updateCheckIntervalPopup: NSPopUpButton!
-
-    private lazy var startupManager = StartupManager()
     private static let sliderDayValues = [1, 2, 3, 4, 5, 6, 7, 14, 30, 90]
 
     private var previewTimezones: [TimezoneData] = []
@@ -123,11 +114,6 @@ class AppearanceViewController: ParentViewController {
         let appDisplayOptions = dataStore.shouldDisplay(.appDisplayOptions)
         appDisplayControl.setSelected(true, forSegment: appDisplayOptions ? 0 : 1)
 
-        // Start at Login
-        startupCheckbox?.integerValue = dataStore.retrieve(key: UserDefaultKeys.startAtLogin) as? Int ?? 0
-
-        // Sparkle update check interval
-        setupUpdateCheckIntervalPopup()
     }
 
     @IBOutlet var timeFormatLabel: NSTextField!
@@ -162,14 +148,12 @@ class AppearanceViewController: ParentViewController {
         menubarModeLabel.stringValue = "Menubar Mode".localized()
         previewLabel.stringValue = "Preview".localized()
         miscelleaneousLabel.stringValue = "Miscellaneous".localized()
-        startAtLoginLabel?.stringValue = NSLocalizedString("Start at Login",
-                                                           comment: "Start at Login")
 
         [timeFormatLabel, panelTheme,
          dayDisplayOptionsLabel, showSliderLabel,
          showSunriseLabel, largerTextLabel, futureSliderRangeLabel,
          includeDayLabel, includeDateLabel, includePlaceLabel, appDisplayLabel, menubarModeLabel,
-         previewLabel, miscelleaneousLabel, startAtLoginLabel].forEach {
+         previewLabel, miscelleaneousLabel].forEach {
             $0?.textColor = NSColor.labelColor
         }
 
@@ -323,12 +307,6 @@ class AppearanceViewController: ParentViewController {
         previewPanelTableView.reloadData()
     }
 
-    // MARK: - Start at Login
-
-    @IBAction func loginPreferenceChanged(_ sender: NSButton) {
-        startupManager.toggleLogin(sender.state == .on)
-    }
-
     // MARK: - Slider Day Range
 
     @IBAction func sliderDayRangeChanged(_ sender: NSPopUpButton) {
@@ -338,37 +316,6 @@ class AppearanceViewController: ParentViewController {
         UserDefaults.standard.set(dayValue, forKey: UserDefaultKeys.futureSliderRange)
     }
 
-    // MARK: - Sparkle Update Check Interval
-
-    private static let updateIntervalValues: [TimeInterval] = [86400, 604800, 2592000]
-    private static let updateIntervalLabels = ["Daily", "Weekly", "Monthly"]
-
-    private func setupUpdateCheckIntervalPopup() {
-        guard let popup = updateCheckIntervalPopup else { return }
-        popup.removeAllItems()
-        popup.addItems(withTitles: Self.updateIntervalLabels)
-
-        guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
-        let currentInterval = appDelegate.updaterController.updater.updateCheckInterval
-        if let index = Self.updateIntervalValues.firstIndex(of: currentInterval) {
-            popup.selectItem(at: index)
-        } else {
-            // Default to weekly if no match
-            popup.selectItem(at: 1)
-        }
-    }
-
-    @IBAction func checkForUpdatesNow(_: NSButton) {
-        guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
-        appDelegate.updaterController.checkForUpdates(self)
-    }
-
-    @IBAction func updateCheckIntervalChanged(_ sender: NSPopUpButton) {
-        let index = sender.indexOfSelectedItem
-        guard index >= 0, index < Self.updateIntervalValues.count else { return }
-        guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
-        appDelegate.updaterController.updater.updateCheckInterval = Self.updateIntervalValues[index]
-    }
 }
 
 extension AppearanceViewController: NSTableViewDataSource, NSTableViewDelegate {

--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -670,77 +670,6 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="sep-SL-2nd">
-                                                    <rect key="frame" x="-3" y="50" width="546" height="5"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="1" id="sep-h1-cst"/>
-                                                    </constraints>
-                                                </box>
-                                                <button translatesAutoresizingMaskIntoConstraints="NO" id="sal-CB-new">
-                                                    <rect key="frame" x="242" y="25" width="18" height="18"/>
-                                                    <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="left" alignment="center" inset="2" id="sal-BC-cel">
-                                                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
-                                                        <font key="font" size="13" name="Avenir-Book"/>
-                                                    </buttonCell>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="14" id="sal-h-cst"/>
-                                                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="20" id="sal-w-cst"/>
-                                                    </constraints>
-                                                    <accessibility identifier="StartAtLogin"/>
-                                                    <connections>
-                                                        <action selector="loginPreferenceChanged:" target="1aL-zR-8L4" id="sal-act-1"/>
-                                                        <binding destination="Gpv-Gr-MxZ" name="value" keyPath="values.startAtLogin" id="sal-bnd-1"/>
-                                                    </connections>
-                                                </button>
-                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sal-LB-new">
-                                                    <rect key="frame" x="264" y="27" width="84" height="18"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="sal-lb-w"/>
-                                                    </constraints>
-                                                    <textFieldCell key="cell" lineBreakMode="clipping" alignment="left" title="Start at Login" id="sal-LB-cel">
-                                                        <font key="font" size="13" name="Avenir-Book"/>
-                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </textField>
-                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="120" translatesAutoresizingMaskIntoConstraints="NO" id="uci-LB-new">
-                                                    <rect key="frame" x="17" y="-10" width="204" height="18"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="uci-LB-wc"/>
-                                                    </constraints>
-                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Check for Updates" id="uci-LB-cel">
-                                                        <font key="font" size="13" name="Avenir-Light"/>
-                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </textField>
-                                                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uci-PU-new">
-                                                    <rect key="frame" x="239" y="-15" width="100" height="25"/>
-                                                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="uci-PU-cel">
-                                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" size="12" name="Avenir-Light"/>
-                                                        <menu key="menu" id="uci-PU-mnu">
-                                                            <items>
-                                                                <menuItem title="Daily" id="uci-MI-d"/>
-                                                                <menuItem title="Weekly" id="uci-MI-w"/>
-                                                                <menuItem title="Monthly" id="uci-MI-m"/>
-                                                            </items>
-                                                        </menu>
-                                                    </popUpButtonCell>
-                                                    <connections>
-                                                        <action selector="updateCheckIntervalChanged:" target="1aL-zR-8L4" id="uci-act-1"/>
-                                                    </connections>
-                                                </popUpButton>
-                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cfu-BT-new">
-                                                    <rect key="frame" x="360" y="-15" width="150" height="25"/>
-                                                    <buttonCell key="cell" type="push" title="Check Now" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="cfu-BT-cel">
-                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" size="12" name="Avenir-Light"/>
-                                                    </buttonCell>
-                                                    <connections>
-                                                        <action selector="checkForUpdatesNow:" target="1aL-zR-8L4" id="cfu-act-1"/>
-                                                    </connections>
-                                                </button>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ffU-Ce-sfU">
                                                     <rect key="frame" x="214" y="185" width="112" height="22"/>
                                                     <constraints>
@@ -794,19 +723,6 @@
                                                 <constraint firstItem="HNj-dh-8gr" firstAttribute="trailing" secondItem="Utg-yF-Rso" secondAttribute="trailing" id="yPE-hM-Mbb"/>
                                                 <constraint firstItem="DjV-qq-hr9" firstAttribute="leading" secondItem="Mai-SZ-AEi" secondAttribute="leading" id="ykI-Ig-kwf"/>
                                                 <constraint firstItem="GaR-Qm-7u4" firstAttribute="top" secondItem="HNj-dh-8gr" secondAttribute="bottom" constant="14" id="z8z-AY-l8y"/>
-                                                <constraint firstItem="sep-SL-2nd" firstAttribute="leading" secondItem="mF4-bp-EID" secondAttribute="leading" constant="-3" id="sep-l-cst"/>
-                                                <constraint firstAttribute="trailing" secondItem="sep-SL-2nd" secondAttribute="trailing" constant="-3" id="sep-r-cst"/>
-                                                <constraint firstItem="sep-SL-2nd" firstAttribute="top" secondItem="pk6-co-N73" secondAttribute="bottom" constant="14" id="sep-t-cst"/>
-                                                <constraint firstItem="sal-CB-new" firstAttribute="top" secondItem="sep-SL-2nd" secondAttribute="bottom" constant="12" id="sal-t-cst"/>
-                                                <constraint firstItem="sal-CB-new" firstAttribute="leading" secondItem="DjV-qq-hr9" secondAttribute="leading" id="sal-l-cst"/>
-                                                <constraint firstItem="sal-LB-new" firstAttribute="leading" secondItem="sal-CB-new" secondAttribute="trailing" constant="8" id="sal-lb-l"/>
-                                                <constraint firstItem="sal-LB-new" firstAttribute="centerY" secondItem="sal-CB-new" secondAttribute="centerY" constant="-1.5" id="sal-lb-cy"/>
-                                                <constraint firstItem="uci-LB-new" firstAttribute="top" secondItem="sal-CB-new" secondAttribute="bottom" constant="14" id="uci-lb-t"/>
-                                                <constraint firstItem="uci-LB-new" firstAttribute="trailing" secondItem="GaR-Qm-7u4" secondAttribute="trailing" id="uci-lb-tr"/>
-                                                <constraint firstItem="uci-PU-new" firstAttribute="centerY" secondItem="uci-LB-new" secondAttribute="centerY" id="uci-pu-cy"/>
-                                                <constraint firstItem="uci-PU-new" firstAttribute="leading" secondItem="DjV-qq-hr9" secondAttribute="leading" constant="-2" id="uci-pu-l"/>
-                                                <constraint firstItem="cfu-BT-new" firstAttribute="centerY" secondItem="uci-PU-new" secondAttribute="centerY" id="cfu-bt-cy"/>
-                                                <constraint firstItem="cfu-BT-new" firstAttribute="leading" secondItem="uci-PU-new" secondAttribute="trailing" constant="8" id="cfu-bt-l"/>
                                             </constraints>
                                         </view>
                                     </tabViewItem>
@@ -847,9 +763,6 @@
                         <outlet property="timeFormat" destination="iiG-Xu-4id" id="oM3-1Y-fAF"/>
                         <outlet property="timeFormatLabel" destination="wtO-uL-QBf" id="udS-d6-Tep"/>
                         <outlet property="visualEffectView" destination="Wj2-aw-ZDm" id="TZy-V2-JFS"/>
-                        <outlet property="startAtLoginLabel" destination="sal-LB-new" id="sal-out-lb"/>
-                        <outlet property="startupCheckbox" destination="sal-CB-new" id="sal-out-cb"/>
-                        <outlet property="updateCheckIntervalPopup" destination="uci-PU-new" id="uci-out-pu"/>
                     </connections>
                 </viewController>
                 <customObject id="u7K-hb-gdM" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>


### PR DESCRIPTION
## Summary
- Move "Start at Login" toggle and "Check for Updates" controls from the Misc sub-tab to the About tab
- Reimplemented in SwiftUI within `AboutView` (previously storyboard + `AppearanceViewController`)
- Remove corresponding IBOutlets, IBActions, storyboard elements, and Sparkle import from `AppearanceViewController`
- Bump version to 2.6.0

## Test plan
- [x] Build succeeds
- [x] All 112 unit tests pass
- [ ] Manual: About tab shows Start at Login toggle, Check for Updates picker, and Check Now button
- [ ] Manual: Start at Login toggle correctly registers/unregisters the login item
- [ ] Manual: Check for Updates interval picker persists selection
- [ ] Manual: Check Now button triggers Sparkle update check

🤖 Generated with [Claude Code](https://claude.com/claude-code)