### PR TITLE
Code quality: remove NSObject, fix DI, name constants

### DIFF
--- a/Meridian/Overall App/DateFormatterManager.swift
+++ b/Meridian/Overall App/DateFormatterManager.swift
@@ -2,7 +2,7 @@
 
 import Cocoa
 
-class DateFormatterManager: NSObject {
+enum DateFormatterManager {
     private static var dateFormatter = DateFormatter()
     private static var calendarDateFormatter = DateFormatter()
     private static var simpleFormatter = DateFormatter()
@@ -12,7 +12,7 @@ class DateFormatterManager: NSObject {
     private static var gregorianCalendar = Calendar(identifier: Calendar.Identifier.gregorian)
     private static var USLocale = Locale(identifier: "en_US")
 
-    class func dateFormatter(with style: DateFormatter.Style, for timezoneIdentifier: String) -> DateFormatter {
+    static func dateFormatter(with style: DateFormatter.Style, for timezoneIdentifier: String) -> DateFormatter {
         dateFormatter.dateStyle = style
         dateFormatter.timeStyle = style
         dateFormatter.locale = USLocale
@@ -20,7 +20,7 @@ class DateFormatterManager: NSObject {
         return dateFormatter
     }
 
-    class func dateFormatterWithFormat(with style: DateFormatter.Style,
+    static func dateFormatterWithFormat(with style: DateFormatter.Style,
                                        format: String,
                                        timezoneIdentifier: String,
                                        locale:
@@ -48,7 +48,7 @@ class DateFormatterManager: NSObject {
         return specializedFormatter
     }
 
-    class func localizedFormatter(with format: String, for timezoneIdentifier: String, locale _: Locale = Locale.autoupdatingCurrent) -> DateFormatter {
+    static func localizedFormatter(with format: String, for timezoneIdentifier: String, locale _: Locale = Locale.autoupdatingCurrent) -> DateFormatter {
         dateFormatter.dateStyle = .none
         dateFormatter.timeStyle = .none
         dateFormatter.locale = Locale.autoupdatingCurrent
@@ -57,7 +57,7 @@ class DateFormatterManager: NSObject {
         return dateFormatter
     }
 
-    class func localizedSimpleFormatter(_ format: String) -> DateFormatter {
+    static func localizedSimpleFormatter(_ format: String) -> DateFormatter {
         localizedSimpleFormatter.dateStyle = .none
         localizedSimpleFormatter.timeStyle = .none
         localizedSimpleFormatter.dateFormat = format

--- a/Meridian/Overall App/NetworkManager.swift
+++ b/Meridian/Overall App/NetworkManager.swift
@@ -3,7 +3,7 @@
 import Cocoa
 import CoreLocation
 
-class NetworkManager: NSObject {
+enum NetworkManager {
     static let internalServerError: NSError = {
         let localizedError = """
         There was a problem retrieving your information. Please try again later.

--- a/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
+++ b/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
@@ -5,7 +5,11 @@ import CoreLocation
 import CoreLoggerKit
 import CoreModelKit
 
-class TimezoneDataOperations: NSObject {
+class TimezoneDataOperations {
+    private enum Constants {
+        static let dstDaysLookahead = 8
+    }
+
     private let dataObject: TimezoneData
     private let store: DataStoring
     private lazy var calendar = Calendar.autoupdatingCurrent
@@ -15,7 +19,6 @@ class TimezoneDataOperations: NSObject {
     init(with timezone: TimezoneData, store: DataStoring) {
         dataObject = timezone
         self.store = store
-        super.init()
     }
 }
 
@@ -55,7 +58,7 @@ extension TimezoneDataOperations {
 
         // We'd like to show upcoming DST changes within the 7 day range.
         // Using 8 as a fail-safe as timezones behind CDT can sometimes be wrongly attributed
-        if numberOfDays > 8 || numberOfDays < 0 {
+        if numberOfDays > Constants.dstDaysLookahead || numberOfDays < 0 {
             return nil
         }
 

--- a/Meridian/Panel/ParentPanelController+ModernSlider.swift
+++ b/Meridian/Panel/ParentPanelController+ModernSlider.swift
@@ -6,7 +6,7 @@ import Foundation
 
 extension ParentPanelController: NSCollectionViewDataSource {
     func collectionView(_: NSCollectionView, numberOfItemsInSection _: Int) -> Int {
-        let futureSliderDayPreference = DataStore.shared().retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
+        let futureSliderDayPreference = dataStore.retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
         let futureSliderDayRange = futureSliderDayPreference.intValue
         return (PanelConstants.modernSliderPointsInADay * futureSliderDayRange * 2) + 1
     }
@@ -147,13 +147,13 @@ extension ParentPanelController {
     }
 
     public func setDefaultDateLabel(_ index: Int) -> Int {
-        let futureSliderDayPreference = DataStore.shared().retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
+        let futureSliderDayPreference = dataStore.retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
         let futureSliderDayRange = futureSliderDayPreference.intValue
         let totalCount = (PanelConstants.modernSliderPointsInADay * futureSliderDayRange * 2) + 1
         let centerPoint = Int(ceil(Double(totalCount / 2)))
         if index >= (centerPoint + 1) {
             let remainder = (index % (centerPoint + 1))
-            let nextDate = Calendar.current.date(byAdding: .minute, value: remainder * 15, to: closestQuarterTimeRepresentation ?? Date())!
+            let nextDate = Calendar.current.date(byAdding: .minute, value: remainder * PanelConstants.minutesPerSliderPoint, to: closestQuarterTimeRepresentation ?? Date())!
             modernSliderLabel.stringValue = timezoneFormattedStringRepresentation(nextDate)
             if resetModernSliderButton.isHidden {
                 animateButton(false)
@@ -162,7 +162,7 @@ extension ParentPanelController {
             return nextDate.minutes(from: Date()) + 1
         } else if index < centerPoint {
             let remainder = centerPoint - index + 1
-            let previousDate = Calendar.current.date(byAdding: .minute, value: -1 * remainder * 15, to: closestQuarterTimeRepresentation ?? Date())!
+            let previousDate = Calendar.current.date(byAdding: .minute, value: -1 * remainder * PanelConstants.minutesPerSliderPoint, to: closestQuarterTimeRepresentation ?? Date())!
             modernSliderLabel.stringValue = timezoneFormattedStringRepresentation(previousDate)
             if resetModernSliderButton.isHidden {
                 animateButton(false)

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -8,6 +8,7 @@ import CoreModelKit
 
 struct PanelConstants {
     static let modernSliderPointsInADay = 96
+    static let minutesPerSliderPoint = 15
 }
 
 class ParentPanelController: NSWindowController {

--- a/Meridian/Preferences/Menu Bar/MenubarTitleProvider.swift
+++ b/Meridian/Preferences/Menu Bar/MenubarTitleProvider.swift
@@ -4,12 +4,11 @@ import Cocoa
 import CoreLoggerKit
 import CoreModelKit
 
-class MenubarTitleProvider: NSObject {
+class MenubarTitleProvider {
     private let store: DataStoring
 
     init(with dataStore: DataStoring) {
         store = dataStore
-        super.init()
     }
 
     func titleForMenubar() -> String? {

--- a/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
@@ -11,6 +11,13 @@ private enum MenubarState {
     case icon
 }
 
+private enum BufferWidthConstants {
+    static let baseWidth = 55
+    static let dayBuffer = 12
+    static let twelveHourBuffer = 20
+    static let dateBuffer = 20
+}
+
 class StatusItemHandler: NSObject {
     var hasActiveIcon: Bool = false
 
@@ -353,18 +360,18 @@ class StatusItemHandler: NSObject {
     }
 
     private func bufferCalculatedWidth() -> Int {
-        var totalWidth = 55
+        var totalWidth = BufferWidthConstants.baseWidth
 
         if store.shouldShowDayInMenubar() {
-            totalWidth += 12
+            totalWidth += BufferWidthConstants.dayBuffer
         }
 
         if store.isBufferRequiredForTwelveHourFormats() {
-            totalWidth += 20
+            totalWidth += BufferWidthConstants.twelveHourBuffer
         }
 
         if store.shouldShowDateInMenubar() {
-            totalWidth += 20
+            totalWidth += BufferWidthConstants.dateBuffer
         }
 
         return totalWidth


### PR DESCRIPTION
## Summary
- Convert `DateFormatterManager` and `NetworkManager` from classes inheriting `NSObject` to `enum` namespaces (no instances are ever created)
- Remove unnecessary `NSObject` inheritance from `TimezoneDataOperations` and `MenubarTitleProvider`
- Replace `DataStore.shared()` calls in `ParentPanelController+ModernSlider.swift` with the injected `dataStore` property
- Extract magic numbers into named constants: DST days lookahead threshold, menubar buffer widths, slider minutes per point

## Test plan
- [x] Project builds successfully
- [x] All 112 unit tests pass
- [x] No new SwiftLint violations introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)