### PR TITLE
Add float-on-top / pin-to-desktop mode

### DIFF
--- a/Meridian/App/en.lproj/Panel.xib
+++ b/Meridian/App/en.lproj/Panel.xib
@@ -389,7 +389,7 @@
                                     </button>
                                     <textField focusRingType="none" verticalHuggingPriority="750" horizontalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="vSt-rL-p9Q">
                                         <rect key="frame" x="50" y="12" width="319" height="16"/>
-                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="" id="vSt-rL-p9R">
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="" id="vSt-rL-p9R">
                                             <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="tertiaryLabelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -204,7 +204,6 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @IBAction open func togglePanel(_ sender: NSButton) {
-        Logger.debug("Toggle Panel called with sender state \(sender.state.rawValue)")
         panelController.showWindow(nil)
         panelController.setActivePanel(newValue: sender.state == .on)
         NSApp.activate(ignoringOtherApps: true)

--- a/Meridian/Meridian.xcodeproj/project.pbxproj
+++ b/Meridian/Meridian.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		35C36F5D2259DD96002FA5C6 /* TimezoneDataOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F5B2259DD96002FA5C6 /* TimezoneDataOperations.swift */; };
 		35C36F6F2259E185002FA5C6 /* CustomSliderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F6C2259E185002FA5C6 /* CustomSliderCell.swift */; };
 		35C36F702259E185002FA5C6 /* BackgroundPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F6D2259E185002FA5C6 /* BackgroundPanelView.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* PanelDragHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F3 /* PanelDragHandleView.swift */; };
 		35C36F712259E185002FA5C6 /* NoTimezoneView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F6E2259E185002FA5C6 /* NoTimezoneView.swift */; };
 		35C36F772259E1D0002FA5C6 /* AppKit + Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F742259E1CF002FA5C6 /* AppKit + Additions.swift */; };
 		35C36F782259E1D0002FA5C6 /* Foundation + Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F752259E1CF002FA5C6 /* Foundation + Additions.swift */; };
@@ -174,6 +175,7 @@
 		35C36F5B2259DD96002FA5C6 /* TimezoneDataOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimezoneDataOperations.swift; sourceTree = "<group>"; };
 		35C36F6C2259E185002FA5C6 /* CustomSliderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSliderCell.swift; sourceTree = "<group>"; };
 		35C36F6D2259E185002FA5C6 /* BackgroundPanelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundPanelView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6A7B8C9D0E1F3 /* PanelDragHandleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanelDragHandleView.swift; sourceTree = "<group>"; };
 		35C36F6E2259E185002FA5C6 /* NoTimezoneView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoTimezoneView.swift; sourceTree = "<group>"; };
 		35C36F742259E1CF002FA5C6 /* AppKit + Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "AppKit + Additions.swift"; sourceTree = "<group>"; };
 		35C36F752259E1CF002FA5C6 /* Foundation + Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Foundation + Additions.swift"; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 			isa = PBXGroup;
 			children = (
 				35C36F6D2259E185002FA5C6 /* BackgroundPanelView.swift */,
+				A1B2C3D4E5F6A7B8C9D0E1F3 /* PanelDragHandleView.swift */,
 				35C36F6C2259E185002FA5C6 /* CustomSliderCell.swift */,
 				35C36F6E2259E185002FA5C6 /* NoTimezoneView.swift */,
 				35C36F562259DD8A002FA5C6 /* CustomPanel.swift */,
@@ -826,6 +829,7 @@
 				35C36F422259D892002FA5C6 /* Timer.swift in Sources */,
 				35C36F772259E1D0002FA5C6 /* AppKit + Additions.swift in Sources */,
 				35C36F702259E185002FA5C6 /* BackgroundPanelView.swift in Sources */,
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* PanelDragHandleView.swift in Sources */,
 				9AB6F1582259CFFC00A44663 /* AboutViewController.swift in Sources */,
 				AA000001SWIFTUI00000001 /* AboutView.swift in Sources */,
 				35C36F2122596253002FA5C6 /* AppearanceViewController.swift in Sources */,

