### PR TITLE
Add unit tests for critical untested paths

### DIFF
--- a/Meridian/Meridian.xcodeproj/project.pbxproj
+++ b/Meridian/Meridian.xcodeproj/project.pbxproj
@@ -91,6 +91,8 @@
 		A1B2C3D4E5F60002SEARCH02 /* TimezoneSearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60001SEARCH01 /* TimezoneSearchService.swift */; };
 		AA000001SWIFTUI00000001 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000002SWIFTUI00000001 /* AboutView.swift */; };
 		AA00000400000002PREFSTB1 /* PreferencesStoryboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00000400000001PREFSTB2 /* PreferencesStoryboardTests.swift */; };
+		CC11AA0100TZDATAOPSTEST1 /* TimezoneDataOperationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC11AA0100TZDATAOPSTEST2 /* TimezoneDataOperationsTests.swift */; };
+		CC11AA0200MNBRTITLTEST1 /* MenubarTitleProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC11AA0200MNBRTITLTEST2 /* MenubarTitleProviderTests.swift */; };
 		AA000011MODERN00000001 /* ModernSliderViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000010MODERN00000001 /* ModernSliderViews.swift */; };
 		AA000013STARTU00000001 /* StartupManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000012STARTU00000001 /* StartupManager.swift */; };
 		AA1B2C3D0002000000000001 /* TimezoneSortingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D0001000000000001 /* TimezoneSortingManager.swift */; };
@@ -217,6 +219,8 @@
 		A1B2C3D4E5F60001SEARCH01 /* TimezoneSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimezoneSearchService.swift; sourceTree = "<group>"; };
 		AA000002SWIFTUI00000001 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		AA00000400000001PREFSTB2 /* PreferencesStoryboardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesStoryboardTests.swift; sourceTree = "<group>"; };
+		CC11AA0100TZDATAOPSTEST2 /* TimezoneDataOperationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimezoneDataOperationsTests.swift; sourceTree = "<group>"; };
+		CC11AA0200MNBRTITLTEST2 /* MenubarTitleProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarTitleProviderTests.swift; sourceTree = "<group>"; };
 		AA000010MODERN00000001 /* ModernSliderViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModernSliderViews.swift; sourceTree = "<group>"; };
 		AA000012STARTU00000001 /* StartupManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartupManager.swift; sourceTree = "<group>"; };
 		AA1B2C3D0001000000000001 /* TimezoneSortingManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimezoneSortingManager.swift; sourceTree = "<group>"; };
@@ -520,6 +524,8 @@
 				919639F9D2F3GLOBALSHRTCU2 /* GlobalShortcutMonitorTests.swift */,
 				4726354D81E1NWMGRASYNCT2 /* NetworkManagerAsyncTests.swift */,
 				AA00000400000001PREFSTB2 /* PreferencesStoryboardTests.swift */,
+				CC11AA0100TZDATAOPSTEST2 /* TimezoneDataOperationsTests.swift */,
+				CC11AA0200MNBRTITLTEST2 /* MenubarTitleProviderTests.swift */,
 			);
 			path = MeridianUnitTests;
 			sourceTree = "<group>";
@@ -763,6 +769,8 @@
 				919639F9D2F3GLOBALSHRTCUT /* GlobalShortcutMonitorTests.swift in Sources */,
 				4726354D81E1NWMGRASYNCTS /* NetworkManagerAsyncTests.swift in Sources */,
 				AA00000400000002PREFSTB1 /* PreferencesStoryboardTests.swift in Sources */,
