### PR TITLE
Fix copy-paste bug, remove force unwraps, add input validation

### DIFF
--- a/Meridian/Overall App/TimezoneSearchService.swift
+++ b/Meridian/Overall App/TimezoneSearchService.swift
@@ -26,6 +26,10 @@ enum TimezoneSearchService {
             throw SearchError.queryTooShort
         }
 
+        guard compactSearch.count <= 200 else {
+            throw SearchError.queryTooLong
+        }
+
         do {
             let geocoder = CLGeocoder()
             let placemarks = try await geocoder.geocodeAddressString(compactSearch)
@@ -65,6 +69,7 @@ enum TimezoneSearchService {
     /// Errors that can occur during timezone search operations.
     enum SearchError: LocalizedError {
         case queryTooShort
+        case queryTooLong
         case offline
         case network(String)
         case zeroResults
@@ -72,6 +77,7 @@ enum TimezoneSearchService {
         var errorDescription: String? {
             switch self {
             case .queryTooShort: return "Search query too short"
+            case .queryTooLong: return "Search query too long"
             case .offline: return PreferencesConstants.noInternetConnectivityError
             case .network(let message): return message
             case .zeroResults: return "No results! Try entering the exact name."

--- a/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
+++ b/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
@@ -290,7 +290,10 @@ extension TimezoneDataOperations {
     // Exposed to public for tests!
     public func timeDifference() -> String {
         let localFormatter = DateFormatterManager.localizedSimpleFormatter("d MMM yyyy HH:mm:ss")
-        let local = localFormatter.date(from: localeDate(with: "d MMM yyyy HH:mm:ss"))!
+        guard let local = localFormatter.date(from: localeDate(with: "d MMM yyyy HH:mm:ss")) else {
+            Logger.log(object: [:], for: "Date conversion failure - local date is nil")
+            return UserDefaultKeys.emptyString
+        }
         let newDate = timezoneDateByAdding(minutesToAdd: 0, TimezoneDataOperations.gregorianCalendar)
 
         let dateFormatter = DateFormatterManager.localizedFormatter(with: "d MMM yyyy HH:mm:ss", for: dataObject.timezone())
@@ -375,7 +378,7 @@ extension TimezoneDataOperations {
         // if timeAgo < 24h => compare DateTime else compare Date only
         let upToHours: Set<Calendar.Component> = [.second, .minute, .hour]
         let difference = calendar.dateComponents(upToHours, from: earliest, to: latest as Date)
-        return difference.minute!
+        return difference.minute ?? 0
     }
 
     func formattedSunriseTime(with sliderValue: Int) -> String {

--- a/Meridian/Panel/PanelController.swift
+++ b/Meridian/Panel/PanelController.swift
@@ -134,10 +134,12 @@ class PanelController: ParentPanelController {
                 break
             }
 
-            let screenMaxX = (statusItemScreen?.frame)!.maxX
-            let minY = statusItemFrame.origin.y < (statusItemScreen?.frame)!.maxY ?
+            guard let resolvedScreen = statusItemScreen else { return }
+
+            let screenMaxX = resolvedScreen.frame.maxX
+            let minY = statusItemFrame.origin.y < resolvedScreen.frame.maxY ?
             statusItemFrame.origin.y :
-            (statusItemScreen?.frame)!.maxY
+            resolvedScreen.frame.maxY
             statusItemFrame.origin.y = minY
 
             setFrameTheNewWay(statusItemFrame, screenMaxX)
@@ -151,7 +153,7 @@ class PanelController: ParentPanelController {
         let preferences = dataStore.timezones()
 
         guard let theme = dataStore.retrieve(key: UserDefaultKeys.themeKey) as? NSNumber,
-              let displayFutureSliderKey = dataStore.retrieve(key: UserDefaultKeys.themeKey) as? NSNumber,
+              let displayFutureSliderKey = dataStore.retrieve(key: UserDefaultKeys.displayFutureSliderKey) as? NSNumber,
               let showAppInForeground = dataStore.retrieve(key: UserDefaultKeys.showAppInForeground) as? NSNumber,
               let relativeDateKey = dataStore.retrieve(key: UserDefaultKeys.relativeDateKey) as? NSNumber,
               let fontSize = dataStore.retrieve(key: UserDefaultKeys.userFontSizePreference) as? NSNumber,

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -103,7 +103,7 @@ class ParentPanelController: NSWindowController {
         mainTableView.style = .plain
 
         // Setup settings button
-        settingsButton.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")!
+        settingsButton.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")
 
         // Setup KVO observers for user default changes
         setupObservers()
@@ -342,7 +342,7 @@ class ParentPanelController: NSWindowController {
 
         var correctRow = row
 
-        target.image = NSImage(systemSymbolName: "ellipsis.circle.fill", accessibilityDescription: "Options")!
+        target.image = NSImage(systemSymbolName: "ellipsis.circle.fill", accessibilityDescription: "Options")
 
         popover.animates = true
 
@@ -474,8 +474,8 @@ extension ParentPanelController {
 
                 cellView.currentLocationIndicator.isHidden = !model.isSystemTimezone
                 cellView.sunriseImage.image = model.isSunriseOrSunset
-                    ? NSImage(systemSymbolName: "sunrise.fill", accessibilityDescription: "Sunrise")!
-                    : NSImage(systemSymbolName: "sunset.fill", accessibilityDescription: "Sunset")!
+                    ? NSImage(systemSymbolName: "sunrise.fill", accessibilityDescription: "Sunrise")
+                    : NSImage(systemSymbolName: "sunset.fill", accessibilityDescription: "Sunset")
                 cellView.sunriseImage.contentTintColor = model.isSunriseOrSunset ? NSColor.systemYellow : NSColor.systemOrange
                 if let note = model.note, !note.isEmpty {
                     cellView.noteLabel.stringValue = note


### PR DESCRIPTION
## Summary
- Fix wrong UserDefaults key in `PanelController.log()` — `themeKey` was read twice instead of `displayFutureSliderKey`, so the future slider preference was never logged correctly
- Replace force unwraps on optional screen frame with safe guard-let (prevents crash if screen is nil)
- Replace force unwrap on date parsing with guard-let and early return
- Replace force unwrap on calendar component with nil-coalescing (`?? 0`)
- Remove unnecessary `!` on `NSImage(systemSymbolName:)` calls (`.image` accepts optionals)
- Add max length validation (200 chars) on timezone search input before passing to CLGeocoder

## Test plan
- [x] Build succeeds
- [x] SwiftLint: 0 violations on changed files
- [x] 151 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)