### PR TITLE
Center preferences window on screen

### DIFF
--- a/Meridian/Preferences/OneWindowController.swift
+++ b/Meridian/Preferences/OneWindowController.swift
@@ -30,6 +30,7 @@ class OneWindowController: NSWindowController {
         window?.titlebarAppearsTransparent = true
         window?.backgroundColor = NSColor.windowBackgroundColor
         window?.identifier = NSUserInterfaceItemIdentifier("Preferences")
+        window?.center()
     }
 
     private func setupToolbarImages() {


### PR DESCRIPTION
## Summary
- Fix preferences window opening in the lower-left of the screen instead of centered
- The window position was hardcoded in the storyboard at fixed pixel coordinates (`x=245, y=301`)
- Added `window?.center()` in `OneWindowController.setupWindow()` so it opens centered on the user's display

## Test plan
- [x] Build succeeds
- [x] All 151 unit tests pass
- [x] SwiftLint clean (0 serious violations)
- [ ] Manual: open preferences from the menu bar panel and verify window appears centered

🤖 Generated with [Claude Code](https://claude.com/claude-code)