### PR TITLE
Add keyboard shortcuts for panel

### DIFF
--- a/Meridian/MeridianUITests/ShortcutTests.swift
+++ b/Meridian/MeridianUITests/ShortcutTests.swift
@@ -49,6 +49,18 @@ class ShortcutTests: XCTestCase {
         XCTAssertFalse(app.tables["mainTableView"].exists)
     }
 
+    func testCmdW_closesPanel() {
+        XCTAssertTrue(app.tables["mainTableView"].exists)
+        app.tables["mainTableView"].typeKey("w", modifierFlags: .command)
+        XCTAssertFalse(app.tables["mainTableView"].exists)
+    }
+
+    func testCmdComma_opensSettings() {
+        XCTAssertTrue(app.tables["mainTableView"].exists)
+        app.tables["mainTableView"].typeKey(",", modifierFlags: .command)
+        XCTAssertTrue(app.windows["Meridian"].exists)
+    }
+
     private func randomLetter() -> String {
         let alphabet: [String] = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
         return alphabet[randomIndex]

--- a/Meridian/Panel/PanelContextMenu.swift
+++ b/Meridian/Panel/PanelContextMenu.swift
@@ -9,10 +9,10 @@ enum PanelContextMenu {
         let menu = NSMenu(title: "More Options")
 
         let openPreferences = NSMenuItem(title: "Settings",
-                                         action: #selector(ParentPanelController.openPreferencesWindow), keyEquivalent: "")
+                                         action: #selector(ParentPanelController.openPreferencesWindow), keyEquivalent: ",")
 
         let terminateOption = NSMenuItem(title: "Quit Meridian",
-                                         action: #selector(ParentPanelController.terminateMeridian), keyEquivalent: "")
+                                         action: #selector(ParentPanelController.terminateMeridian), keyEquivalent: "q")
 
         let appDisplayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") ?? "Meridian"
         let shortVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") ?? "N/A"

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -509,6 +509,19 @@ extension ParentPanelController {
         NSApplication.shared.terminate(nil)
     }
 
+    @objc func copyFirstTimezoneToClipboard() {
+        guard mainTableView.numberOfRows > 0,
+              let cellView = mainTableView.view(atColumn: 0, row: 0, makeIfNecessary: false) as? TimezoneCellView else {
+            return
+        }
+
+        let clipboardCopy = "\(cellView.customName.stringValue) - \(cellView.time.stringValue)"
+        let pasteboard = NSPasteboard.general
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString(clipboardCopy, forType: .string)
+        window?.contentView?.makeToast("Copied to Clipboard".localized())
+    }
+
     @objc func reportIssue() {
         guard let url = URL(string: AboutUsConstants.GitHubIssuesURL) else { return }
         NSWorkspace.shared.open(url)

--- a/Meridian/Panel/UI/CustomPanel.swift
+++ b/Meridian/Panel/UI/CustomPanel.swift
@@ -11,12 +11,39 @@ class CustomPanel: NSPanel {
         return true
     }
 
-    override func keyDown(with event: NSEvent) {
-        super.keyDown(with: event)
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        guard event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command),
+              let key = event.charactersIgnoringModifiers else {
+            return super.performKeyEquivalent(with: event)
+        }
 
-        // Escape key is pressed
+        switch key {
+        case "q":
+            NSApplication.shared.terminate(nil)
+            return true
+        case ",":
+            if let panelController = windowController as? ParentPanelController {
+                panelController.openPreferencesWindow()
+            }
+            return true
+        case "w":
+            close()
+            return true
+        case "c":
+            if let panelController = windowController as? ParentPanelController {
+                panelController.copyFirstTimezoneToClipboard()
+            }
+            return true
+        default:
+            return super.performKeyEquivalent(with: event)
+        }
+    }
+
+    override func keyDown(with event: NSEvent) {
         if event.keyCode == 53 {
             close()
+        } else {
+            super.keyDown(with: event)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add standard macOS keyboard shortcuts when the panel is open: ⌘Q (quit), ⌘, (settings), ⌘W (close panel), ⌘C (copy first timezone to clipboard)
- Show shortcut hints in the "More Options" context menu for discoverability
- Fix Escape key handling to prevent system beep

Closes #50

## Test plan
- [x] Build succeeds
- [x] SwiftLint passes (0 violations on changed files)
- [x] 151 unit tests pass
- [ ] Manual: open panel → ⌘Q quits app
- [ ] Manual: open panel → ⌘, opens Settings window
- [ ] Manual: open panel → ⌘W closes panel
- [ ] Manual: open panel → ⌘C copies first timezone to clipboard
- [ ] Manual: context menu shows ⌘, and ⌘Q hints

🤖 Generated with [Claude Code](https://claude.com/claude-code)