### PR TITLE
Fix Sparkle update validation with properly signed release

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -1,21 +1,21 @@
-<?xml version="1.0" encoding="utf-8"?>
-<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" xmlns:dc="http://purl.org/dc/elements/1.1/">
+<?xml version="1.0" standalone="yes"?>
+<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">
     <channel>
-        <title>Meridian Updates</title>
-        <description>Most recent changes with links to updates.</description>
-        <language>en</language>
+        <title>Meridian</title>
         <item>
-            <title>Version 2.6.0</title>
-            <pubDate>Sun, 09 Mar 2026 10:42:28 +0000</pubDate>
-            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <title>2.6.0</title>
+            <pubDate>Mon, 09 Mar 2026 22:18:54 +1100</pubDate>
             <sparkle:version>2.6.0</sparkle:version>
+            <sparkle:shortVersionString>2.6.0</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
+            <sparkle:hardwareRequirements>arm64</sparkle:hardwareRequirements>
             <description><![CDATA[
                 <ul>
                     <li>Fix slow startup caused by coordinate geocoding on every launch</li>
                     <li>Move Start at Login and Check for Updates to About tab</li>
                 </ul>
             ]]></description>
-            <enclosure url="https://github.com/tpak/meridian/releases/download/v2.6.0/Meridian.app.zip" sparkle:edSignature="auK8Nk8JXx7eahLZhxWZfc18zMwIywEkVbJ32ZdOc9i5ggF7y03qohulumjYKKlfglRoIszktmihcXhuW5nTAA==" length="3159387" type="application/octet-stream"/>
+            <enclosure url="https://github.com/tpak/meridian/releases/download/v2.6.0/Meridian.app.zip" length="3149613" type="application/octet-stream" sparkle:edSignature="ZF9sX9hQ+JX2VbnTKSKyUZJ/Tkj86DU9yDzYnjdEZeIY2ssqIahYVuDZ9V6a8/xC356+ANvlnmxLsmi+TiYxCA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
## Summary
- Rebuild v2.6.0 release with ad-hoc code signing (`CODE_SIGN_IDENTITY="-"`) instead of `CODE_SIGNING_REQUIRED=NO`
- Previous build had no sealed resources or code identity, causing Sparkle to reject the update with "improperly signed" error
- Regenerated appcast using Sparkle's `generate_appcast` tool for correct EdDSA signatures
- Re-uploaded `Meridian.app.zip` to v2.6.0 GitHub Release

## Root cause
Building with `CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY=` produces a linker-signed binary with no sealed resources (`Sealed Resources=none`, `Info.plist=not bound`). Sparkle validates the code signature of the update bundle and rejects it. Building with `CODE_SIGN_IDENTITY="-"` produces a properly ad-hoc signed bundle with sealed resources.

## Test plan
- [ ] Manual: "Check for Updates" on v2.5.0 → finds v2.6.0 → install succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)