### PR TITLE
Fix sunrise/sunset not showing for timezone-type entries

### DIFF
--- a/Meridian/Panel/UI/TimezoneDataSource.swift
+++ b/Meridian/Panel/UI/TimezoneDataSource.swift
@@ -105,7 +105,7 @@ extension TimezoneDataSource: NSTableViewDataSource, NSTableViewDelegate {
                 rowHeight -= 5
             }
 
-            if shouldShowSunrise, model.selectionType == .city {
+            if shouldShowSunrise, model.latitude != nil, model.longitude != nil {
                 rowHeight += 8
             }
 


### PR DESCRIPTION
## Summary
- Sunrise/sunset was only displayed for timezones added via city search (`selectionType == .city`)
- Timezones added via timezone identifier (e.g. America/Denver) have `selectionType == .timezone` and were excluded, even when they had valid latitude/longitude coordinates
- Fix: check for presence of coordinates instead of selection type

One-line change in `TimezoneDataSource.swift` line 108.

## Test plan
- [ ] Manual: Denver (added via timezone identifier) now shows sunrise/sunset
- [ ] Manual: Melbourne/India (added via city search) still show sunrise/sunset
- [x] 151 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)