--- a/Meridian/Overall App/UserDefaults + KVOExtensions.swift
+++ b/Meridian/Overall App/UserDefaults + KVOExtensions.swift
@@ -14,4 +14,9 @@ extension UserDefaults {
     @objc dynamic var sliderDayRange: Int {
         return integer(forKey: UserDefaultKeys.futureSliderRange)
     }
+
+    // Property name must match the UserDefaults key string for KVO notifications to fire.
+    @objc dynamic var displayAppAsForegroundApp: Int {
+        return integer(forKey: UserDefaultKeys.showAppInForeground)
+    }
 }

--- a/Meridian/Panel/PanelController.swift
+++ b/Meridian/Panel/PanelController.swift
@@ -5,6 +5,9 @@ import CoreLoggerKit
 
 class PanelController: ParentPanelController {
     @objc dynamic var hasActivePanel: Bool = false
+    private var isShowingContextMenu = false
+    private var pinButton: NSButton?
+    private var dragHandleView: PanelDragHandleView?
 
     @IBOutlet var backgroundView: BackgroundPanelView!
 
@@ -20,22 +23,116 @@ class PanelController: ParentPanelController {
 
         if let panel = window {
             panel.acceptsMouseMovedEvents = true
-            panel.level = .popUpMenu
             panel.isOpaque = false
             panel.backgroundColor = NSColor.clear
         }
+
+        applyWindowMode()
 
         mainTableView.registerForDraggedTypes([.dragSession])
 
         super.updatePanelColor()
 
         super.updateDefaultPreferences()
+
+        setupFloatingModeObserver()
+        setupFloatModeUI()
     }
 
     private func enablePerformanceLoggingIfNeccessary() {
         if !ProcessInfo.processInfo.environment.keys.contains("ENABLE_PERF_LOGGING") {
             PerfLogger.disable()
         }
+    }
+
+    private var isFloatingMode: Bool {
+        return dataStore.shouldDisplay(.showAppInForeground)
+    }
+
+    private func applyWindowMode() {
+        guard let panel = window else { return }
+        if isFloatingMode {
+            panel.isMovableByWindowBackground = true
+            panel.level = .floating
+            panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+            panel.hidesOnDeactivate = false
+            // Restore saved position, or center on screen if first time
+            let restored = panel.setFrameUsingName("MeridianFloatingPanel")
+            panel.setFrameAutosaveName("MeridianFloatingPanel")
+            if !restored {
+                panel.center()
+            }
+        } else {
+            panel.isMovableByWindowBackground = false
+            panel.level = .popUpMenu
+            panel.collectionBehavior = []
+            panel.hidesOnDeactivate = false
+            panel.setFrameAutosaveName("")
+        }
+        updateFloatModeUI()
+    }
+
+    private func setupFloatModeUI() {
+        guard let contentView = window?.contentView,
+              let footer = settingsButton?.superview else { return }
+
+        // Drag handle: thin strip at top of panel for repositioning in float mode.
+        let drag = PanelDragHandleView()
+        drag.translatesAutoresizingMaskIntoConstraints = false
+        drag.isHidden = true
+        contentView.addSubview(drag)
+        NSLayoutConstraint.activate([
+            drag.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6),
+            drag.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            drag.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            drag.heightAnchor.constraint(equalToConstant: 16),
+        ])
+        dragHandleView = drag
+
+        // Pin button: quick float toggle next to the version label in the footer.
+        let pin = NSButton()
+        pin.translatesAutoresizingMaskIntoConstraints = false
+        pin.bezelStyle = .recessed
+        pin.isBordered = false
+        pin.imagePosition = .imageOnly
+        pin.target = self
+        pin.action = #selector(toggleFloatingMode)
+        footer.addSubview(pin)
+        NSLayoutConstraint.activate([
+            pin.centerYAnchor.constraint(equalTo: footer.centerYAnchor),
+            pin.trailingAnchor.constraint(equalTo: footer.trailingAnchor, constant: -8),
+            pin.widthAnchor.constraint(equalToConstant: 22),
+            pin.heightAnchor.constraint(equalToConstant: 22),
+        ])
+        // Shrink version label trailing margin to make room for the pin button.
+        for c in footer.constraints where c.secondItem === versionStatusLabel && c.secondAttribute == .trailing {
+            c.constant = 34 // 22pt button + 4pt gap + 8pt margin
+            break
+        }
+        pinButton = pin
+        updateFloatModeUI()
+    }
+
+    private func updateFloatModeUI() {
+        let floating = isFloatingMode
+        dragHandleView?.isHidden = !floating
+        let symbol = floating ? "pin.fill" : "pin"
+        pinButton?.image = NSImage(systemSymbolName: symbol, accessibilityDescription: floating ? "Unpin from Desktop" : "Pin to Desktop")
+        pinButton?.contentTintColor = floating ? .controlAccentColor : .secondaryLabelColor
+        pinButton?.toolTip = floating ? "Unpin from Desktop" : "Pin to Desktop"
+    }
+
+    private func setupFloatingModeObserver() {
+        UserDefaults.standard.publisher(for: \.displayAppAsForegroundApp)
+            .receive(on: RunLoop.main)
+            .dropFirst()
+            .sink { [weak self] _ in
+                self?.applyWindowMode()  // also calls updateFloatModeUI
+                if self?.isFloatingMode == true, self?.window?.isVisible == false {
+                    self?.setActivePanel(newValue: true)
+                }
+            }
+            .store(in: &cancellables)
     }
 
     func setFrameTheNewWay(_ rect: NSRect, _ maxX: CGFloat) {
@@ -59,6 +156,17 @@ class PanelController: ParentPanelController {
 
         guard isWindowLoaded == true else {
             return
+        }
+
+        // Cancel any in-flight fade-out animation and restore full opacity immediately.
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0
+            window?.animator().alphaValue = 1
+        }
+
+        // Keep button state in sync regardless of how the panel was opened (click vs programmatic).
+        if let btn = (NSApplication.shared.delegate as? AppDelegate)?.statusItemForPanel().statusItem.button {
+            btn.state = .on
         }
 
         super.dismissRowActions()
@@ -90,7 +198,9 @@ class PanelController: ParentPanelController {
 
         setTimezoneDatasourceSlider(sliderValue: 0)
 
-        setPanelFrame()
+        if !isFloatingMode {
+            setPanelFrame()
+        }
 
         startWindowTimer()
 
@@ -254,14 +364,20 @@ class PanelController: ParentPanelController {
         parentTimer?.pause()
 
         updatePopoverDisplayState()
-
-        NSAnimationContext.beginGrouping()
-        NSAnimationContext.current.duration = 0.1
-        window?.animator().alphaValue = 0
         additionalOptionsPopover?.close()
-        NSAnimationContext.endGrouping()
 
-        window?.orderOut(nil)
+        // Keep button state in sync regardless of how the panel was closed (click vs programmatic).
+        if let btn = (NSApplication.shared.delegate as? AppDelegate)?.statusItemForPanel().statusItem.button {
+            btn.state = .off
+        }
+
+        let windowToHide = window
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.1
+            windowToHide?.animator().alphaValue = 0
+        }, completionHandler: {
+            windowToHide?.orderOut(nil)
+        })
 
         datasource = nil
         parentTimer?.pause()
@@ -291,30 +407,19 @@ class PanelController: ParentPanelController {
     }
 
     override func showNotesPopover(forRow row: Int, relativeTo positioningRect: NSRect, andButton target: NSButton!) -> Bool {
-        if additionalOptionsPopover == nil {
-            additionalOptionsPopover = NSPopover()
-        }
+        guard let target = target else { return false }
 
-        guard let popover = additionalOptionsPopover else {
-            return false
-        }
-
-        target.image = NSImage(systemSymbolName: "ellipsis.circle.fill", accessibilityDescription: "Options")
-
-        if popover.isShown, row == previousPopoverRow {
+        // The NotesPopover XIB/controller was removed in the strip commit.
+        // Update the button icon for the ellipsis toggle but don't try to show a popover.
+        if let popover = additionalOptionsPopover, popover.isShown, row == previousPopoverRow {
             popover.close()
             target.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: "Options")
             previousPopoverRow = -1
             return false
         }
 
+        target.image = NSImage(systemSymbolName: "ellipsis.circle.fill", accessibilityDescription: "Options")
         previousPopoverRow = row
-
-        super.showNotesPopover(forRow: row, relativeTo: positioningRect, andButton: target)
-
-        popover.show(relativeTo: positioningRect,
-                     of: target,
-                     preferredEdge: .minX)
 
         if let timer = parentTimer, timer.state == .paused {
             timer.start()
@@ -348,15 +453,44 @@ class PanelController: ParentPanelController {
         // If the parent view is hidden, then that doesn't automatically mean that all the childViews are also hidden
         // Hence, check if the parent view is totally hidden or not..
     }
+
+    @objc func toggleFloatingMode() {
+        let newValue = isFloatingMode ? 0 : 1
+        UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.showAppInForeground)
+        applyWindowMode()
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        guard let contentView = window?.contentView else { return }
+        isShowingContextMenu = true
+        let menu = NSMenu(title: "Panel Options")
+        let title = isFloatingMode ? "Unpin from Desktop" : "Pin to Desktop"
+        let item = NSMenuItem(title: title, action: #selector(toggleFloatingMode), keyEquivalent: "")
+        item.target = self
+        menu.addItem(item)
+        NSMenu.popUpContextMenu(menu, with: event, for: contentView)
+        isShowingContextMenu = false
+    }
 }
 
 extension PanelController: NSWindowDelegate {
+    func windowShouldClose(_: NSWindow) -> Bool {
+        if isFloatingMode {
+            setActivePanel(newValue: false)
+            return false
+        }
+        return true
+    }
+
     func windowWillClose(_: Notification) {
         parentTimer = nil
         setActivePanel(newValue: false)
     }
 
     func windowDidResignKey(_: Notification) {
+        if isFloatingMode || isShowingContextMenu {
+            return
+        }
         parentTimer = nil
 
         if let isVisible = window?.isVisible, isVisible == true {

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -346,6 +346,8 @@ class ParentPanelController: NSWindowController {
 
     @discardableResult
     func showNotesPopover(forRow row: Int, relativeTo _: NSRect, andButton target: NSButton!) -> Bool {
+        guard let target = target else { return false }
+
         let defaults = dataStore.timezones()
 
         guard let popover = additionalOptionsPopover else {

--- a/Meridian/Panel/UI/PanelDragHandleView.swift
+++ b/Meridian/Panel/UI/PanelDragHandleView.swift
@@ -1,0 +1,38 @@
+import Cocoa
+
+/// A thin strip at the top of the floating panel that the user can grab to drag the window.
+class PanelDragHandleView: NSView {
+    private var trackingArea: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let existing = trackingArea { removeTrackingArea(existing) }
+        trackingArea = NSTrackingArea(rect: bounds,
+                                     options: [.activeAlways, .mouseEnteredAndExited, .cursorUpdate],
+                                     owner: self, userInfo: nil)
+        addTrackingArea(trackingArea!)
+    }
+
+    override func cursorUpdate(with event: NSEvent) {
+        NSCursor.openHand.set()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.performDrag(with: event)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        // Draw a row of subtle grip dots centred in the strip.
+        NSColor.quaternaryLabelColor.setFill()
+        let dotSize: CGFloat = 3
+        let gap: CGFloat = 4
+        let count = 5
+        let totalW = CGFloat(count) * dotSize + CGFloat(count - 1) * gap
+        var x = (bounds.width - totalW) / 2
+        let y = (bounds.height - dotSize) / 2
+        for _ in 0..<count {
+            NSBezierPath(ovalIn: NSRect(x: x, y: y, width: dotSize, height: dotSize)).fill()
+            x += dotSize + gap
+        }
+    }
+}

--- a/Meridian/Panel/UI/TimezoneCellView.swift
+++ b/Meridian/Panel/UI/TimezoneCellView.swift
@@ -197,8 +197,8 @@ class TimezoneCellView: NSTableCellView {
     }
 
     override func rightMouseDown(with event: NSEvent) {
+        // Pass right-clicks up the responder chain (e.g. to PanelController for Pin to Desktop).
+        // The old notes popover was removed in the strip commit; showExtraOptions would crash.
         super.rightMouseDown(with: event)
-        showExtraOptions(extraOptions)
-        Logger.debug("Right Click Open Options")
     }
 }

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -16,6 +16,8 @@ class AppearanceViewController: ParentViewController {
     @IBOutlet var includePlaceNameControl: NSSegmentedControl!
     @IBOutlet var appearanceTab: NSTabView!
     @IBOutlet var appDisplayControl: NSSegmentedControl!
+    @IBOutlet var floatOnTopControl: NSSegmentedControl!
+    @IBOutlet var floatOnTopLabel: NSTextField!
 
     private static let sliderDayValues = [1, 2, 3, 4, 5, 6, 7, 14, 30, 90]
 
@@ -114,6 +116,10 @@ class AppearanceViewController: ParentViewController {
         let appDisplayOptions = dataStore.shouldDisplay(.appDisplayOptions)
         appDisplayControl.setSelected(true, forSegment: appDisplayOptions ? 0 : 1)
 
+        // True means float on top enabled
+        let floatOnTop = dataStore.shouldDisplay(.showAppInForeground)
+        floatOnTopControl.setSelected(true, forSegment: floatOnTop ? 0 : 1)
+
     }
 
     @IBOutlet var timeFormatLabel: NSTextField!
@@ -148,12 +154,14 @@ class AppearanceViewController: ParentViewController {
         menubarModeLabel.stringValue = "Menubar Mode".localized()
         previewLabel.stringValue = "Preview".localized()
         miscelleaneousLabel.stringValue = "Miscellaneous".localized()
+        floatOnTopLabel.stringValue = "Float on Top".localized()
+        appDisplayLabel.stringValue = "Show Meridian in".localized()
 
         [timeFormatLabel, panelTheme,
          dayDisplayOptionsLabel, showSliderLabel,
          showSunriseLabel, largerTextLabel, futureSliderRangeLabel,
          includeDayLabel, includeDateLabel, includePlaceLabel, appDisplayLabel, menubarModeLabel,
-         previewLabel, miscelleaneousLabel].forEach {
+         previewLabel, miscelleaneousLabel, floatOnTopLabel].forEach {
             $0?.textColor = NSColor.labelColor
         }
 
@@ -248,6 +256,12 @@ class AppearanceViewController: ParentViewController {
             Logger.debug("Dock Mode: Selection=Menubar and Dock")
             NSApp.setActivationPolicy(.regular)
         }
+    }
+
+    @IBAction func floatOnTopChanged(_ sender: NSSegmentedControl) {
+        let value = sender.selectedSegment == 0 ? 1 : 0
+        UserDefaults.standard.set(value, forKey: UserDefaultKeys.showAppInForeground)
+        Logger.debug("Float on Top: \(value == 1 ? "Enabled" : "Disabled")")
     }
 
     private func refresh(panel: Bool) {

--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -605,6 +605,30 @@
                                                         <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.com.abhishek.appDisplayOptions" id="4Ix-iO-C4I"/>
                                                     </connections>
                                                 </segmentedControl>
+                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="floatTop-ctrl-001">
+                                                    <rect key="frame" x="242" y="106" width="128" height="24"/>
+                                                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="floatTop-cell-001">
+                                                        <font key="font" size="12" name="Avenir-Light"/>
+                                                        <segments>
+                                                            <segment label="Yes"/>
+                                                            <segment label="No" selected="YES" tag="1"/>
+                                                        </segments>
+                                                    </segmentedCell>
+                                                    <connections>
+                                                        <action selector="floatOnTopChanged:" target="1aL-zR-8L4" id="floatTop-act-001"/>
+                                                    </connections>
+                                                </segmentedControl>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="120" translatesAutoresizingMaskIntoConstraints="NO" id="floatTop-lbl-001">
+                                                    <rect key="frame" x="67" y="109" width="154" height="18"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="floatTop-lbl-w01"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Float on Top" id="floatTop-lbl-cel1">
+                                                        <font key="font" size="13" name="Avenir-Light"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="120" translatesAutoresizingMaskIntoConstraints="NO" id="GaR-Qm-7u4">
                                                     <rect key="frame" x="17" y="109" width="204" height="18"/>
                                                     <constraints>
@@ -722,7 +746,11 @@
                                                 <constraint firstItem="Q3M-Kz-XV3" firstAttribute="centerX" secondItem="mF4-bp-EID" secondAttribute="centerX" id="yKZ-7i-UKv"/>
                                                 <constraint firstItem="HNj-dh-8gr" firstAttribute="trailing" secondItem="Utg-yF-Rso" secondAttribute="trailing" id="yPE-hM-Mbb"/>
                                                 <constraint firstItem="DjV-qq-hr9" firstAttribute="leading" secondItem="Mai-SZ-AEi" secondAttribute="leading" id="ykI-Ig-kwf"/>
-                                                <constraint firstItem="GaR-Qm-7u4" firstAttribute="top" secondItem="HNj-dh-8gr" secondAttribute="bottom" constant="14" id="z8z-AY-l8y"/>
+                                                <constraint firstItem="floatTop-lbl-001" firstAttribute="top" secondItem="HNj-dh-8gr" secondAttribute="bottom" constant="14" id="floatTop-con-top"/>
+                                                <constraint firstItem="GaR-Qm-7u4" firstAttribute="top" secondItem="floatTop-lbl-001" secondAttribute="bottom" constant="14" id="floatTop-con-bot"/>
+                                                <constraint firstItem="floatTop-ctrl-001" firstAttribute="centerY" secondItem="floatTop-lbl-001" secondAttribute="centerY" id="floatTop-con-cy"/>
+                                                <constraint firstItem="floatTop-ctrl-001" firstAttribute="leading" secondItem="DjV-qq-hr9" secondAttribute="leading" id="floatTop-con-lead"/>
+                                                <constraint firstItem="floatTop-lbl-001" firstAttribute="trailing" secondItem="HNj-dh-8gr" secondAttribute="trailing" id="floatTop-con-trail"/>
                                             </constraints>
                                         </view>
                                     </tabViewItem>
@@ -739,6 +767,8 @@
                     <connections>
                         <outlet property="appDisplayControl" destination="DjV-qq-hr9" id="Q4N-i2-oWr"/>
                         <outlet property="appDisplayLabel" destination="HNj-dh-8gr" id="A6U-gp-sje"/>
+                        <outlet property="floatOnTopControl" destination="floatTop-ctrl-001" id="floatTop-out-ctrl"/>
+                        <outlet property="floatOnTopLabel" destination="floatTop-lbl-001" id="floatTop-out-lbl"/>
                         <outlet property="appearanceTab" destination="SGu-yd-JQh" id="CJn-3E-Ujd"/>
                         <outlet property="dayDisplayOptionsLabel" destination="gFE-hZ-J92" id="tVv-pC-MSW"/>
                         <outlet property="futureSliderRangeLabel" destination="GaR-Qm-7u4" id="0aB-BK-7fN"/>


### PR DESCRIPTION
## Summary

- Restores the always-on-top floating window from the original Clocker codebase
- Panel can be pinned to the desktop — stays visible above all windows, freely draggable, persists across Space switches, saves/restores position
- Toggle via pin button in panel footer, right-click context menu, or Preferences → Appearance → Misc → Float on Top
- Drag handle strip at top of panel for repositioning when floating
- Version/last-checked label centered in panel footer

## Test plan

- [ ] Toggle float mode via pin button in footer — panel stays on top and is movable
- [ ] Toggle via right-click context menu — Pin to Desktop / Unpin from Desktop
- [ ] Toggle via Preferences → Appearance → Misc → Float on Top
- [ ] Drag panel by grabbing the handle at the top
- [ ] Cmd+W hides the floating panel (doesn't close/quit)
- [ ] Panel position is restored after relaunch when float mode is on
- [ ] Panel behaves normally (anchors to menu bar) when float mode is off
- [ ] Timer keeps running while panel is floating

🤖 Generated with [Claude Code](https://claude.com/claude-code)