### PR TITLE
Update repo URLs after rename to Meridian

### DIFF
--- a/Meridian/Clocker/Clocker-Info.plist
+++ b/Meridian/Clocker/Clocker-Info.plist
@@ -41,7 +41,7 @@
 	<key>RequestsOpenAccess</key>
 	<string>YES</string>
 	<key>SUFeedURL</key>
-	<string>https://raw.githubusercontent.com/tpak/meridian/main/appcast.xml</string>
+	<string>https://raw.githubusercontent.com/tpak/Meridian/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>6aLwQvjUe74RhVN1IVlf9IIIAc6kwbQF74tC8CBifqU=</string>
 </dict>

--- a/Meridian/Preferences/About/AboutViewController.swift
+++ b/Meridian/Preferences/About/AboutViewController.swift
@@ -4,10 +4,10 @@ import Cocoa
 import SwiftUI
 
 struct AboutUsConstants {
-    static let GitHubURL = "https://github.com/tpak/meridian"
-    static let GitHubIssuesURL = "https://github.com/tpak/meridian/issues"
-    static let AppStoreLink = "https://github.com/tpak/meridian"
-    static let FAQsLink = "https://github.com/tpak/meridian/wiki"
+    static let GitHubURL = "https://github.com/tpak/Meridian"
+    static let GitHubIssuesURL = "https://github.com/tpak/Meridian/issues"
+    static let AppStoreLink = "https://github.com/tpak/Meridian"
+    static let FAQsLink = "https://github.com/tpak/Meridian/wiki"
     static let OriginalProjectURL = "https://github.com/n0shake/Clocker"
     static let CrowdInLocalizationLink = "https://crwd.in/clocker"
 }

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 <h1 align="center">Meridian</h1>
 
 <p align="center">
-  <a href="https://github.com/tpak/meridian/actions/workflows/ci.yml"><img src="https://github.com/tpak/meridian/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/tpak/meridian/actions/workflows/codeql.yml"><img src="https://github.com/tpak/meridian/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
-  <a href="https://github.com/tpak/meridian/blob/main/.swiftlint.yml"><img src="https://img.shields.io/badge/SwiftLint-configured-brightgreen" alt="SwiftLint"></a>
-  <a href="https://github.com/tpak/meridian/blob/main/LICENSE"><img src="https://img.shields.io/github/license/tpak/meridian" alt="License"></a>
+  <a href="https://github.com/tpak/Meridian/actions/workflows/ci.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/tpak/Meridian/actions/workflows/codeql.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
+  <a href="https://github.com/tpak/Meridian/blob/main/.swiftlint.yml"><img src="https://img.shields.io/badge/SwiftLint-configured-brightgreen" alt="SwiftLint"></a>
+  <a href="https://github.com/tpak/Meridian/blob/main/LICENSE"><img src="https://img.shields.io/github/license/tpak/Meridian" alt="License"></a>
 </p>
 
 A macOS menu bar world clock. Track time across zones for your team, friends, and family.
@@ -26,7 +26,7 @@ A macOS menu bar world clock. Track time across zones for your team, friends, an
 
 ## Install
 
-Download the latest release from [GitHub Releases](https://github.com/tpak/meridian/releases).
+Download the latest release from [GitHub Releases](https://github.com/tpak/Meridian/releases).
 
 Requires macOS 13 (Ventura) or later.
 
@@ -35,8 +35,8 @@ Requires macOS 13 (Ventura) or later.
 Requires Xcode 15+ and macOS 13 (Ventura) or later.
 
 ```bash
-git clone https://github.com/tpak/meridian.git
-cd meridian
+git clone https://github.com/tpak/Meridian.git
+cd Meridian
 ```
 
 ### Build & Run
@@ -61,7 +61,7 @@ Version is set via `MARKETING_VERSION` in the Xcode project (3 build configurati
 
 1. Search for `MARKETING_VERSION` in `Meridian/Meridian.xcodeproj/project.pbxproj`
 2. Update all 3 occurrences to the new version
-3. Commit, tag, and create a [GitHub Release](https://github.com/tpak/meridian/releases)
+3. Commit, tag, and create a [GitHub Release](https://github.com/tpak/Meridian/releases)
 
 ### Project Structure
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -15,7 +15,7 @@
                     <li>Move Start at Login and Check for Updates to About tab</li>
                 </ul>
             ]]></description>
-            <enclosure url="https://github.com/tpak/meridian/releases/download/v2.6.0/Meridian.app.zip" length="3149613" type="application/octet-stream" sparkle:edSignature="ZF9sX9hQ+JX2VbnTKSKyUZJ/Tkj86DU9yDzYnjdEZeIY2ssqIahYVuDZ9V6a8/xC356+ANvlnmxLsmi+TiYxCA=="/>
+            <enclosure url="https://github.com/tpak/Meridian/releases/download/v2.6.0/Meridian.app.zip" length="3149613" type="application/octet-stream" sparkle:edSignature="ZF9sX9hQ+JX2VbnTKSKyUZJ/Tkj86DU9yDzYnjdEZeIY2ssqIahYVuDZ9V6a8/xC356+ANvlnmxLsmi+TiYxCA=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
## Summary
- GitHub repo renamed from `tpak/meridian` to `tpak/Meridian`
- Updated all URL references: SUFeedURL in Info.plist, appcast.xml download URL, About screen links, README badges/links/clone command

🤖 Generated with [Claude Code](https://claude.com/claude-code)