### PR TITLE
Skip CI on appcast and docs-only pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - 'appcast.xml'
+      - '*.md'
+      - 'LICENSE'
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
## Summary
- Adds `paths-ignore` to the CI push trigger for `appcast.xml`, `*.md`, and `LICENSE`
- Every release makes 2 pushes to main (version bump + appcast update) — this eliminates the redundant second CI run since no Swift code changes in the appcast commit
- If a push touches source code alongside any of these files, CI still runs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)