### PR TITLE
Add Homebrew cask support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Meridian** (formerly Clocker) — macOS menu bar world clock app. ~11K lines of Swift across 77 files. Bundle ID: `com.tpak.Meridian`. Forked from [Clocker](https://github.com/n0shake/Clocker) by Abhishek Banthia.
 
+## Installation
+
+```bash
+brew tap tpak/tpak
+brew install --cask meridian
+```
+
+Cask definition lives in [`tpak/homebrew-tpak`](https://github.com/tpak/homebrew-tpak). Updated automatically by the release script.
+
 ## Git Workflow
 
 **Always create a feature branch before making changes.** Never commit directly to `main`. Use descriptive branch names like `fix/sunrise-bug` or `feature/accessibility-labels`. Open a PR when the work is ready for review. This applies to all work — bug fixes, features, refactors, doc updates.
@@ -61,6 +70,7 @@ The release script (`scripts/release.sh`) handles everything:
 6. Signs zip with Sparkle EdDSA key
 7. Creates GitHub release with zip attached
 8. Updates `appcast.xml` with new entry, commits, and pushes
+9. Updates Homebrew cask in `tpak/homebrew-tpak` via GitHub API
 
 **Release notes** are auto-collected from all PRs merged since the last release tag. Override with `NOTES="..."` or specify a single PR with `PR=35`. If no PRs found, opens `$EDITOR`.
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -340,11 +340,38 @@ fi
 
 echo "── Appcast updated and pushed."
 
-# ── Phase 6: Summary ────────────────────────────────────────────────
+# ── Phase 6: Update Homebrew cask ──────────────────────────────────
+
+echo "── Updating Homebrew cask..."
+ZIP_SHA256="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
+
+CASK_REPO="tpak/homebrew-tpak"
+CASK_FILE="Casks/meridian.rb"
+
+if FILE_SHA="$(gh api "repos/$CASK_REPO/contents/$CASK_FILE" --jq '.sha' 2>/dev/null)"; then
+    CASK_CONTENT="$(gh api "repos/$CASK_REPO/contents/$CASK_FILE" \
+        --jq '.content' | base64 -d \
+        | sed "s/version \".*\"/version \"$VERSION\"/" \
+        | sed "s/sha256 \".*\"/sha256 \"$ZIP_SHA256\"/")"
+
+    ENCODED="$(printf '%s' "$CASK_CONTENT" | base64)"
+
+    gh api --method PUT "repos/$CASK_REPO/contents/$CASK_FILE" \
+        -f message="Update meridian to v$VERSION" \
+        -f content="$ENCODED" \
+        -f sha="$FILE_SHA" > /dev/null
+
+    echo "── Homebrew cask updated to v$VERSION."
+else
+    echo "WARNING: Homebrew cask file not found at $CASK_REPO/$CASK_FILE. Skipping cask update."
+fi
+
+# ── Phase 7: Summary ────────────────────────────────────────────────
 
 echo ""
 echo "=== Release v$VERSION complete! ==="
 echo ""
 echo "  GitHub release: https://github.com/tpak/Meridian/releases/tag/v$VERSION"
 echo "  Appcast updated with signature and download URL"
+echo "  Homebrew cask: brew install --cask tpak/tpak/meridian"
 echo ""


### PR DESCRIPTION
## Summary
- Created `Casks/meridian.rb` in [tpak/homebrew-tpak](https://github.com/tpak/homebrew-tpak) (already pushed via GitHub API)
- Added Phase 6 to `scripts/release.sh` to auto-update the cask version and SHA256 on each release
- Updated `CLAUDE.md` with installation instructions and release step

## Install
```bash
brew tap tpak/tpak
brew install --cask meridian
```

## How it works
On `make release VERSION=X.Y.Z`, after the appcast update, the script:
1. Computes SHA256 of the release zip
2. Fetches the current cask file from `tpak/homebrew-tpak` via GitHub API
3. Updates the `version` and `sha256` fields
4. Pushes the updated cask back — no local clone needed

If the cask update fails, the release is already live; the cask can be updated manually.

## Test plan
- [ ] `brew tap tpak/tpak && brew install --cask meridian` installs Meridian.app
- [ ] Verify next release auto-updates the cask

🤖 Generated with [Claude Code](https://claude.com/claude-code)