### PR TITLE
Fix Export Log button for sandboxed app

### DIFF
--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -190,12 +190,10 @@ private struct DebugLoggingSection: View {
 
         if debugLogging {
             Button(String(localized: "Export Log")) {
-                let panel = NSSavePanel()
-                panel.nameFieldStringValue = "meridian-log.txt"
-                panel.allowedContentTypes = [.plainText]
-                guard panel.runModal() == .OK, let url = panel.url else { return }
+                let url = FileManager.default.temporaryDirectory.appendingPathComponent("meridian-log.txt")
                 do {
                     try Logger.exportLog(to: url)
+                    NSWorkspace.shared.selectFile(url.path, inFileViewerRootedAtPath: "")
                 } catch {
                     Logger.production("Failed to export log: \(error.localizedDescription)")
                 }


### PR DESCRIPTION
## Summary
- Fix Export Log button doing nothing — `NSSavePanel.runModal()` doesn't work reliably from SwiftUI in a secondary window
- Write log to sandbox temp directory and reveal in Finder instead

## Test plan
- [x] Build succeeds, 151 tests pass
- [ ] Manual: enable debug logging, click Export Log, verify file opens in Finder

🤖 Generated with [Claude Code](https://claude.com/claude-code)