+				CC11AA0100TZDATAOPSTEST1 /* TimezoneDataOperationsTests.swift in Sources */,
+				CC11AA0200MNBRTITLTEST1 /* MenubarTitleProviderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Meridian/MeridianUnitTests/MenubarTitleProviderTests.swift
+++ b/Meridian/MeridianUnitTests/MenubarTitleProviderTests.swift
@@ -1,0 +1,149 @@
+// Copyright © 2015 Abhishek Banthia
+
+import CoreModelKit
+import XCTest
+
+@testable import Meridian
+
+class MenubarTitleProviderTests: XCTestCase {
+    private var mockStore: MockDataStore!
+
+    private let mumbai: [String: Any] = ["customLabel": "Ghar",
+                                         "formattedAddress": "Mumbai",
+                                         "place_id": "ChIJwe1EZjDG5zsRaYxkjY_tpF0",
+                                         "timezoneID": "Asia/Calcutta",
+                                         "nextUpdate": "",
+                                         "latitude": 19.0759837,
+                                         "longitude": 72.8776559]
+
+    private let newYork: [String: Any] = ["customLabel": "NYC",
+                                          "formattedAddress": "New York",
+                                          "place_id": "TestNY",
+                                          "timezoneID": "America/New_York",
+                                          "nextUpdate": "",
+                                          "latitude": 40.7128,
+                                          "longitude": -74.0060]
+
+    override func setUp() {
+        super.setUp()
+        mockStore = MockDataStore()
+        mockStore.preferences[UserDefaultKeys.selectedTimeZoneFormatKey] = NSNumber(value: 0)
+        mockStore.preferences[UserDefaultKeys.relativeDateKey] = NSNumber(value: 0)
+        // Ensure non-compact mode (menubarCompactMode != 0 means standard mode)
+        mockStore.viewTypeDisplayPreferences[.menubarCompactMode] = false
+    }
+
+    override func tearDown() {
+        mockStore = nil
+        super.tearDown()
+    }
+
+    // MARK: - No Favorites Tests
+
+    func testNoFavoritesReturnsNil() {
+        mockStore.storedTimezones = []
+        let provider = MenubarTitleProvider(with: mockStore)
+        XCTAssertNil(provider.titleForMenubar(), "No favorites should return nil")
+    }
+
+    func testUnfavouritedTimezoneReturnsNil() {
+        let dataObject = TimezoneData(with: mumbai)
+        dataObject.isFavourite = 0
+        mockStore.addTimezone(dataObject)
+
+        let provider = MenubarTitleProvider(with: mockStore)
+        let title = provider.titleForMenubar()
+        // menubarTimezones filters by isFavourite == 1, so empty list => nil
+        XCTAssertNil(title, "Unfavourited timezone should result in nil title")
+    }
+
+    // MARK: - Single Timezone Tests
+
+    func testSingleFavouriteTimezone() {
+        let dataObject = TimezoneData(with: mumbai)
+        dataObject.isFavourite = 1
+        mockStore.addTimezone(dataObject)
+
+        let provider = MenubarTitleProvider(with: mockStore)
+        let title = provider.titleForMenubar()
+        XCTAssertNotNil(title, "Single favourite should produce a title")
+        XCTAssertFalse(title!.isEmpty, "Title should not be empty")
+    }
+
+    func testSingleTimezoneWith12HourFormat() {
+        mockStore.preferences[UserDefaultKeys.selectedTimeZoneFormatKey] = NSNumber(value: 0)
+        let dataObject = TimezoneData(with: mumbai)
+        dataObject.isFavourite = 1
+        mockStore.addTimezone(dataObject)
+
+        let provider = MenubarTitleProvider(with: mockStore)
+        let title = provider.titleForMenubar()
+        XCTAssertNotNil(title)
+        // Title should contain AM or PM for 12-hour format
+        let hasAMPM = title!.contains("AM") || title!.contains("PM")
+        XCTAssertTrue(hasAMPM, "12-hour format title should contain AM/PM but got: \(title!)")
+    }
+
+    func testSingleTimezoneWith24HourFormat() {
+        mockStore.preferences[UserDefaultKeys.selectedTimeZoneFormatKey] = NSNumber(value: 1)
+        let dataObject = TimezoneData(with: mumbai)
+        dataObject.isFavourite = 1
+        mockStore.addTimezone(dataObject)
+
+        let provider = MenubarTitleProvider(with: mockStore)
+        let title = provider.titleForMenubar()
+        XCTAssertNotNil(title)
+        // Title should NOT contain AM or PM for 24-hour format
+        let hasAMPM = title!.contains("AM") || title!.contains("PM")
+        XCTAssertFalse(hasAMPM, "24-hour format title should not contain AM/PM but got: \(title!)")
+    }
+
+    // MARK: - Multiple Timezones Tests
+
+    func testMultipleTimezones() {
+        let mumbaiData = TimezoneData(with: mumbai)
+        mumbaiData.isFavourite = 1
+        mockStore.addTimezone(mumbaiData)
+
+        let nyData = TimezoneData(with: newYork)
+        nyData.isFavourite = 1
+        mockStore.addTimezone(nyData)
+
+        let provider = MenubarTitleProvider(with: mockStore)
+        let title = provider.titleForMenubar()
+        XCTAssertNotNil(title, "Multiple favourites should produce a title")
+        XCTAssertFalse(title!.isEmpty, "Title with multiple timezones should not be empty")
+    }
+
+    func testMultipleTimezonesContainsBothTimes() {
+        let mumbaiData = TimezoneData(with: mumbai)
+        mumbaiData.isFavourite = 1
+        mockStore.addTimezone(mumbaiData)
+
+        let nyData = TimezoneData(with: newYork)
+        nyData.isFavourite = 1
+        mockStore.addTimezone(nyData)
+
+        let provider = MenubarTitleProvider(with: mockStore)
+        let title = provider.titleForMenubar()
+        XCTAssertNotNil(title)
+
+        // With two timezones, the title should contain a space (separator between the two titles)
+        // The titles are joined with a space
+        XCTAssertTrue(title!.count > 4, "Combined title should have reasonable length but got: \(title!)")
+    }
+
+    // MARK: - Compact Mode Tests
+
+    func testCompactModeReturnsNil() {
+        mockStore.viewTypeDisplayPreferences[.menubarCompactMode] = true
+
+        let dataObject = TimezoneData(with: mumbai)
+        dataObject.isFavourite = 1
+        mockStore.addTimezone(dataObject)
+
+        let provider = MenubarTitleProvider(with: mockStore)
+        let title = provider.titleForMenubar()
+        XCTAssertNil(title, "Compact mode should return nil from titleForMenubar")
+    }
+}

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -458,4 +458,77 @@ class MeridianUnitTests: XCTestCase {
         XCTAssertNil(defaults?.object(forKey: "test1"))
         XCTAssertNil(defaults?.object(forKey: "test2"))
     }
+
+    func testDeserializationWithInvalidSelectionType() {
+        // Archive a valid TimezoneData, then tamper with the plist to set an invalid selectionType
+        let original = TimezoneData(with: california)
+        original.selectionType = .city
+
+        guard let archivedData = try? NSKeyedArchiver.archivedData(withRootObject: original, requiringSecureCoding: true) else {
+            XCTFail("Failed to archive TimezoneData")
+            return
+        }
+
+        // Deserialize the archive into a mutable plist, tamper with selectionType, re-serialize
+        guard var plist = try? PropertyListSerialization.propertyList(from: archivedData, format: nil) as? [String: Any],
+              var objects = plist["$objects"] as? [Any]
+        else {
+            XCTFail("Failed to parse archived plist")
+            return
+        }
+
+        // Find the root object and tamper with selectionType
+        // The root object is typically at index 1 in $objects (index 0 is "$null")
+        // Walk objects looking for a dictionary containing "selectionType"
+        for i in 0 ..< objects.count {
+            if var dict = objects[i] as? [String: Any], dict["selectionType"] != nil {
+                dict["selectionType"] = 999 // Invalid raw value
+                objects[i] = dict
+                break
+            }
+        }
+
+        plist["$objects"] = objects
+
+        guard let tamperedData = try? PropertyListSerialization.data(fromPropertyList: plist, format: .binary, options: 0) else {
+            XCTFail("Failed to re-serialize tampered plist")
+            return
+        }
+
+        // Unarchive — init?(coder:) uses `?? .city` so invalid values should default
+        let result = TimezoneData.customObject(from: tamperedData)
+
+        XCTAssertNotNil(result, "Deserialization should not return nil for invalid selectionType")
+        XCTAssertEqual(result?.selectionType, .city, "Invalid selectionType should default to .city")
+    }
+
+    func testSecureCodingRoundtrip() {
+        let original = TimezoneData(with: california)
+        original.isFavourite = 1
+        original.selectionType = .city
+        original.setShouldOverrideGlobalTimeFormat(2) // 24-hour
+        original.note = "Test note"
+
+        // Archive using secureArchive
+        guard let archivedData = NSKeyedArchiver.secureArchive(with: original) else {
+            XCTFail("secureArchive returned nil")
+            return
+        }
+
+        // Unarchive using customObject(from:) which uses requiresSecureCoding = true
+        let restored = TimezoneData.customObject(from: archivedData)
+
+        XCTAssertNotNil(restored, "customObject(from:) should return non-nil")
+        XCTAssertEqual(restored?.placeID, original.placeID, "placeID should match")
+        XCTAssertEqual(restored?.timezoneID, original.timezoneID, "timezoneID should match")
+        XCTAssertEqual(restored?.formattedAddress, original.formattedAddress, "formattedAddress should match")
+        XCTAssertEqual(restored?.customLabel, original.customLabel, "customLabel should match")
+        XCTAssertEqual(restored?.isFavourite, original.isFavourite, "isFavourite should match")
+        XCTAssertEqual(restored?.selectionType, original.selectionType, "selectionType should match")
+        XCTAssertEqual(restored?.overrideFormat, original.overrideFormat, "overrideFormat should match")
+        XCTAssertEqual(restored?.note, original.note, "note should match")
+        XCTAssertEqual(restored?.isSystemTimezone, original.isSystemTimezone, "isSystemTimezone should match")
+        XCTAssertEqual(restored?.latitude, original.latitude, "latitude should match")
+        XCTAssertEqual(restored?.longitude, original.longitude, "longitude should match")
+    }
 }

--- a/Meridian/MeridianUnitTests/TimezoneDataOperationsTests.swift
+++ b/Meridian/MeridianUnitTests/TimezoneDataOperationsTests.swift
@@ -1,0 +1,361 @@
+// Copyright © 2015 Abhishek Banthia
+
+import CoreModelKit
+import XCTest
+
+@testable import Meridian
+
+class TimezoneDataOperationsTests: XCTestCase {
+    private var mockStore: MockDataStore!
+
+    private let newYork: [String: Any] = ["customLabel": "NYC",
+                                          "formattedAddress": "New York",
+                                          "place_id": "TestNY",
+                                          "timezoneID": "America/New_York",
+                                          "nextUpdate": "",
+                                          "latitude": 40.7128,
+                                          "longitude": -74.0060]
+
+    private let tokyo: [String: Any] = ["customLabel": "Tokyo",
+                                        "formattedAddress": "Tokyo",
+                                        "place_id": "TestTokyo",
+                                        "timezoneID": "Asia/Tokyo",
+                                        "nextUpdate": "",
+                                        "latitude": 35.6762,
+                                        "longitude": 139.6503]
+
+    private let london: [String: Any] = ["customLabel": "London",
+                                         "formattedAddress": "London",
+                                         "place_id": "TestLondon",
+                                         "timezoneID": "Europe/London",
+                                         "nextUpdate": "",
+                                         "latitude": 51.5074,
+                                         "longitude": -0.1278]
+
+    private let noCoords: [String: Any] = ["customLabel": "",
+                                           "formattedAddress": "Africa/Algiers",
+                                           "place_id": "",
+                                           "timezoneID": "Africa/Algiers",
+                                           "nextUpdate": "",
+                                           "latitude": "",
+                                           "longitude": ""]
+
+    override func setUp() {
+        super.setUp()
+        mockStore = MockDataStore()
+        // Default to 12-hour format
+        mockStore.preferences[UserDefaultKeys.selectedTimeZoneFormatKey] = NSNumber(value: 0)
+        // Default to relative day display
+        mockStore.preferences[UserDefaultKeys.relativeDateKey] = NSNumber(value: 0)
+    }
+
+    override func tearDown() {
+        mockStore = nil
+        super.tearDown()
+    }
+
+    // MARK: - Time Formatting Tests
+
+    func testTimeFormatting12Hour() {
+        let dataObject = TimezoneData(with: newYork)
+        mockStore.preferences[UserDefaultKeys.selectedTimeZoneFormatKey] = NSNumber(value: 0)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let timeString = operations.time(with: 0)
+        XCTAssertFalse(timeString.isEmpty, "Time string should not be empty")
+        // 12-hour format should contain AM or PM
+        let hasAMPM = timeString.contains("AM") || timeString.contains("PM")
+        XCTAssertTrue(hasAMPM, "12-hour format should contain AM/PM but got: \(timeString)")
+    }
+
+    func testTimeFormatting24Hour() {
+        let dataObject = TimezoneData(with: newYork)
+        dataObject.setShouldOverrideGlobalTimeFormat(2) // 24-hour
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let timeString = operations.time(with: 0)
+        XCTAssertFalse(timeString.isEmpty, "Time string should not be empty")
+        // 24-hour format should NOT contain AM or PM
+        let hasAMPM = timeString.contains("AM") || timeString.contains("PM")
+        XCTAssertFalse(hasAMPM, "24-hour format should not contain AM/PM but got: \(timeString)")
+    }
+
+    func testTimeFormattingWithSeconds() {
+        let dataObject = TimezoneData(with: tokyo)
+        dataObject.setShouldOverrideGlobalTimeFormat(4) // 12-hour with seconds
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let timeString = operations.time(with: 0)
+        // Should have format like "h:mm:ss AM" — two colons
+        let colonCount = timeString.filter { $0 == ":" }.count
+        XCTAssertEqual(colonCount, 2, "12-hour with seconds should have 2 colons, got: \(timeString)")
+    }
+
+    // MARK: - Slider Offset Tests
+
+    func testTimeWithPositiveSliderOffset() {
+        let dataObject = TimezoneData(with: newYork)
+        dataObject.setShouldOverrideGlobalTimeFormat(2) // 24-hour for easier parsing
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let currentTime = operations.time(with: 0)
+        let futureTime = operations.time(with: 60) // 1 hour ahead
+
+        XCTAssertFalse(currentTime.isEmpty)
+        XCTAssertFalse(futureTime.isEmpty)
+        // We can't easily compare times, but they should be different (unless wrapping around midnight)
+        // Just verify no crash and non-empty
+    }
+
+    func testTimeWithNegativeSliderOffset() {
+        let dataObject = TimezoneData(with: newYork)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let pastTime = operations.time(with: -60) // 1 hour behind
+        XCTAssertFalse(pastTime.isEmpty, "Past time should not be empty")
+    }
+
+    func testTimeWithLargeSliderOffset() {
+        let dataObject = TimezoneData(with: tokyo)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        // ±48 hours (2880 minutes) is the max slider range
+        let farFuture = operations.time(with: 2880)
+        let farPast = operations.time(with: -2880)
+
+        XCTAssertFalse(farFuture.isEmpty, "Far future time should not be empty")
+        XCTAssertFalse(farPast.isEmpty, "Far past time should not be empty")
+    }
+
+    // MARK: - Time Difference Tests
+
+    func testTimeDifferenceSameTimezone() {
+        let localTZ = TimeZone.autoupdatingCurrent.identifier
+        let localData: [String: Any] = ["customLabel": "Local",
+                                        "formattedAddress": "Local",
+                                        "place_id": "TestLocal",
+                                        "timezoneID": localTZ,
+                                        "nextUpdate": "",
+                                        "latitude": 0.0,
+                                        "longitude": 0.0]
+        let dataObject = TimezoneData(with: localData)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let diff = operations.timeDifference()
+        XCTAssertEqual(diff, "", "Same timezone should have empty time difference")
+    }
+
+    func testTimeDifferenceAheadTimezone() {
+        let dataObject = TimezoneData(with: tokyo)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let localTZ = TimeZone.autoupdatingCurrent
+        let tokyoTZ = TimeZone(identifier: "Asia/Tokyo")!
+        let diffSeconds = tokyoTZ.secondsFromGMT(for: Date()) - localTZ.secondsFromGMT(for: Date())
+
+        let diff = operations.timeDifference()
+
+        if diffSeconds == 0 {
+            XCTAssertEqual(diff, "", "Same offset should have empty difference")
+        } else if diffSeconds > 0 {
+            XCTAssertTrue(diff.contains("+"), "Ahead timezone should contain '+' but got: \(diff)")
+        } else {
+            XCTAssertTrue(diff.contains("-"), "Behind timezone should contain '-' but got: \(diff)")
+        }
+    }
+
+    func testTimeDifferenceBehindTimezone() {
+        let dataObject = TimezoneData(with: newYork)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let diff = operations.timeDifference()
+
+        let localTZ = TimeZone.autoupdatingCurrent
+        let nyTZ = TimeZone(identifier: "America/New_York")!
+        let diffSeconds = nyTZ.secondsFromGMT(for: Date()) - localTZ.secondsFromGMT(for: Date())
+
+        if diffSeconds == 0 {
+            XCTAssertEqual(diff, "", "Same offset should have empty difference")
+        } else {
+            XCTAssertFalse(diff.isEmpty, "Different timezone should have non-empty difference")
+        }
+    }
+
+    // MARK: - Date Display Tests
+
+    func testDateWithRelativeDayDisplay() {
+        let dataObject = TimezoneData(with: newYork)
+        mockStore.preferences[UserDefaultKeys.relativeDateKey] = NSNumber(value: 0)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let dateString = operations.date(with: 0, displayType: .panel)
+        XCTAssertFalse(dateString.isEmpty, "Panel date display should not be empty")
+    }
+
+    func testDateWithDayNameDisplay() {
+        let dataObject = TimezoneData(with: london)
+        mockStore.preferences[UserDefaultKeys.relativeDateKey] = NSNumber(value: 1)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let dateString = operations.date(with: 0, displayType: .panel)
+        XCTAssertFalse(dateString.isEmpty, "Day name display should not be empty")
+    }
+
+    func testDateWithDateFormatDisplay() {
+        let dataObject = TimezoneData(with: tokyo)
+        mockStore.preferences[UserDefaultKeys.relativeDateKey] = NSNumber(value: 2)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let dateString = operations.date(with: 0, displayType: .panel)
+        XCTAssertFalse(dateString.isEmpty, "Date format display should not be empty")
+    }
+
+    func testDateWithHiddenDisplay() {
+        let dataObject = TimezoneData(with: newYork)
+        mockStore.preferences[UserDefaultKeys.relativeDateKey] = NSNumber(value: 3)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let dateString = operations.date(with: 0, displayType: .panel)
+        XCTAssertEqual(dateString, "", "Hidden date display should return empty string")
+    }
+
+    func testDateWithMenuDisplayType() {
+        let dataObject = TimezoneData(with: newYork)
+        mockStore.preferences[UserDefaultKeys.relativeDateKey] = NSNumber(value: 0)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let dateString = operations.date(with: 0, displayType: .menu)
+        XCTAssertFalse(dateString.isEmpty, "Menu date display should not be empty")
+    }
+
+    // MARK: - Sunrise/Sunset Tests
+
+    func testFormattedSunriseTimeWithValidCoordinates() {
+        let dataObject = TimezoneData(with: newYork)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let sunrise = operations.formattedSunriseTime(with: 0)
+        XCTAssertFalse(sunrise.isEmpty, "Sunrise time should not be empty for location with coordinates")
+        XCTAssertNotNil(dataObject.sunriseTime, "Sunrise time property should be set")
+        XCTAssertNotNil(dataObject.sunsetTime, "Sunset time property should be set")
+    }
+
+    func testFormattedSunriseTimeWithNilCoordinates() {
+        let dataObject = TimezoneData(with: noCoords)
+        dataObject.selectionType = .timezone
+        dataObject.latitude = nil
+        dataObject.longitude = nil
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let sunrise = operations.formattedSunriseTime(with: 0)
+        XCTAssertEqual(sunrise, "", "Sunrise time should be empty when coordinates are nil")
+        XCTAssertNil(dataObject.sunriseTime, "Sunrise time property should be nil")
+        XCTAssertNil(dataObject.sunsetTime, "Sunset time property should be nil")
+    }
+
+    func testFormattedSunsetTimeWithNilCoordinates() {
+        let dataObject = TimezoneData(with: noCoords)
+        dataObject.latitude = nil
+        dataObject.longitude = nil
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let sunriseResult = operations.formattedSunriseTime(with: 0)
+        XCTAssertEqual(sunriseResult, "", "Should return empty string when coordinates are nil")
+    }
+
+    // MARK: - DST Transition Tests
+
+    func testNextDaylightSavingsTransitionForNonDSTTimezone() {
+        // Asia/Tokyo does not observe DST
+        let dataObject = TimezoneData(with: tokyo)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let transition = operations.nextDaylightSavingsTransitionIfAvailable(with: 0)
+        XCTAssertNil(transition, "Tokyo should not have DST transitions")
+    }
+
+    func testNextDaylightSavingsTransitionFormat() {
+        // America/New_York observes DST; transition may or may not be within 8 days
+        let dataObject = TimezoneData(with: newYork)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let transition = operations.nextDaylightSavingsTransitionIfAvailable(with: 0)
+        // Either nil (no upcoming transition within 8 days) or a properly formatted string
+        if let transition = transition {
+            XCTAssertTrue(transition.hasPrefix("Heads up:"), "DST message should start with 'Heads up:' but got: \(transition)")
+            XCTAssertTrue(transition.contains("DST transition"), "DST message should contain 'DST transition'")
+        }
+    }
+
+    // MARK: - Menu Title Tests
+
+    func testMenuTitleWithDefaults() {
+        let dataObject = TimezoneData(with: newYork)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let title = operations.menuTitle()
+        XCTAssertFalse(title.isEmpty, "Menu title should not be empty")
+    }
+
+    func testMenuTitleWithCityShown() {
+        let dataObject = TimezoneData(with: newYork)
+        mockStore.viewTypeDisplayPreferences[.placeInMenubar] = true
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let title = operations.menuTitle()
+        // When placeInMenubar is true, city name should appear
+        XCTAssertTrue(title.contains("NYC") || title.contains("New York"),
+                      "Menu title should contain city name but got: \(title)")
+    }
+
+    // MARK: - Compact Menu Title Tests
+
+    func testCompactMenuTitle() {
+        let dataObject = TimezoneData(with: tokyo)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let title = operations.compactMenuTitle()
+        XCTAssertFalse(title.isEmpty, "Compact menu title should not be empty")
+    }
+
+    func testCompactMenuSubtitle() {
+        let dataObject = TimezoneData(with: tokyo)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let subtitle = operations.compactMenuSubtitle()
+        XCTAssertFalse(subtitle.isEmpty, "Compact menu subtitle should not be empty")
+    }
+
+    // MARK: - Today's Date Tests
+
+    func testTodaysDate() {
+        let dataObject = TimezoneData(with: london)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let dateStr = operations.todaysDate(with: 0)
+        XCTAssertFalse(dateStr.isEmpty, "Today's date should not be empty")
+    }
+
+    func testTodaysDateWithLocale() {
+        let dataObject = TimezoneData(with: london)
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let germanLocale = Locale(identifier: "de_DE")
+        let dateStr = operations.todaysDate(with: 0, locale: germanLocale)
+        XCTAssertFalse(dateStr.isEmpty, "Today's date with German locale should not be empty")
+    }
+
+    // MARK: - Epoch Time Tests
+
+    func testEpochTimeFormat() {
+        let dataObject = TimezoneData(with: newYork)
+        dataObject.setShouldOverrideGlobalTimeFormat(12) // epoch
+        let operations = TimezoneDataOperations(with: dataObject, store: mockStore)
+
+        let timeString = operations.time(with: 0)
+        XCTAssertFalse(timeString.isEmpty, "Epoch time should not be empty")
+        // Epoch time should be a numeric string
+        let numericOnly = timeString.allSatisfy { $0.isNumber || $0 == "-" }
+        XCTAssertTrue(numericOnly, "Epoch time should be numeric but got: \(timeString)")
+    }
+}


### PR DESCRIPTION
Add TimezoneDataOperationsTests, MenubarTitleProviderTests, and deserialization robustness tests. Test count: 112 to 148.