### PR TITLE
Add production observability logging and debug toggle

### DIFF
--- a/Meridian/App/LocationController.swift
+++ b/Meridian/App/LocationController.swift
@@ -111,6 +111,6 @@ extension LocationController: CLLocationManagerDelegate {
     }
 
     func locationManager(_: CLLocationManager, didFailWithError error: Error) {
-        Logger.info(error.localizedDescription)
+        Logger.production("Location error: \(error.localizedDescription)")
     }
 }

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -10,13 +10,77 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
     internal lazy var panelController = PanelController(windowNibName: .panel)
     private var statusBarHandler: StatusItemHandler!
     let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+    private var memoryPressureSource: DispatchSourceMemoryPressure?
 
     public func applicationDidFinishLaunching(_: Notification) {
         AppDefaults.initialize(with: DataStore.shared(), defaults: UserDefaults.standard)
+        logLaunch()
+        checkForPreviousUncleanExit()
+        writeSentinelFile()
         enableAutoUpdateByDefault()
         backfillMissingCoordinates()
         continueUsually()
+        setupMemoryPressureMonitoring()
     }
+
+    public func applicationWillTerminate(_: Notification) {
+        Logger.production("App terminating cleanly")
+        removeSentinelFile()
+    }
+
+    // MARK: - Lifecycle Logging
+
+    private func logLaunch() {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "?"
+        let osVersion = ProcessInfo.processInfo.operatingSystemVersionString
+        let tzCount = DataStore.shared().timezones().count
+        Logger.production("App launched v\(version)(\(build)) on macOS \(osVersion), \(tzCount) timezones")
+    }
+
+    // MARK: - Crash Sentinel
+
+    private var sentinelURL: URL? {
+        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first?
+            .appendingPathComponent("Meridian")
+            .appendingPathComponent(".running")
+    }
+
+    private func writeSentinelFile() {
+        guard let url = sentinelURL else { return }
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                  withIntermediateDirectories: true)
+        try? Date().ISO8601Format().write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private func removeSentinelFile() {
+        guard let url = sentinelURL else { return }
+        try? FileManager.default.removeItem(at: url)
+    }
+
+    private func checkForPreviousUncleanExit() {
+        guard let url = sentinelURL,
+              FileManager.default.fileExists(atPath: url.path) else { return }
+        let timestamp = (try? String(contentsOf: url, encoding: .utf8)) ?? "unknown"
+        Logger.production("Previous session exited uncleanly (launched at \(timestamp))")
+    }
+
+    // MARK: - Memory Pressure
+
+    private func setupMemoryPressureMonitoring() {
+        memoryPressureSource = DispatchSource.makeMemoryPressureSource(eventMask: [.warning, .critical], queue: .main)
+        memoryPressureSource?.setEventHandler { [weak self] in
+            let level = self?.memoryPressureSource?.data ?? []
+            if level.contains(.critical) {
+                Logger.production("Memory pressure: CRITICAL")
+            } else if level.contains(.warning) {
+                Logger.production("Memory pressure: WARNING")
+            }
+        }
+        memoryPressureSource?.resume()
+    }
+
+    // MARK: - Backfill Coordinates
 
     private func backfillMissingCoordinates() {
         let store = DataStore.shared()
@@ -51,6 +115,8 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
 
+    // MARK: - Auto-Update Default
+
     private func enableAutoUpdateByDefault() {
         let hasSetAutoUpdate = "HasSetAutoUpdateDefault"
         guard !UserDefaults.standard.bool(forKey: hasSetAutoUpdate) else { return }
@@ -58,6 +124,8 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
         updaterController.updater.automaticallyChecksForUpdates = true
         updaterController.updater.automaticallyDownloadsUpdates = true
     }
+
+    // MARK: - Dock Menu
 
     public func applicationDockMenu(_: NSApplication) -> NSMenu? {
         let menu = NSMenu(title: "Quick Access")
@@ -136,7 +204,7 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @IBAction open func togglePanel(_ sender: NSButton) {
-        Logger.info("Toggle Panel called with sender state \(sender.state.rawValue)")
+        Logger.debug("Toggle Panel called with sender state \(sender.state.rawValue)")
         panelController.showWindow(nil)
         panelController.setActivePanel(newValue: sender.state == .on)
         NSApp.activate(ignoringOtherApps: true)

--- a/Meridian/CoreLoggerKit/Sources/CoreLoggerKit/Logger.swift
+++ b/Meridian/CoreLoggerKit/Sources/CoreLoggerKit/Logger.swift
@@ -2,19 +2,37 @@
 
 import Cocoa
 import os
-public class Logger: NSObject {
-    let logObjc = OSLog(subsystem: "com.tpak.Meridian", category: "app")
+import OSLog
 
-    public class func log(object annotations: [String: Any]?, for event: NSString) {
-        #if DEBUG
-            os_log(.default, "[%@] - [%@]", event, annotations ?? [:])
-        #endif
+public enum Logger {
+    private static let lifecycle = OSLog(subsystem: "com.tpak.Meridian", category: "lifecycle")
+    private static let debugLog = OSLog(subsystem: "com.tpak.Meridian", category: "debug")
+
+    /// Always-on logging for critical lifecycle events. Visible in Console.app.
+    public static func production(_ message: String) {
+        os_log(.default, log: lifecycle, "%{public}@", message)
     }
 
-    public class func info(_ message: String) {
-        #if DEBUG
-            os_log(.info, "%@", message)
-        #endif
+    /// Opt-in verbose logging for debugging. Visible in Console.app when enabled.
+    public static func debug(_ message: String) {
+        guard debugLoggingEnabled else { return }
+        os_log(.default, log: debugLog, "%{public}@", message)
+    }
+
+    public static var debugLoggingEnabled: Bool {
+        UserDefaults.standard.bool(forKey: "com.tpak.meridian.debugLoggingEnabled")
+    }
+
+    /// Export recent log entries to a file for sharing. Uses OSLogStore.
+    public static func exportLog(to url: URL) throws {
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
+        let cutoff = store.position(date: Date().addingTimeInterval(-7 * 24 * 3600))
+        let entries = try store.getEntries(at: cutoff, matching: NSPredicate(format: "subsystem == 'com.tpak.Meridian'"))
+        let lines = entries.compactMap { entry -> String? in
+            guard let logEntry = entry as? OSLogEntryLog else { return nil }
+            return "[\(logEntry.date.ISO8601Format())] [\(logEntry.category)] \(logEntry.composedMessage)"
+        }
+        try lines.joined(separator: "\n").write(to: url, atomically: true, encoding: .utf8)
     }
 }
 

--- a/Meridian/CoreLoggerKit/Tests/CoreLoggerKitTests/CoreLoggerKitTests.swift
+++ b/Meridian/CoreLoggerKit/Tests/CoreLoggerKitTests/CoreLoggerKitTests.swift
@@ -8,98 +8,79 @@ import XCTest
 
 final class LoggerTests: XCTestCase {
 
-    // MARK: log(object:for:)
+    // MARK: production(_:)
 
-    func testLogWithAnnotationsAndEvent() {
-        let annotations: [String: Any] = ["key": "value", "count": 42]
-        Logger.log(object: annotations, for: "TestEvent")
+    func testProductionWithSimpleMessage() {
+        Logger.production("Simple production message")
     }
 
-    func testLogWithNilAnnotations() {
-        Logger.log(object: nil, for: "TestEventNilAnnotations")
+    func testProductionWithEmptyMessage() {
+        Logger.production("")
     }
 
-    func testLogWithEmptyAnnotations() {
-        Logger.log(object: [:], for: "TestEventEmptyAnnotations")
+    func testProductionWithSpecialCharacters() {
+        Logger.production("Special chars: %@ %d %f \n\t\\")
     }
 
-    func testLogWithEmptyEventString() {
-        Logger.log(object: ["key": "value"], for: "")
+    func testProductionWithUnicode() {
+        Logger.production("Unicode: \u{1F600}\u{1F680}\u{2603}")
     }
 
-    func testLogWithLargeAnnotations() {
-        var annotations: [String: Any] = [:]
-        for i in 0..<100 {
-            annotations["key_\(i)"] = "value_\(i)"
-        }
-        Logger.log(object: annotations, for: "LargeAnnotationsEvent")
+    // MARK: debug(_:)
+
+    func testDebugWithSimpleMessage() {
+        Logger.debug("Simple debug message")
     }
 
-    func testLogWithNestedAnnotations() {
-        let annotations: [String: Any] = [
-            "nested": ["inner": "value"],
-            "array": [1, 2, 3],
-            "bool": true,
-            "nil_val": NSNull()
-        ]
-        Logger.log(object: annotations, for: "NestedEvent")
+    func testDebugWithEmptyMessage() {
+        Logger.debug("")
     }
 
-    func testLogWithSpecialCharactersInEvent() {
-        Logger.log(object: nil, for: "Event with spaces & special chars: %@ %d \n\t")
+    func testDebugRespectsEnabledFlag() {
+        // When disabled (default), should not crash
+        UserDefaults.standard.set(false, forKey: "com.tpak.meridian.debugLoggingEnabled")
+        Logger.debug("Should be skipped")
+
+        // When enabled, should not crash
+        UserDefaults.standard.set(true, forKey: "com.tpak.meridian.debugLoggingEnabled")
+        Logger.debug("Should be logged")
+
+        // Reset
+        UserDefaults.standard.removeObject(forKey: "com.tpak.meridian.debugLoggingEnabled")
     }
 
-    func testLogWithUnicodeEvent() {
-        Logger.log(object: ["emoji": "test"], for: "Unicode: \u{1F600}\u{1F680}")
-    }
-
-    // MARK: info(_:)
-
-    func testInfoWithSimpleMessage() {
-        Logger.info("Simple info message")
-    }
-
-    func testInfoWithEmptyMessage() {
-        Logger.info("")
-    }
-
-    func testInfoWithLongMessage() {
-        let longMessage = String(repeating: "a", count: 10_000)
-        Logger.info(longMessage)
-    }
-
-    func testInfoWithSpecialCharacters() {
-        Logger.info("Special chars: %@ %d %f \n\t\\")
-    }
-
-    func testInfoWithUnicode() {
-        Logger.info("Unicode: \u{1F600}\u{1F680}\u{2603}")
-    }
-
-    func testInfoWithNewlines() {
-        Logger.info("Line 1\nLine 2\nLine 3")
+    func testDebugLoggingEnabledDefaultsToFalse() {
+        UserDefaults.standard.removeObject(forKey: "com.tpak.meridian.debugLoggingEnabled")
+        XCTAssertFalse(Logger.debugLoggingEnabled)
     }
 
     // MARK: Rapid successive calls
 
-    func testRapidLogCalls() {
+    func testRapidProductionCalls() {
         for i in 0..<50 {
-            Logger.log(object: ["iteration": i], for: "RapidEvent" as NSString)
+            Logger.production("Rapid production message \(i)")
         }
     }
 
-    func testRapidInfoCalls() {
+    func testRapidDebugCalls() {
+        UserDefaults.standard.set(true, forKey: "com.tpak.meridian.debugLoggingEnabled")
         for i in 0..<50 {
-            Logger.info("Rapid info message \(i)")
+            Logger.debug("Rapid debug message \(i)")
         }
+        UserDefaults.standard.removeObject(forKey: "com.tpak.meridian.debugLoggingEnabled")
     }
 
-    // MARK: Logger instance
+    // MARK: exportLog
 
-    func testLoggerIsNSObjectSubclass() {
-        let logger = CoreLoggerKit.Logger()
-        XCTAssertNotNil(logger)
-        XCTAssertTrue(logger is NSObject)
+    func testExportLogToFile() throws {
+        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent("test-meridian-log.txt")
+        defer { try? FileManager.default.removeItem(at: tempURL) }
+
+        // Should not throw
+        try Logger.exportLog(to: tempURL)
+
+        // File should exist
+        XCTAssertTrue(FileManager.default.fileExists(atPath: tempURL.path))
     }
 }
 
@@ -132,12 +113,6 @@ final class PerfLoggerTests: XCTestCase {
         // After disabling, signpost calls should still not crash
         PerfLogger.startMarker("AfterDisable")
         PerfLogger.endMarker("AfterDisable")
-    }
-
-    func testPerfLoggerIsNSObjectSubclass() {
-        let perfLogger = PerfLogger()
-        XCTAssertNotNil(perfLogger)
-        XCTAssertTrue(perfLogger is NSObject)
     }
 
     func testSignpostIDIsStable() {

--- a/Meridian/CoreModelKit/Sources/CoreModelKit/TimezoneData.swift
+++ b/Meridian/CoreModelKit/Sources/CoreModelKit/TimezoneData.swift
@@ -214,7 +214,7 @@ public class TimezoneData: NSObject, NSCoding, NSSecureCoding {
         } else if shouldOverride == 12 {
             overrideFormat = .epochTime
         } else {
-            Logger.info("Chosen a wrong timezone format: \(shouldOverride)")
+            Logger.debug("Chosen a wrong timezone format: \(shouldOverride)")
         }
     }
 

--- a/Meridian/Overall App/DataStore.swift
+++ b/Meridian/Overall App/DataStore.swift
@@ -107,7 +107,7 @@ class DataStore: NSObject, DataStoring {
 
         currentLineup.removeLast()
 
-        Logger.log(object: [:], for: "Undo Action Executed")
+        Logger.debug("Undo Action Executed")
 
         setTimezones(currentLineup)
     }

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -31,4 +31,5 @@ public enum UserDefaultKeys {
     static let installHomeIndicatorObject = "installHomeIndicatorObject"
     static let switchToCompactModeAlert = "com.tpak.meridian.switchToCompactMode"
     static let appleInterfaceStyleKey = "AppleInterfaceStyle"
+    static let debugLoggingEnabled = "com.tpak.meridian.debugLoggingEnabled"
 }

--- a/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
+++ b/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
@@ -214,7 +214,7 @@ extension TimezoneDataOperations {
 
     func date(with sliderValue: Int, displayType: TimezoneData.DateDisplayType) -> String {
         guard let relativeDayPreference = store.retrieve(key: UserDefaultKeys.relativeDateKey) as? NSNumber else {
-            Logger.info("Data was unexpectedly nil")
+            Logger.production("Data was unexpectedly nil for relative day preference")
             return UserDefaultKeys.emptyString
         }
 
@@ -260,11 +260,7 @@ extension TimezoneDataOperations {
                 return "\(todaysDate(with: sliderValue))\(timeDifference())"
             }
 
-            let errorDictionary: [String: Any] = ["Timezone": dataObject.timezone(),
-                                                  "Current Locale": Locale.autoupdatingCurrent.identifier,
-                                                  "Slider Value": sliderValue,
-                                                  "Today's Date": Date()]
-            Logger.log(object: errorDictionary, for: "Unable to get date")
+            Logger.production("Unable to get date: Timezone=\(dataObject.timezone()), CurrentLocale=\(Locale.autoupdatingCurrent.identifier), SliderValue=\(sliderValue), TodaysDate=\(Date())")
 
             return "Error"
 
@@ -296,12 +292,7 @@ extension TimezoneDataOperations {
         let dateFormatter = DateFormatterManager.localizedFormatter(with: "d MMM yyyy HH:mm:ss", for: dataObject.timezone())
 
         guard let timezoneDate = localFormatter.date(from: dateFormatter.string(from: newDate)) else {
-            let unableToConvertDateParameters = [
-                "New Date": newDate,
-                "Timezone": dataObject.timezone(),
-                "Locale": dateFormatter.locale.identifier
-            ] as [String: Any]
-            Logger.log(object: unableToConvertDateParameters, for: "Date conversion failure - New Date is nil")
+            Logger.production("Date conversion failure - New Date is nil: NewDate=\(newDate), Timezone=\(dataObject.timezone()), Locale=\(dateFormatter.locale.identifier)")
             return UserDefaultKeys.emptyString
         }
 
@@ -349,7 +340,7 @@ extension TimezoneDataOperations {
         guard let lat = dataObject.latitude,
               let long = dataObject.longitude
         else {
-            Logger.info("Data was unexpectedly nil")
+            Logger.production("Sunrise/sunset coordinates unexpectedly nil")
             return
         }
 
@@ -364,7 +355,7 @@ extension TimezoneDataOperations {
             dataObject.sunsetTime = sunset
             dataObject.isSunriseOrSunset = solar.isNighttime
         } else {
-            Logger.log(object: ["Unable to fetch sunrise/sunset": dataObject.formattedTimezoneLabel()], for: "Sunrise/Sunset Error")
+            Logger.production("Sunrise/Sunset Error: Unable to fetch sunrise/sunset for \(dataObject.formattedTimezoneLabel())")
         }
     }
 

--- a/Meridian/Panel/Modern Slider/ModernSliderViews.swift
+++ b/Meridian/Panel/Modern Slider/ModernSliderViews.swift
@@ -68,7 +68,7 @@ class DraggableClipView: NSClipView {
                 clickPoint = nil
                 gestureInProgress = false
             default:
-                Logger.info("Default mouse event occurred for \(event.type)")
+                Logger.debug("Default mouse event occurred for \(event.type)")
             }
         }
     }

--- a/Meridian/Panel/PanelController.swift
+++ b/Meridian/Panel/PanelController.swift
@@ -186,7 +186,7 @@ class PanelController: ParentPanelController {
             "Number of Timezones": preferences.count
         ]
 
-        Logger.log(object: panelEvent, for: "openedPanel")
+        Logger.debug("openedPanel: \(panelEvent)")
 
         PerfLogger.endMarker("Logging")
     }
@@ -210,7 +210,7 @@ class PanelController: ParentPanelController {
     }
 
     private func startTimer() {
-        Logger.info("Start timer called")
+        Logger.debug("Start timer called")
 
         parentTimer = Repeater(interval: .seconds(1), mode: .infinite) { _ in
             OperationQueue.main.addOperation {
@@ -225,7 +225,7 @@ class PanelController: ParentPanelController {
 
         if count >= 1 {
             if let delegate = NSApplication.shared.delegate as? AppDelegate {
-                Logger.info("We will be invalidating the menubar timer as we want the parent timer to take care of both panel and menubar ")
+                Logger.debug("We will be invalidating the menubar timer as we want the parent timer to take care of both panel and menubar ")
 
                 delegate.invalidateMenubarTimer(false)
             }
@@ -339,7 +339,7 @@ class PanelController: ParentPanelController {
 
     override func scrollWheel(with event: NSEvent) {
         if event.phase == NSEvent.Phase.ended {
-            Logger.log(object: nil, for: "Scroll Event Ended")
+            Logger.debug("Scroll Event Ended")
         }
 
         // We only want to move the slider if the slider is visible.

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -78,7 +78,7 @@ class ParentPanelController: NSWindowController {
         UserDefaults.standard.publisher(for: \.userFontSize)
             .receive(on: RunLoop.main)
             .sink { [weak self] newFontSize in
-                Logger.log(object: ["FontSize": newFontSize], for: "User Font Size Preference")
+                Logger.debug("User Font Size Preference: \(newFontSize)")
                 self?.mainTableView.reloadData()
                 self?.setScrollViewConstraint()
             }
@@ -336,7 +336,7 @@ class ParentPanelController: NSWindowController {
         let defaults = dataStore.timezones()
 
         guard let popover = additionalOptionsPopover else {
-            Logger.info("Data was unexpectedly nil")
+            Logger.debug("Data was unexpectedly nil")
             return false
         }
 
@@ -422,7 +422,7 @@ extension ParentPanelController {
                                         object: nil)
 
         // Now log!
-        Logger.log(object: nil, for: "Deleted Timezone Through Swipe")
+        Logger.debug("Deleted Timezone Through Swipe")
     }
 
     private func updateMenubarDisplay() {
@@ -528,7 +528,7 @@ extension ParentPanelController {
 
         if let countryCode = Locale.autoupdatingCurrent.region?.identifier {
             let custom: [String: Any] = ["Country": countryCode]
-            Logger.log(object: custom, for: "Report Issue Opened")
+            Logger.debug("Report Issue Opened: \(custom)")
         }
     }
 

--- a/Meridian/Panel/UI/PanelTableView.swift
+++ b/Meridian/Panel/UI/PanelTableView.swift
@@ -92,7 +92,7 @@ class PanelTableView: NSTableView {
 
     private func evaluateForHighlight(at point: NSPoint) {
         if enableHover == false {
-            Logger.info("Unable to show hover button because window is occluded!")
+            Logger.debug("Unable to show hover button because window is occluded!")
             return
         }
 

--- a/Meridian/Panel/UI/TimezoneCellView.swift
+++ b/Meridian/Panel/UI/TimezoneCellView.swift
@@ -47,7 +47,7 @@ class TimezoneCellView: NSTableCellView {
         guard let relativeFont = relativeDate.font,
               let sunriseFont = sunriseSetTime.font
         else {
-            Logger.info("Unable to convert to NSString")
+            Logger.debug("Unable to convert to NSString")
             return
         }
 
@@ -130,14 +130,14 @@ class TimezoneCellView: NSTableCellView {
 
     private func setupTextSize() {
         guard let userFontSize = DataStore.shared().retrieve(key: UserDefaultKeys.userFontSizePreference) as? NSNumber else {
-            Logger.info("User Font Size is in unexpected format")
+            Logger.debug("User Font Size is in unexpected format")
             return
         }
 
         guard let customFont = customName.font,
               let timeFont = time.font
         else {
-            Logger.info("User Font Size is unexpectedly nil")
+            Logger.debug("User Font Size is unexpectedly nil")
             return
         }
 
@@ -179,7 +179,7 @@ class TimezoneCellView: NSTableCellView {
                                                     relativeTo: bounds,
                                                     andButton: sender)
 
-        Logger.log(object: nil, for: "Open Extra Options")
+        Logger.debug("Open Extra Options")
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -199,6 +199,6 @@ class TimezoneCellView: NSTableCellView {
     override func rightMouseDown(with event: NSEvent) {
         super.rightMouseDown(with: event)
         showExtraOptions(extraOptions)
-        Logger.log(object: nil, for: "Right Click Open Options")
+        Logger.debug("Right Click Open Options")
     }
 }

--- a/Meridian/Panel/UI/TimezoneDataSource.swift
+++ b/Meridian/Panel/UI/TimezoneDataSource.swift
@@ -45,13 +45,13 @@ extension TimezoneDataSource: NSTableViewDataSource, NSTableViewDelegate {
                 return addCellView
             }
 
-            Logger.info("Unable to create AddTableViewCell")
+            Logger.debug("Unable to create AddTableViewCell")
             return nil
         }
 
         let cellID = NSUserInterfaceItemIdentifier(rawValue: "timeZoneCell")
         guard let cellView = tableView.makeView(withIdentifier: cellID, owner: self) as? TimezoneCellView else {
-            Logger.info("Unable to create tableviewcell")
+            Logger.debug("Unable to create tableviewcell")
             return NSView()
         }
 

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -63,6 +63,11 @@ struct AboutView: View {
 
             AutoUpdateToggle()
 
+            Divider()
+                .padding(.horizontal, 20)
+
+            DebugLoggingSection()
+
             HStack(spacing: 8) {
                 Text(String(localized: "Check for Updates"))
                     .font(.custom("Avenir-Light", size: 13))
@@ -113,7 +118,7 @@ struct AboutView: View {
     private func openURL(_ urlString: String, logEvent: String, metadata: [String: Any]) {
         guard let url = URL(string: urlString) else { return }
         NSWorkspace.shared.open(url)
-        Logger.log(object: metadata, for: logEvent as NSString)
+        Logger.debug("\(logEvent): \(metadata)")
     }
 }
 
@@ -171,6 +176,32 @@ private struct UpdateCheckControls: View {
             appDelegate.updaterController.checkForUpdates(nil)
         }
         .font(.custom("Avenir-Light", size: 12))
+    }
+}
+
+private struct DebugLoggingSection: View {
+    @AppStorage(UserDefaultKeys.debugLoggingEnabled) private var debugLogging = false
+
+    var body: some View {
+        Toggle(String(localized: "Enable Debug Logging"), isOn: $debugLogging)
+            .font(.custom("Avenir-Book", size: 13))
+            .toggleStyle(.checkbox)
+            .accessibilityIdentifier("DebugLogging")
+
+        if debugLogging {
+            Button(String(localized: "Export Log")) {
+                let panel = NSSavePanel()
+                panel.nameFieldStringValue = "meridian-log.txt"
+                panel.allowedContentTypes = [.plainText]
+                guard panel.runModal() == .OK, let url = panel.url else { return }
+                do {
+                    try Logger.exportLog(to: url)
+                } catch {
+                    Logger.production("Failed to export log: \(error.localizedDescription)")
+                }
+            }
+            .font(.custom("Avenir-Light", size: 12))
+        }
     }
 }
 

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -168,7 +168,7 @@ class AppearanceViewController: ParentViewController {
 
         if let selectedFormat = sender.selectedItem?.title,
            selectedFormat.contains("ss") {
-            Logger.info("Selected format contains timezone format")
+            Logger.debug("Selected format contains timezone format")
             guard let panelController = PanelController.panel() else { return }
             panelController.pauseTimer()
         }
@@ -197,13 +197,13 @@ class AppearanceViewController: ParentViewController {
 
         switch selectedMenuItem {
         case 0:
-            Logger.log(object: ["themeSelected": "Light"], for: "Theme")
+            Logger.debug("Theme: themeSelected=Light")
         case 1:
-            Logger.log(object: ["themeSelected": "Dark"], for: "Theme")
+            Logger.debug("Theme: themeSelected=Dark")
         case 2:
-            Logger.log(object: ["themeSelected": "System"], for: "Theme")
+            Logger.debug("Theme: themeSelected=System")
         default:
-            Logger.log(object: ["themeSelected": "System"], for: "Theme")
+            Logger.debug("Theme: themeSelected=System")
         }
     }
 
@@ -223,7 +223,7 @@ class AppearanceViewController: ParentViewController {
     }
 
     @IBAction func changeRelativeDayDisplay(_ sender: NSSegmentedControl) {
-        Logger.log(object: ["dayPreference": loggingStringForRelativeDisplaySelection(sender.selectedSegment)], for: "RelativeDate")
+        Logger.debug("RelativeDate: dayPreference=\(loggingStringForRelativeDisplaySelection(sender.selectedSegment))")
 
         refresh(panel: true)
 
@@ -235,17 +235,17 @@ class AppearanceViewController: ParentViewController {
     }
 
     @IBAction func showSunriseSunset(_ sender: NSSegmentedControl) {
-        Logger.log(object: ["Is It Displayed": sender.selectedSegment == 0 ? "YES" : "NO"], for: "Sunrise Sunset")
+        Logger.debug("Sunrise Sunset: IsItDisplayed=\(sender.selectedSegment == 0 ? "YES" : "NO")")
         refresh(panel: true)
         previewPanelTableView.reloadData()
     }
 
     @IBAction func changeAppDisplayOptions(_ sender: NSSegmentedControl) {
         if sender.selectedSegment == 0 {
-            Logger.log(object: ["Selection": "Menubar"], for: "Dock Mode")
+            Logger.debug("Dock Mode: Selection=Menubar")
             NSApp.setActivationPolicy(.accessory)
         } else {
-            Logger.log(object: ["Selection": "Menubar and Dock"], for: "Dock Mode")
+            Logger.debug("Dock Mode: Selection=Menubar and Dock")
             NSApp.setActivationPolicy(.regular)
         }
     }
@@ -297,9 +297,9 @@ class AppearanceViewController: ParentViewController {
         statusItem.setupStatusItem()
 
         if sender.selectedSegment == 0 {
-            Logger.log(object: ["Context": "In Appearance View"], for: "Switched to Compact Mode")
+            Logger.debug("Switched to Compact Mode: Context=In Appearance View")
         } else {
-            Logger.log(object: ["Context": "In Appearance View"], for: "Switched to Standard Mode")
+            Logger.debug("Switched to Standard Mode: Context=In Appearance View")
         }
     }
 
@@ -330,7 +330,7 @@ extension AppearanceViewController: NSTableViewDataSource, NSTableViewDelegate {
 
         let cellID = NSUserInterfaceItemIdentifier(rawValue: "previewTimezoneCell")
         guard let cellView = tableView.makeView(withIdentifier: cellID, owner: self) as? TimezoneCellView else {
-            Logger.info("Unable to create tableviewcell")
+            Logger.debug("Unable to create tableviewcell")
             return NSView()
         }
 

--- a/Meridian/Preferences/General/PreferencesDataSource.swift
+++ b/Meridian/Preferences/General/PreferencesDataSource.swift
@@ -62,12 +62,12 @@ extension PreferencesDataSource: NSTableViewDelegate {
         let pBoard = info.draggingPasteboard
 
         guard let data = pBoard.data(forType: .dragSession) else {
-            Logger.info("Data was unexpectedly nil")
+            Logger.debug("Data was unexpectedly nil")
             return false
         }
 
         guard let rowIndexes = try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSIndexSet.self, from: data) else {
-            Logger.info("Row was unexpectedly nil")
+            Logger.debug("Row was unexpectedly nil")
             return false
         }
 
@@ -165,11 +165,7 @@ extension PreferencesDataSource: NSTableViewDataSource {
         let formattedValue = label.trimmingCharacters(in: NSCharacterSet.whitespacesAndNewlines)
 
         if selectedTimezones.count > row {
-            Logger.log(object: [
-                "Old Label": dataObject.customLabel ?? "Error",
-                "New Label": formattedValue
-            ],
-            for: "Custom Label Changed")
+            Logger.debug("Custom Label Changed: OldLabel=\(dataObject.customLabel ?? "Error"), NewLabel=\(formattedValue)")
 
             dataObject.setLabel(formattedValue)
 
@@ -177,12 +173,7 @@ extension PreferencesDataSource: NSTableViewDataSource {
 
             updateMenubarTitles()
         } else {
-            Logger.log(object: [
-                "MethodName": "SetObjectValue",
-                "Selected Timezone Count": selectedTimezones.count,
-                "Current Row": row
-            ],
-            for: "Error in selected row count")
+            Logger.debug("Error in selected row count: MethodName=SetObjectValue, SelectedTimezoneCount=\(selectedTimezones.count), CurrentRow=\(row)")
         }
     }
 

--- a/Meridian/Preferences/General/PreferencesViewController.swift
+++ b/Meridian/Preferences/General/PreferencesViewController.swift
@@ -205,7 +205,7 @@ class PreferencesViewController: ParentViewController {
         if let zeroView = notimezoneView {
             notimezoneView?.wantsLayer = true
             tableview.addSubview(zeroView)
-            Logger.log(object: ["Showing Empty View": "YES"], for: "Showing Empty View")
+            Logger.debug("Showing Empty View")
         }
         additionalSortOptions.isHidden = true
     }
@@ -227,7 +227,7 @@ class PreferencesViewController: ParentViewController {
 extension PreferencesViewController: NSTableViewDataSource, NSTableViewDelegate {
     private func _markAsFavorite(_ dataObject: TimezoneData) {
         if dataObject.customLabel != nil {
-            Logger.log(object: ["label": dataObject.customLabel ?? "Error"], for: "favouriteSelected")
+            Logger.debug("favouriteSelected: label=\(dataObject.customLabel ?? "Error")")
         }
 
         if let appDelegate = NSApplication.shared.delegate as? AppDelegate {
@@ -240,8 +240,7 @@ extension PreferencesViewController: NSTableViewDataSource, NSTableViewDelegate 
     }
 
     private func _unfavourite(_ dataObject: TimezoneData) {
-        Logger.log(object: ["label": dataObject.customLabel ?? "Error"],
-                   for: "favouriteRemoved")
+        Logger.debug("favouriteRemoved: label=\(dataObject.customLabel ?? "Error")")
 
         if let appDelegate = NSApplication.shared.delegate as? AppDelegate,
            let menubarFavourites = dataStore.menubarTimezones(),
@@ -296,7 +295,7 @@ extension PreferencesViewController: NSTableViewDataSource, NSTableViewDelegate 
 
                 self.updateStatusBarAppearance()
 
-                Logger.log(object: ["Context": ">1 Menubar Timezone in Preferences"], for: "Switched to Compact Mode")
+                Logger.debug("Switched to Compact Mode: Context=>1 Menubar Timezone in Preferences")
             }
         }
     }
@@ -330,7 +329,7 @@ extension PreferencesViewController {
         }
 
         if timezoneTableView.selectedRow == -1, selectedTimeZones.count <= timezoneTableView.selectedRow {
-            Logger.info("Data was unexpectedly nil")
+            Logger.debug("Data was unexpectedly nil")
             return
         }
 

--- a/Meridian/Preferences/General/TimezoneAdditionHandler.swift
+++ b/Meridian/Preferences/General/TimezoneAdditionHandler.swift
@@ -68,7 +68,7 @@ class TimezoneAdditionHandler: NSObject {
         isActivityInProgress = true
         host.placeholderLabel.placeholderString = "Searching for \(searchString)"
 
-        Logger.info(host.placeholderLabel.placeholderString ?? "")
+        Logger.debug(host.placeholderLabel.placeholderString ?? "")
 
         searchTask = Task { @MainActor in
             do {
@@ -137,7 +137,7 @@ class TimezoneAdditionHandler: NSObject {
     private func reloadSearchResults() {
         guard let host = host else { return }
         if host.searchResultsDataSource.calculateChangesets() {
-            Logger.info("Reloading Search Results")
+            Logger.debug("Reloading Search Results")
             host.availableTimezoneTableView.reloadData()
         }
     }
@@ -197,7 +197,7 @@ class TimezoneAdditionHandler: NSObject {
     private func installTimezone(_ timezone: TimeZone, for placemark: CLPlacemark) {
         guard let host = host else { return }
         guard let dataObject = host.searchResultsDataSource.retrieveFilteredResultFromGoogleAPI(host.availableTimezoneTableView.selectedRow) else {
-            Logger.info("Data was unexpectedly nil")
+            Logger.debug("Data was unexpectedly nil")
             return
         }
 
@@ -222,7 +222,7 @@ class TimezoneAdditionHandler: NSObject {
         let operationsObject = TimezoneDataOperations(with: timezoneObject, store: dataStore)
         operationsObject.saveObject()
 
-        Logger.log(object: ["PlaceName": filteredAddress, "Timezone": timezone.identifier], for: "Filtered Address")
+        Logger.debug("Filtered Address: PlaceName=\(filteredAddress), Timezone=\(timezone.identifier)")
     }
 
     private func updateViewState() {
@@ -301,7 +301,7 @@ class TimezoneAdditionHandler: NSObject {
     private func cleanupAfterInstallingCity() {
         guard let host = host else { return }
         guard let dataObject = host.searchResultsDataSource.retrieveFilteredResultFromGoogleAPI(host.availableTimezoneTableView.selectedRow) else {
-            Logger.info("Data was unexpectedly nil")
+            Logger.debug("Data was unexpectedly nil")
             return
         }
 
@@ -326,12 +326,12 @@ class TimezoneAdditionHandler: NSObject {
                 let operationsObject = TimezoneDataOperations(with: timezoneObject, store: dataStore)
                 operationsObject.saveObject()
 
-                Logger.log(object: ["PlaceName": filteredAddress, "Timezone": timezoneID], for: "Filtered Address")
+                Logger.debug("Filtered Address: PlaceName=\(filteredAddress), Timezone=\(timezoneID)")
                 updateViewState()
             } else {
                 // Fall back to reverse geocoding if no timezone ID
                 guard let latitude = dataObject.latitude, let longitude = dataObject.longitude else {
-                    Logger.info("Data was unexpectedly nil")
+                    Logger.debug("Data was unexpectedly nil")
                     return
                 }
                 getTimezone(for: latitude, and: longitude)

--- a/Meridian/Preferences/Menu Bar/StatusContainerView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusContainerView.swift
@@ -162,7 +162,7 @@ class StatusContainerView: NSView {
 
     func updateTime() {
         if subviews.isEmpty {
-            Logger.info("Subviews count should > 0")
+            Logger.debug("Subviews count should > 0")
         }
 
         for view in subviews {
@@ -194,7 +194,7 @@ class StatusContainerView: NSView {
         }
 
         if newWidth != frame.size.width, newWidth > frame.size.width + 2.0 {
-            Logger.info("Correcting our width to \(newWidth) and the previous width was \(frame.size.width)")
+            Logger.debug("Correcting our width to \(newWidth) and the previous width was \(frame.size.width)")
             // NSView move animation
             NSAnimationContext.runAnimationGroup { context in
                 context.duration = 0.2

--- a/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
@@ -76,7 +76,7 @@ class StatusItemHandler: NSObject {
                 setMenubarIcon()
             }
 
-            Logger.info("Status Bar Current State changed: \(currentState)\n")
+            Logger.debug("Status Bar Current State changed: \(currentState)")
         }
     }
 
@@ -135,12 +135,18 @@ class StatusItemHandler: NSObject {
 
         NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.willSleepNotification)
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in self?.menubarTimer?.invalidate() }
+            .sink { [weak self] _ in
+                Logger.production("System entering sleep")
+                self?.menubarTimer?.invalidate()
+            }
             .store(in: &cancellables)
 
         NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)
             .receive(on: RunLoop.main)
-            .sink { [weak self] _ in self?.setupStatusItem() }
+            .sink { [weak self] _ in
+                Logger.production("System woke from sleep")
+                self?.setupStatusItem()
+            }
             .store(in: &cancellables)
     }
 
@@ -217,7 +223,7 @@ class StatusItemHandler: NSObject {
         menubarTimer?.tolerance = shouldDisplaySeconds ? 0.5 : 20
 
         guard let runLoopTimer = menubarTimer else {
-            Logger.info("Timer is unexpectedly nil")
+            Logger.debug("Timer is unexpectedly nil")
             return
         }
 
@@ -253,12 +259,12 @@ class StatusItemHandler: NSObject {
         } else if let minutes = components.minute {
             components.minute = minutes + 1
         } else {
-            Logger.info("Unable to create date components for the menubar timewr")
+            Logger.production("Unable to create date components for menubar timer")
             return nil
         }
 
         guard let fireDate = calendar.date(from: components) else {
-            Logger.info("Unable to form Fire Date")
+            Logger.production("Unable to form Fire Date")
             return nil
         }
 
@@ -285,7 +291,7 @@ class StatusItemHandler: NSObject {
     }
 
     private func setupForStandardTextMode() {
-        Logger.info("Initializing menubar timer")
+        Logger.debug("Initializing menubar timer")
 
         // Let's invalidate the previous timer
         menubarTimer?.invalidate()
@@ -299,7 +305,7 @@ class StatusItemHandler: NSObject {
         let menubarFavourites = store.menubarTimezones() ?? []
 
         if menubarFavourites.isEmpty {
-            Logger.info("Invalidating menubar timer!")
+            Logger.debug("Invalidating menubar timer")
 
             invalidation()
 
@@ -308,7 +314,7 @@ class StatusItemHandler: NSObject {
             }
 
         } else if sync {
-            Logger.info("Invalidating menubar timer for sync purposes!")
+            Logger.debug("Invalidating menubar timer for sync")
 
             invalidation()
 
@@ -317,7 +323,7 @@ class StatusItemHandler: NSObject {
             }
 
         } else {
-            Logger.info("Not stopping menubar timer!")
+            Logger.debug("Not stopping menubar timer")
         }
     }
 

--- a/Meridian/Preferences/StartupManager.swift
+++ b/Meridian/Preferences/StartupManager.swift
@@ -12,7 +12,7 @@ struct StartupManager {
                 try SMAppService.mainApp.unregister()
             }
         } catch {
-            Logger.info("Failed to toggle login item: \(error)")
+            Logger.production("Failed to toggle login item: \(error)")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace DEBUG-only logging with two-tier OSLog system visible in Console.app
- **`Logger.production()`** (lifecycle category) — always on: app launch/terminate, crash detection via sentinel file, sleep/wake, memory pressure, critical errors
- **`Logger.debug()`** (debug category) — opt-in toggle in About settings: all user actions, preference changes, state transitions
- Both use `os_log(.default)` which the OS persists in the unified log
- Add crash sentinel (`.running` file) — detects previous unclean exits on next launch
- Add "Export Log" button in About settings — saves last 7 days via `OSLogStore`
- Migrate all 66 existing Logger calls from old DEBUG-only methods to new system

### How to view logs
```bash
# All Meridian logs from last 24 hours
log show --predicate 'subsystem == "com.tpak.Meridian"' --last 24h

# Lifecycle only (always on)
log show --predicate 'subsystem == "com.tpak.Meridian" AND category == "lifecycle"' --last 7d

# Debug only (when toggle is enabled)
log show --predicate 'subsystem == "com.tpak.Meridian" AND category == "debug"' --last 1h
```

## Test plan
- [x] Build succeeds
- [x] SwiftLint: 0 violations
- [x] 151 unit tests pass
- [ ] Manual: launch app → Console.app shows "App launched v..." under subsystem com.tpak.Meridian
- [ ] Manual: enable debug logging toggle → perform actions → Console.app shows debug category entries
- [ ] Manual: force-quit app → relaunch → Console.app shows "Previous session exited uncleanly"
- [ ] Manual: "Export Log" button produces a readable text file

🤖 Generated with [Claude Code](https://claude.com/claude-code)