### PR TITLE
Add last-checked date to About tab, fix centering and debug footer

### DIFF
--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -113,14 +113,6 @@ class ParentPanelController: NSWindowController {
         // Setup KVO observers for user default changes
         setupObservers()
 
-        // Set the background color of the bottom buttons view to something different to indicate we're not in a release candidate
-#if DEBUG
-        stackView.arrangedSubviews.last?.layer?.backgroundColor = NSColor(deviceRed: 255.0 / 255.0,
-                                                                          green: 150.0 / 255.0,
-                                                                          blue: 122.0 / 255.0,
-                                                                          alpha: 0.5).cgColor
-        stackView.arrangedSubviews.last?.toolTip = "Debug Mode"
-#endif
 
         NotificationCenter.default.publisher(for: NSNotification.Name.NSSystemTimeZoneDidChange)
             .receive(on: RunLoop.main)

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -56,6 +56,7 @@ struct AboutView: View {
             Toggle(String(localized: "Start at Login"), isOn: $startAtLogin)
                 .font(.custom("Avenir-Book", size: 13))
                 .toggleStyle(.checkbox)
+                .fixedSize()
                 .accessibilityIdentifier("StartAtLogin")
                 .onChange(of: startAtLogin) { newValue in
                     startupManager.toggleLogin(newValue)
@@ -124,27 +125,47 @@ struct AboutView: View {
 
 private struct AutoUpdateToggle: View {
     @State private var autoUpdate: Bool
+    @State private var lastCheckDate: Date?
 
     init() {
         let updater = (NSApplication.shared.delegate as? AppDelegate)?.updaterController.updater
         _autoUpdate = State(initialValue: updater?.automaticallyDownloadsUpdates ?? true)
+        _lastCheckDate = State(initialValue: updater?.lastUpdateCheckDate)
     }
 
     var body: some View {
-        Toggle(String(localized: "Automatically download and install updates"), isOn: $autoUpdate)
-            .font(.custom("Avenir-Book", size: 13))
-            .toggleStyle(.checkbox)
-            .accessibilityIdentifier("AutoUpdate")
-            .onChange(of: autoUpdate) { newValue in
-                guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
-                let updater = appDelegate.updaterController.updater
-                updater.automaticallyChecksForUpdates = newValue
-                updater.automaticallyDownloadsUpdates = newValue
-            }
-            .onAppear {
-                guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
-                autoUpdate = appDelegate.updaterController.updater.automaticallyDownloadsUpdates
-            }
+        VStack(alignment: .center, spacing: 4) {
+            Toggle(String(localized: "Automatically download and install updates"), isOn: $autoUpdate)
+                .font(.custom("Avenir-Book", size: 13))
+                .toggleStyle(.checkbox)
+                .fixedSize()
+                .accessibilityIdentifier("AutoUpdate")
+                .onChange(of: autoUpdate) { newValue in
+                    guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+                    let updater = appDelegate.updaterController.updater
+                    updater.automaticallyChecksForUpdates = newValue
+                    updater.automaticallyDownloadsUpdates = newValue
+                }
+                .onAppear {
+                    guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+                    let updater = appDelegate.updaterController.updater
+                    autoUpdate = updater.automaticallyDownloadsUpdates
+                    lastCheckDate = updater.lastUpdateCheckDate
+                }
+
+            Text(lastCheckedText)
+                .font(.custom("Avenir-Light", size: 11))
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+    private var lastCheckedText: String {
+        guard let date = lastCheckDate else { return String(localized: "Last checked: Never") }
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return String(localized: "Last checked: \(formatter.string(from: date))")
     }
 }
 
@@ -186,6 +207,7 @@ private struct DebugLoggingSection: View {
         Toggle(String(localized: "Enable Debug Logging"), isOn: $debugLogging)
             .font(.custom("Avenir-Book", size: 13))
             .toggleStyle(.checkbox)
+            .fixedSize()
             .accessibilityIdentifier("DebugLogging")
 
         if debugLogging {


### PR DESCRIPTION
## Summary
- Show last Sparkle update-check timestamp below the auto-update checkbox in the About tab
- Center all checkboxes with `fixedSize()` so they hug their label width rather than stretching
- Remove the debug-mode orange background from the panel footer (was only visible in debug builds, but ugly)

## Test plan
- [ ] About tab: last-checked date appears below "Automatically download and install updates"
- [ ] About tab: all three checkboxes are centered
- [ ] Panel footer: no orange/bronze background in debug builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)