### PR TITLE
Backfill missing coordinates for sunrise/sunset

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -14,7 +14,41 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
     public func applicationDidFinishLaunching(_: Notification) {
         AppDefaults.initialize(with: DataStore.shared(), defaults: UserDefaults.standard)
         enableAutoUpdateByDefault()
+        backfillMissingCoordinates()
         continueUsually()
+    }
+
+    private func backfillMissingCoordinates() {
+        let store = DataStore.shared()
+        var timezones = store.timezones()
+        var indicesToBackfill: [(Int, TimezoneData)] = []
+
+        for (index, data) in timezones.enumerated() {
+            guard let timezone = TimezoneData.customObject(from: data) else { continue }
+            if timezone.latitude == nil || timezone.longitude == nil,
+               let timezoneID = timezone.timezoneID, !timezoneID.isEmpty {
+                indicesToBackfill.append((index, timezone))
+            }
+        }
+
+        guard !indicesToBackfill.isEmpty else { return }
+
+        Task { @MainActor in
+            for (index, timezone) in indicesToBackfill {
+                let components = (timezone.timezoneID ?? "").split(separator: "/")
+                guard let cityComponent = components.last else { continue }
+                let cityName = cityComponent.replacingOccurrences(of: "_", with: " ")
+                if let placemark = try? await NetworkManager.geocodeAddress(cityName),
+                   let location = placemark.location {
+                    timezone.latitude = location.coordinate.latitude
+                    timezone.longitude = location.coordinate.longitude
+                    if let encoded = NSKeyedArchiver.secureArchive(with: timezone) {
+                        timezones[index] = encoded
+                    }
+                }
+            }
+            store.setTimezones(timezones)
+        }
     }
 
     private func enableAutoUpdateByDefault() {


### PR DESCRIPTION
## Summary
- Fixes Denver (and any other timezone-identifier entry) not showing sunrise/sunset
- Root cause: geocoding can fail silently when a timezone is added via identifier, leaving coordinates permanently nil
- On each app launch, any timezone with missing coordinates is now geocoded from the city name in its timezone ID (e.g. "Denver" from "America/Denver") and the result is persisted
- Works together with #53 (row height fix) to fully resolve the issue

## Test plan
- [ ] Manual: launch app with Denver timezone that has nil coordinates — sunrise/sunset should appear after launch
- [ ] Manual: Melbourne and India continue showing sunrise/sunset
- [x] 151 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)