### PR TITLE
Remove broken xcresulttool step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,17 +91,6 @@ jobs:
             -resultBundlePath TestResults/unit-tests.xcresult \
             | xcpretty
 
-      - name: Test Results Summary
-        # NOTE: xcresulttool is unmaintained (still Node 16). No drop-in replacement exists.
-        # Remove this step if it stops working after GitHub drops Node 20 (Sept 2026).
-        if: always()
-        continue-on-error: true
-        uses: kishikawakatsumi/xcresulttool@v1
-        with:
-          path: TestResults/unit-tests.xcresult
-          show-passed-tests: false
-          show-code-coverage: true
-
       - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary
- Remove `kishikawakatsumi/xcresulttool@v1` — it has been silently failing with `xcrun exit code 64` on every CI run, never producing any output or posting test summaries anywhere
- Eliminates the last remaining Node.js 20 deprecation warning
- No functionality lost — the `.xcresult` artifact upload step is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)