### PR TITLE
Harden security: secure coding, retain cycles, crash guards

### DIFF
--- a/Meridian/App/LocationController.swift
+++ b/Meridian/App/LocationController.swift
@@ -51,17 +51,6 @@ class LocationController: NSObject {
         if CLLocationManager.locationServicesEnabled() {
             locationManager.startUpdatingLocation()
         }
-
-        switch authorizationStatus() {
-        case .authorizedAlways:
-            locationManager.startUpdatingLocation()
-        case .notDetermined:
-            locationManager.startUpdatingLocation()
-        case .denied, .restricted:
-            locationManager.startUpdatingLocation()
-        default:
-            fatalError("Unexpected Authorization Status")
-        }
     }
 
     private func updateHomeObject(with customLabel: String, coordinates: CLLocationCoordinate2D?) {
@@ -105,12 +94,9 @@ extension LocationController: CLLocationManagerDelegate {
 
         let reverseGeoCoder = CLGeocoder()
 
-        reverseGeoCoder.reverseGeocodeLocation(locations[0]) { placemarks, _ in
-
-            guard let customLabel = placemarks?.first?.locality else { return }
-
+        reverseGeoCoder.reverseGeocodeLocation(locations[0]) { [weak self] placemarks, _ in
+            guard let self, let customLabel = placemarks?.first?.locality else { return }
             self.updateHomeObject(with: customLabel, coordinates: coordinates)
-
             self.locationManager.stopUpdatingLocation()
         }
     }

--- a/Meridian/CoreModelKit/Sources/CoreModelKit/TimezoneData.swift
+++ b/Meridian/CoreModelKit/Sources/CoreModelKit/TimezoneData.swift
@@ -113,22 +113,22 @@ public class TimezoneData: NSObject, NSCoding, NSSecureCoding {
     }
 
     public required init?(coder aDecoder: NSCoder) {
-        customLabel = aDecoder.decodeObject(forKey: "customLabel") as? String
-        formattedAddress = aDecoder.decodeObject(forKey: "formattedAddress") as? String
-        placeID = aDecoder.decodeObject(forKey: "place_id") as? String
-        timezoneID = aDecoder.decodeObject(forKey: "timezoneID") as? String
-        latitude = aDecoder.decodeObject(forKey: "latitude") as? Double
-        longitude = aDecoder.decodeObject(forKey: "longitude") as? Double
-        note = aDecoder.decodeObject(forKey: "note") as? String
-        nextUpdate = aDecoder.decodeObject(forKey: "nextUpdate") as? Date
-        sunriseTime = aDecoder.decodeObject(forKey: "sunriseTime") as? Date
-        sunsetTime = aDecoder.decodeObject(forKey: "sunsetTime") as? Date
+        customLabel = aDecoder.decodeObject(of: NSString.self, forKey: "customLabel") as? String
+        formattedAddress = aDecoder.decodeObject(of: NSString.self, forKey: "formattedAddress") as? String
+        placeID = aDecoder.decodeObject(of: NSString.self, forKey: "place_id") as? String
+        timezoneID = aDecoder.decodeObject(of: NSString.self, forKey: "timezoneID") as? String
+        latitude = aDecoder.decodeObject(of: NSNumber.self, forKey: "latitude")?.doubleValue
+        longitude = aDecoder.decodeObject(of: NSNumber.self, forKey: "longitude")?.doubleValue
+        note = aDecoder.decodeObject(of: NSString.self, forKey: "note") as? String
+        nextUpdate = aDecoder.decodeObject(of: NSDate.self, forKey: "nextUpdate") as? Date
+        sunriseTime = aDecoder.decodeObject(of: NSDate.self, forKey: "sunriseTime") as? Date
+        sunsetTime = aDecoder.decodeObject(of: NSDate.self, forKey: "sunsetTime") as? Date
         isFavourite = aDecoder.decodeInteger(forKey: "isFavourite")
         let selection = aDecoder.decodeInteger(forKey: "selectionType")
-        selectionType = SelectionType(rawValue: selection)!
+        selectionType = SelectionType(rawValue: selection) ?? .city
         isSystemTimezone = aDecoder.decodeBool(forKey: "isSystemTimezone")
         let override = aDecoder.decodeInteger(forKey: "overrideFormat")
-        overrideFormat = TimezoneOverride(rawValue: override)!
+        overrideFormat = TimezoneOverride(rawValue: override) ?? .globalFormat
     }
 
     public class func customObject(from encodedData: Data?) -> TimezoneData? {
@@ -137,7 +137,7 @@ public class TimezoneData: NSObject, NSCoding, NSSecureCoding {
         }
 
         guard let unarchiver = try? NSKeyedUnarchiver(forReadingFrom: dataObject) else { return nil }
-        unarchiver.requiresSecureCoding = false
+        unarchiver.requiresSecureCoding = true
         let result = unarchiver.decodeObject(of: TimezoneData.self, forKey: NSKeyedArchiveRootObjectKey)
         unarchiver.finishDecoding()
         return result

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -57,6 +57,7 @@ class ParentPanelController: NSWindowController {
     }
 
     deinit {
+        NotificationCenter.default.removeObserver(self)
         datasource = nil
     }
 


### PR DESCRIPTION
## Summary
- **Secure coding**: Set `requiresSecureCoding = true` on `NSKeyedUnarchiver` and updated all `decodeObject(forKey:)` calls in `TimezoneData.init?(coder:)` to use type-safe `decodeObject(of:forKey:)` variants (`NSString`, `NSNumber`, `NSDate`)
- **Safe enum init**: Replace force-unwrapped `SelectionType(rawValue:)!` and `TimezoneOverride(rawValue:)!` with nil-coalescing defaults (`.city` and `.globalFormat`)
- **Retain cycle fix**: Add `[weak self]` to `reverseGeocodeLocation` closure in `LocationController` to prevent retain cycle
- **Remove fatalError**: Replace redundant switch statement (every case called `startUpdatingLocation`) with a single `if CLLocationManager.locationServicesEnabled()` guard, eliminating the `fatalError` in the default branch
- **Observer cleanup**: Add `NotificationCenter.default.removeObserver(self)` to `ParentPanelController.deinit` to clean up bounds-change observer registered in the modern slider extension

## Test plan
- [x] All 112 unit tests pass with 0 failures
- [x] Debug build succeeds with no warnings from changed files
- [ ] Verify timezone data loads correctly from existing UserDefaults (round-trip with secure coding)
- [ ] Verify location authorization flow works without crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)