### PR TITLE
Fix log export scope and enlarge About tab

### DIFF
--- a/Meridian/CoreLoggerKit/Sources/CoreLoggerKit/Logger.swift
+++ b/Meridian/CoreLoggerKit/Sources/CoreLoggerKit/Logger.swift
@@ -25,7 +25,7 @@ public enum Logger {
 
     /// Export recent log entries to a file for sharing. Uses OSLogStore.
     public static func exportLog(to url: URL) throws {
-        let store = try OSLogStore(scope: .currentProcessIdentifier)
+        let store = try OSLogStore(scope: .system)
         let cutoff = store.position(date: Date().addingTimeInterval(-7 * 24 * 3600))
         let entries = try store.getEntries(at: cutoff, matching: NSPredicate(format: "subsystem == 'com.tpak.Meridian'"))
         let lines = entries.compactMap { entry -> String? in

--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -59,7 +59,7 @@
             <objects>
                 <viewController id="oFk-9v-L8T" customClass="AboutViewController" customModule="Meridian" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="HdR-qn-zua">
-                        <rect key="frame" x="0.0" y="0.0" width="548" height="468"/>
+                        <rect key="frame" x="0.0" y="0.0" width="548" height="560"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </view>
                 </viewController>


### PR DESCRIPTION
## Summary
- Fix Export Log only showing current session — changed OSLogStore scope from `.currentProcessIdentifier` to `.system` so it includes logs from all sessions (last 7 days)
- Increase About tab height from 468 to 560 to fit the debug logging controls without crowding

## Test plan
- [x] Build succeeds, 151 tests pass
- [ ] Manual: Export Log now includes entries from previous app sessions
- [ ] Manual: About tab has proper spacing for all controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)