### PR TITLE
Improve test coverage: Refactor UI logic, mock network calls, and fix…

### DIFF
--- a/Meridian/Meridian.xcodeproj/project.pbxproj
+++ b/Meridian/Meridian.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		35C36F592259DD8A002FA5C6 /* TimezoneCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F552259DD8A002FA5C6 /* TimezoneCellView.swift */; };
 		35C36F5A2259DD8A002FA5C6 /* CustomPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F562259DD8A002FA5C6 /* CustomPanel.swift */; };
 		35C36F5D2259DD96002FA5C6 /* TimezoneDataOperations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F5B2259DD96002FA5C6 /* TimezoneDataOperations.swift */; };
+		E1F2A3B400TMSCRLRVM0001 /* TimeScrollerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B400TMSCRLRVM0002 /* TimeScrollerViewModel.swift */; };
 		35C36F6F2259E185002FA5C6 /* CustomSliderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F6C2259E185002FA5C6 /* CustomSliderCell.swift */; };
 		35C36F702259E185002FA5C6 /* BackgroundPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F6D2259E185002FA5C6 /* BackgroundPanelView.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* PanelDragHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F3 /* PanelDragHandleView.swift */; };
@@ -63,6 +64,7 @@
 		35E65125268EDD2E00E3E1E3 /* Toasty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35E65124268EDD2E00E3E1E3 /* Toasty.swift */; };
 		3DEE1440C33BTZSORTINGTST /* TimezoneSortingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DEE1440C33BTZSORTINGTST2 /* TimezoneSortingManagerTests.swift */; };
 		4726354D81E1NWMGRASYNCTS /* NetworkManagerAsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4726354D81E1NWMGRASYNCT2 /* NetworkManagerAsyncTests.swift */; };
+		E1F2A3B400TMSCRLRVMTST1 /* TimeScrollerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F2A3B400TMSCRLRVMTST2 /* TimeScrollerViewModelTests.swift */; };
 		818B546B7B8B47D88692CD80 /* GlobalShortcutMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FEC776853CC4796AD9A1DC6 /* GlobalShortcutMonitor.swift */; };
 		919639F9D2F3GLOBALSHRTCUT /* GlobalShortcutMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 919639F9D2F3GLOBALSHRTCU2 /* GlobalShortcutMonitorTests.swift */; };
 		9A0385BB269E3434003B5E72 /* StandardMenubarHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0385BA269E3434003B5E72 /* StandardMenubarHandlerTests.swift */; };
@@ -178,6 +180,7 @@
 		35C36F552259DD8A002FA5C6 /* TimezoneCellView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimezoneCellView.swift; sourceTree = "<group>"; };
 		35C36F562259DD8A002FA5C6 /* CustomPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomPanel.swift; sourceTree = "<group>"; };
 		35C36F5B2259DD96002FA5C6 /* TimezoneDataOperations.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimezoneDataOperations.swift; sourceTree = "<group>"; };
+		E1F2A3B400TMSCRLRVM0002 /* TimeScrollerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeScrollerViewModel.swift; sourceTree = "<group>"; };
 		35C36F6C2259E185002FA5C6 /* CustomSliderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomSliderCell.swift; sourceTree = "<group>"; };
 		35C36F6D2259E185002FA5C6 /* BackgroundPanelView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundPanelView.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6A7B8C9D0E1F3 /* PanelDragHandleView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanelDragHandleView.swift; sourceTree = "<group>"; };
@@ -190,6 +193,7 @@
 		35E65124268EDD2E00E3E1E3 /* Toasty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toasty.swift; sourceTree = "<group>"; };
 		3DEE1440C33BTZSORTINGTST2 /* TimezoneSortingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimezoneSortingManagerTests.swift; sourceTree = "<group>"; };
 		4726354D81E1NWMGRASYNCT2 /* NetworkManagerAsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkManagerAsyncTests.swift; sourceTree = "<group>"; };
+		E1F2A3B400TMSCRLRVMTST2 /* TimeScrollerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeScrollerViewModelTests.swift; sourceTree = "<group>"; };
 		527EBAA6C18049AE931DDE49 /* PanelContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelContextMenu.swift; sourceTree = "<group>"; };
 		919639F9D2F3GLOBALSHRTCU2 /* GlobalShortcutMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalShortcutMonitorTests.swift; sourceTree = "<group>"; };
 		9A0385BA269E3434003B5E72 /* StandardMenubarHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardMenubarHandlerTests.swift; sourceTree = "<group>"; };
@@ -402,6 +406,7 @@
 			isa = PBXGroup;
 			children = (
 				35C36F5B2259DD96002FA5C6 /* TimezoneDataOperations.swift */,
+				E1F2A3B400TMSCRLRVM0002 /* TimeScrollerViewModel.swift */,
 			);
 			path = "Data Layer";
 			sourceTree = "<group>";
@@ -537,6 +542,7 @@
 				3DEE1440C33BTZSORTINGTST2 /* TimezoneSortingManagerTests.swift */,
 				919639F9D2F3GLOBALSHRTCU2 /* GlobalShortcutMonitorTests.swift */,
 				4726354D81E1NWMGRASYNCT2 /* NetworkManagerAsyncTests.swift */,
+				E1F2A3B400TMSCRLRVMTST2 /* TimeScrollerViewModelTests.swift */,
 				AA00000400000001PREFSTB2 /* PreferencesStoryboardTests.swift */,
 				CC11AA0100TZDATAOPSTEST2 /* TimezoneDataOperationsTests.swift */,
 				CC11AA0200MNBRTITLTEST2 /* MenubarTitleProviderTests.swift */,
@@ -798,6 +804,7 @@
 				3DEE1440C33BTZSORTINGTST /* TimezoneSortingManagerTests.swift in Sources */,
 				919639F9D2F3GLOBALSHRTCUT /* GlobalShortcutMonitorTests.swift in Sources */,
 				4726354D81E1NWMGRASYNCTS /* NetworkManagerAsyncTests.swift in Sources */,
+				E1F2A3B400TMSCRLRVMTST1 /* TimeScrollerViewModelTests.swift in Sources */,
 				AA00000400000002PREFSTB1 /* PreferencesStoryboardTests.swift in Sources */,
 				CC11AA0100TZDATAOPSTEST1 /* TimezoneDataOperationsTests.swift in Sources */,
 				CC11AA0200MNBRTITLTEST1 /* MenubarTitleProviderTests.swift in Sources */,
@@ -834,6 +841,7 @@
 				35C36F16225961DA002FA5C6 /* Date+Inits.swift in Sources */,
 				35C36F4F2259D981002FA5C6 /* AppDefaults.swift in Sources */,
 				35C36F5D2259DD96002FA5C6 /* TimezoneDataOperations.swift in Sources */,
+				E1F2A3B400TMSCRLRVM0001 /* TimeScrollerViewModel.swift in Sources */,
 				3508CC942599FFEC000E3530 /* MenubarTitleProvider.swift in Sources */,
 				35C36F792259E1D0002FA5C6 /* String + Additions.swift in Sources */,
 				35C36F422259D892002FA5C6 /* Timer.swift in Sources */,

--- a/Meridian/MeridianUnitTests/AppDelegateTests.swift
+++ b/Meridian/MeridianUnitTests/AppDelegateTests.swift
@@ -138,7 +138,7 @@ class AppDelegateTests: XCTestCase {
         if olderTimezones.isEmpty {
             XCTAssertNotNil(statusItemHandler?.statusItem.button?.image)
         } else {
-            XCTAssertTrue(statusItemHandler?.statusItem.button?.title != nil)
+            XCTAssertNotNil(statusItemHandler?.statusItem.button?.title)
         }
 
         let timezone1 = TimezoneData()

--- a/Meridian/MeridianUnitTests/NetworkManagerAsyncTests.swift
+++ b/Meridian/MeridianUnitTests/NetworkManagerAsyncTests.swift
@@ -184,30 +184,23 @@ class NetworkManagerAsyncTests: XCTestCase {
     // MARK: - NetworkManager Async Method Tests
 
     func testNetworkManagerAsyncDataFromURL() async throws {
-        // Test that NetworkManager's async methods work properly
-        // Note: This requires network access, so we're testing the pattern
-        let testURL = URL(string: "https://httpbin.org/json")!
+        let testURL = URL(string: "https://example.com/json")!
+        let expectedData = "{\"success\": true}".data(using: .utf8)!
 
-        do {
-            // Use the real NetworkManager with actual URLSession
-            let data = try await NetworkManager.data(from: testURL)
-            XCTAssertFalse(data.isEmpty, "Data should not be empty")
-        } catch {
-            // Network might not be available in test environment
-            // This is acceptable for unit tests
-        }
+        MockURLProtocol.register(pathContaining: "json", statusCode: 200, data: expectedData)
+
+        let data = try await NetworkManager.data(from: testURL, session: mockSession)
+        XCTAssertEqual(data, expectedData)
     }
 
     func testNetworkManagerAsyncDataFromString() async throws {
-        let testURLString = "https://httpbin.org/json"
+        let testURLString = "https://example.com/json"
+        let expectedData = "{\"success\": true}".data(using: .utf8)!
 
-        do {
-            let data = try await NetworkManager.data(from: testURLString)
-            XCTAssertFalse(data.isEmpty, "Data should not be empty")
-        } catch {
-            // Network might not be available in test environment
-            // This is acceptable for unit tests
-        }
+        MockURLProtocol.register(pathContaining: "json", statusCode: 200, data: expectedData)
+
+        let data = try await NetworkManager.data(from: testURLString, session: mockSession)
+        XCTAssertEqual(data, expectedData)
     }
 
     func testNetworkManagerAsyncWithInvalidURL() async {

--- a/Meridian/MeridianUnitTests/StandardMenubarHandlerTests.swift
+++ b/Meridian/MeridianUnitTests/StandardMenubarHandlerTests.swift
@@ -52,7 +52,7 @@ class StandardMenubarHandlerTests: XCTestCase {
         saveTimezoneToStore(dataObject, store: store)
 
         let menubarString = menubarHandler.titleForMenubar()
-        XCTAssertTrue(menubarString.count == 0)
+        XCTAssertEqual(menubarString.count, 0)
     }
 
     func testWithEmptyMenubarTimezones() {

--- a/Meridian/MeridianUnitTests/TimeScrollerViewModelTests.swift
+++ b/Meridian/MeridianUnitTests/TimeScrollerViewModelTests.swift
@@ -47,19 +47,12 @@ class TimeScrollerViewModelTests: XCTestCase {
         let totalPoints = viewModel.totalSliderPoints()
         let centerIndex = totalPoints / 2
         let forwardIndex = centerIndex + 1
-        
-        let baseDate = Date()
-        let result = viewModel.calculateMinutesToAdd(for: forwardIndex, baseDate: baseDate)
-        
-        // forwardIndex is centerIndex + 1, so remainder is 0? 
-        // Let's check logic: remainder = (index % (centerPoint + 1))
-        // centerPoint = ceil(totalPoints / 2)
-        // for totalPoints = 193, centerPoint = 97.
-        // if index = 98 (centerPoint + 1), remainder = 98 % 98 = 0.
-        // minuteOffset = 0 * 15 = 0.
-        // nextDate = baseDate.
-        // result.0 = nextDate.minutes(from: Date()) + 1 = 1.
-        
+
+        // Use the same date for baseDate and now so minutes(from:) is deterministic.
+        // forwardIndex == centerPoint + 1, so remainder = 0, minuteOffset = 0,
+        // nextDate == baseDate, and nextDate.minutes(from: now) + 1 == 1.
+        let fixedDate = Date()
+        let result = viewModel.calculateMinutesToAdd(for: forwardIndex, baseDate: fixedDate, now: fixedDate)
         XCTAssertEqual(result.0, 1)
     }
 

--- a/Meridian/MeridianUnitTests/TimeScrollerViewModelTests.swift
+++ b/Meridian/MeridianUnitTests/TimeScrollerViewModelTests.swift
@@ -1,0 +1,72 @@
+// Copyright © 2015 Abhishek Banthia
+
+import XCTest
+@testable import Meridian
+
+class TimeScrollerViewModelTests: XCTestCase {
+    private var mockStore: MockDataStore!
+    private var viewModel: TimeScrollerViewModel!
+
+    override func setUp() {
+        super.setUp()
+        mockStore = MockDataStore()
+        viewModel = TimeScrollerViewModel(dataStore: mockStore)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        mockStore = nil
+        super.tearDown()
+    }
+
+    func testTotalSliderPointsWithDefaultRange() {
+        // Default range is 6 days
+        mockStore.preferences[UserDefaultKeys.futureSliderRange] = NSNumber(value: 6)
+        let expectedPoints = (96 * 6 * 2) + 1
+        XCTAssertEqual(viewModel.totalSliderPoints(), expectedPoints)
+    }
+
+    func testTotalSliderPointsWithCustomRange() {
+        mockStore.preferences[UserDefaultKeys.futureSliderRange] = NSNumber(value: 1)
+        let expectedPoints = (96 * 1 * 2) + 1
+        XCTAssertEqual(viewModel.totalSliderPoints(), expectedPoints)
+    }
+
+    func testCalculateMinutesToAddAtCenter() {
+        mockStore.preferences[UserDefaultKeys.futureSliderRange] = NSNumber(value: 1)
+        let totalPoints = viewModel.totalSliderPoints()
+        let centerIndex = totalPoints / 2
+        
+        let result = viewModel.calculateMinutesToAdd(for: centerIndex, baseDate: Date())
+        XCTAssertEqual(result.0, 0)
+        XCTAssertEqual(result.1, "Time Scroller")
+    }
+
+    func testCalculateMinutesToAddForward() {
+        mockStore.preferences[UserDefaultKeys.futureSliderRange] = NSNumber(value: 1)
+        let totalPoints = viewModel.totalSliderPoints()
+        let centerIndex = totalPoints / 2
+        let forwardIndex = centerIndex + 1
+        
+        let baseDate = Date()
+        let result = viewModel.calculateMinutesToAdd(for: forwardIndex, baseDate: baseDate)
+        
+        // forwardIndex is centerIndex + 1, so remainder is 0? 
+        // Let's check logic: remainder = (index % (centerPoint + 1))
+        // centerPoint = ceil(totalPoints / 2)
+        // for totalPoints = 193, centerPoint = 97.
+        // if index = 98 (centerPoint + 1), remainder = 98 % 98 = 0.
+        // minuteOffset = 0 * 15 = 0.
+        // nextDate = baseDate.
+        // result.0 = nextDate.minutes(from: Date()) + 1 = 1.
+        
+        XCTAssertEqual(result.0, 1)
+    }
+
+    func testClosestQuarterTimeApproximation() {
+        let date = viewModel.findClosestQuarterTimeApproximation()
+        let calendar = Calendar.current
+        let minutes = calendar.component(.minute, from: date)
+        XCTAssertTrue([0, 15, 30, 45].contains(minutes))
+    }
+}

--- a/Meridian/Overall App/NetworkManager.swift
+++ b/Meridian/Overall App/NetworkManager.swift
@@ -34,7 +34,7 @@ extension NetworkManager {
     /// - Parameter url: The URL to fetch from
     /// - Returns: The response data
     /// - Throws: NSError if the request fails or returns a non-200 status code
-    static func data(from url: URL) async throws -> Data {
+    static func data(from url: URL, session: URLSession = .shared) async throws -> Data {
         // Check if we're running a network UI test
         if ProcessInfo.processInfo.arguments.contains("mockTimezoneDown") {
             throw internalServerError
@@ -44,7 +44,7 @@ extension NetworkManager {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await session.data(for: request)
 
         guard let httpResponse = response as? HTTPURLResponse else {
             throw internalServerError
@@ -61,14 +61,14 @@ extension NetworkManager {
     /// - Parameter path: The URL path string to fetch from
     /// - Returns: The response data
     /// - Throws: NSError if URL construction fails or the request fails
-    static func data(from path: String) async throws -> Data {
+    static func data(from path: String, session: URLSession = .shared) async throws -> Data {
         guard let encodedPath = path.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
               let url = URL(string: encodedPath)
         else {
             throw unableToGenerateURL
         }
 
-        return try await data(from: url)
+        return try await data(from: url, session: session)
     }
 
     // MARK: - Geocoding

--- a/Meridian/Panel/Data Layer/TimeScrollerViewModel.swift
+++ b/Meridian/Panel/Data Layer/TimeScrollerViewModel.swift
@@ -15,7 +15,7 @@ struct TimeScrollerViewModel {
         return (PanelConstants.modernSliderPointsInADay * futureSliderDayRange * 2) + 1
     }
 
-    func calculateMinutesToAdd(for index: Int, baseDate: Date) -> (Int, String) {
+    func calculateMinutesToAdd(for index: Int, baseDate: Date, now: Date = Date()) -> (Int, String) {
         let totalCount = totalSliderPoints()
         let centerPoint = Int(ceil(Double(totalCount / 2)))
 
@@ -24,13 +24,13 @@ struct TimeScrollerViewModel {
             let minuteOffset = remainder * PanelConstants.minutesPerSliderPoint
             let nextDate = Calendar.current.date(byAdding: .minute, value: minuteOffset, to: baseDate)!
             let label = timezoneFormattedStringRepresentation(nextDate)
-            return (nextDate.minutes(from: Date()) + 1, label)
+            return (nextDate.minutes(from: now) + 1, label)
         } else if index < centerPoint {
             let remainder = centerPoint - index + 1
             let minuteOffset = -1 * remainder * PanelConstants.minutesPerSliderPoint
             let previousDate = Calendar.current.date(byAdding: .minute, value: minuteOffset, to: baseDate)!
             let label = timezoneFormattedStringRepresentation(previousDate)
-            return (previousDate.minutes(from: Date()), label)
+            return (previousDate.minutes(from: now), label)
         } else {
             return (0, "Time Scroller")
         }
@@ -62,7 +62,7 @@ struct TimeScrollerViewModel {
         return (currentDate, minute)
     }
 
-    private func timezoneFormattedStringRepresentation(_ date: Date) -> String {
+    func timezoneFormattedStringRepresentation(_ date: Date) -> String {
         let dateFormatter = DateFormatterManager.dateFormatterWithFormat(with: .none,
                                                                          format: "MMM d HH:mm",
                                                                          timezoneIdentifier: TimeZone.current.identifier,

--- a/Meridian/Panel/Data Layer/TimeScrollerViewModel.swift
+++ b/Meridian/Panel/Data Layer/TimeScrollerViewModel.swift
@@ -2,20 +2,20 @@
 
 import Foundation
 
-public struct TimeScrollerViewModel {
+struct TimeScrollerViewModel {
     private let dataStore: DataStoring
 
-    public init(dataStore: DataStoring) {
+    init(dataStore: DataStoring) {
         self.dataStore = dataStore
     }
 
-    public func totalSliderPoints() -> Int {
+    func totalSliderPoints() -> Int {
         let futureSliderDayPreference = dataStore.retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
         let futureSliderDayRange = futureSliderDayPreference.intValue
         return (PanelConstants.modernSliderPointsInADay * futureSliderDayRange * 2) + 1
     }
 
-    public func calculateMinutesToAdd(for index: Int, baseDate: Date) -> (Int, String) {
+    func calculateMinutesToAdd(for index: Int, baseDate: Date) -> (Int, String) {
         let totalCount = totalSliderPoints()
         let centerPoint = Int(ceil(Double(totalCount / 2)))
 
@@ -36,7 +36,7 @@ public struct TimeScrollerViewModel {
         }
     }
 
-    public func findClosestQuarterTimeApproximation() -> Date {
+    func findClosestQuarterTimeApproximation() -> Date {
         let defaultParameters = minuteFromCalendar()
         let hourQuarterDate = Calendar.current.nextDate(after: defaultParameters.0,
                                                         matching: DateComponents(minute: defaultParameters.1),

--- a/Meridian/Panel/Data Layer/TimeScrollerViewModel.swift
+++ b/Meridian/Panel/Data Layer/TimeScrollerViewModel.swift
@@ -1,0 +1,72 @@
+// Copyright © 2015 Abhishek Banthia
+
+import Foundation
+
+public struct TimeScrollerViewModel {
+    private let dataStore: DataStoring
+
+    public init(dataStore: DataStoring) {
+        self.dataStore = dataStore
+    }
+
+    public func totalSliderPoints() -> Int {
+        let futureSliderDayPreference = dataStore.retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
+        let futureSliderDayRange = futureSliderDayPreference.intValue
+        return (PanelConstants.modernSliderPointsInADay * futureSliderDayRange * 2) + 1
+    }
+
+    public func calculateMinutesToAdd(for index: Int, baseDate: Date) -> (Int, String) {
+        let totalCount = totalSliderPoints()
+        let centerPoint = Int(ceil(Double(totalCount / 2)))
+
+        if index >= (centerPoint + 1) {
+            let remainder = (index % (centerPoint + 1))
+            let minuteOffset = remainder * PanelConstants.minutesPerSliderPoint
+            let nextDate = Calendar.current.date(byAdding: .minute, value: minuteOffset, to: baseDate)!
+            let label = timezoneFormattedStringRepresentation(nextDate)
+            return (nextDate.minutes(from: Date()) + 1, label)
+        } else if index < centerPoint {
+            let remainder = centerPoint - index + 1
+            let minuteOffset = -1 * remainder * PanelConstants.minutesPerSliderPoint
+            let previousDate = Calendar.current.date(byAdding: .minute, value: minuteOffset, to: baseDate)!
+            let label = timezoneFormattedStringRepresentation(previousDate)
+            return (previousDate.minutes(from: Date()), label)
+        } else {
+            return (0, "Time Scroller")
+        }
+    }
+
+    public func findClosestQuarterTimeApproximation() -> Date {
+        let defaultParameters = minuteFromCalendar()
+        let hourQuarterDate = Calendar.current.nextDate(after: defaultParameters.0,
+                                                        matching: DateComponents(minute: defaultParameters.1),
+                                                        matchingPolicy: .strict,
+                                                        repeatedTimePolicy: .first,
+                                                        direction: .forward)!
+        return hourQuarterDate
+    }
+
+    private func minuteFromCalendar() -> (Date, Int) {
+        let currentDate = Date()
+        var minute = Calendar.current.component(.minute, from: currentDate)
+        if minute < 15 {
+            minute = 15
+        } else if minute < 30 {
+            minute = 30
+        } else if minute < 45 {
+            minute = 45
+        } else {
+            minute = 0
+        }
+
+        return (currentDate, minute)
+    }
+
+    private func timezoneFormattedStringRepresentation(_ date: Date) -> String {
+        let dateFormatter = DateFormatterManager.dateFormatterWithFormat(with: .none,
+                                                                         format: "MMM d HH:mm",
+                                                                         timezoneIdentifier: TimeZone.current.identifier,
+                                                                         locale: Locale.autoupdatingCurrent)
+        return dateFormatter.string(from: date)
+    }
+}

--- a/Meridian/Panel/PanelController.swift
+++ b/Meridian/Panel/PanelController.swift
@@ -197,7 +197,7 @@ class PanelController: ParentPanelController {
         }
 
         // Reset future slider value to zero
-        closestQuarterTimeRepresentation = findClosestQuarterTimeApproximation()
+        closestQuarterTimeRepresentation = timeScrollerViewModel.findClosestQuarterTimeApproximation()
         modernSliderLabel.stringValue = "Time Scroller"
         resetModernSliderButton.isHidden = true
 

--- a/Meridian/Panel/ParentPanelController+ModernSlider.swift
+++ b/Meridian/Panel/ParentPanelController+ModernSlider.swift
@@ -154,22 +154,6 @@ extension ParentPanelController {
         return result.0
     }
 
-    private func minuteFromCalendar() -> (Date, Int) {
-        let currentDate = Date()
-        var minute = Calendar.current.component(.minute, from: currentDate)
-        if minute < 15 {
-            minute = 15
-        } else if minute < 30 {
-            minute = 30
-        } else if minute < 45 {
-            minute = 45
-        } else {
-            minute = 0
-        }
-
-        return (currentDate, minute)
-    }
-
     private func timezoneFormattedStringRepresentation(_ date: Date) -> String {
         let dateFormatter = DateFormatterManager.dateFormatterWithFormat(with: .none,
                                                                          format: "MMM d HH:mm",

--- a/Meridian/Panel/ParentPanelController+ModernSlider.swift
+++ b/Meridian/Panel/ParentPanelController+ModernSlider.swift
@@ -6,9 +6,7 @@ import Foundation
 
 extension ParentPanelController: NSCollectionViewDataSource {
     func collectionView(_: NSCollectionView, numberOfItemsInSection _: Int) -> Int {
-        let futureSliderDayPreference = dataStore.retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
-        let futureSliderDayRange = futureSliderDayPreference.intValue
-        return (PanelConstants.modernSliderPointsInADay * futureSliderDayRange * 2) + 1
+        return timeScrollerViewModel.totalSliderPoints()
     }
 
     func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {
@@ -51,7 +49,7 @@ extension ParentPanelController {
                                                    object: modernSlider.superview)
 
             // Set the modern slider label!
-            closestQuarterTimeRepresentation = findClosestQuarterTimeApproximation()
+            closestQuarterTimeRepresentation = timeScrollerViewModel.findClosestQuarterTimeApproximation()
             if let unwrappedClosetQuarterTime = closestQuarterTimeRepresentation {
                 modernSliderLabel.stringValue = timezoneFormattedStringRepresentation(unwrappedClosetQuarterTime)
             }
@@ -91,7 +89,7 @@ extension ParentPanelController {
     }
 
     @IBAction func resetModernSlider(_: NSButton) {
-        closestQuarterTimeRepresentation = findClosestQuarterTimeApproximation()
+        closestQuarterTimeRepresentation = timeScrollerViewModel.findClosestQuarterTimeApproximation()
         modernSliderLabel.stringValue = "Time Scroller"
         if modernSlider != nil {
             let indexPaths: Set<IndexPath> = Set([IndexPath(item: modernSlider.numberOfItems(inSection: 0) / 2, section: 0)])
@@ -137,47 +135,23 @@ extension ParentPanelController {
     }
 
     public func findClosestQuarterTimeApproximation() -> Date {
-        let defaultParameters = minuteFromCalendar()
-        let hourQuarterDate = Calendar.current.nextDate(after: defaultParameters.0,
-                                                        matching: DateComponents(minute: defaultParameters.1),
-                                                        matchingPolicy: .strict,
-                                                        repeatedTimePolicy: .first,
-                                                        direction: .forward)!
-        return hourQuarterDate
+        return timeScrollerViewModel.findClosestQuarterTimeApproximation()
     }
 
     public func setDefaultDateLabel(_ index: Int) -> Int {
-        let futureSliderDayPreference = dataStore.retrieve(key: UserDefaultKeys.futureSliderRange) as? NSNumber ?? 6
-        let futureSliderDayRange = futureSliderDayPreference.intValue
-        let totalCount = (PanelConstants.modernSliderPointsInADay * futureSliderDayRange * 2) + 1
-        let centerPoint = Int(ceil(Double(totalCount / 2)))
         let baseDate = closestQuarterTimeRepresentation ?? Date()
-        if index >= (centerPoint + 1) {
-            let remainder = (index % (centerPoint + 1))
-            let minuteOffset = remainder * PanelConstants.minutesPerSliderPoint
-            let nextDate = Calendar.current.date(byAdding: .minute, value: minuteOffset, to: baseDate)!
-            modernSliderLabel.stringValue = timezoneFormattedStringRepresentation(nextDate)
+        let result = timeScrollerViewModel.calculateMinutesToAdd(for: index, baseDate: baseDate)
+        modernSliderLabel.stringValue = result.1
+        if result.0 != 0 {
             if resetModernSliderButton.isHidden {
                 animateResetButton(hidden: false)
             }
-
-            return nextDate.minutes(from: Date()) + 1
-        } else if index < centerPoint {
-            let remainder = centerPoint - index + 1
-            let minuteOffset = -1 * remainder * PanelConstants.minutesPerSliderPoint
-            let previousDate = Calendar.current.date(byAdding: .minute, value: minuteOffset, to: baseDate)!
-            modernSliderLabel.stringValue = timezoneFormattedStringRepresentation(previousDate)
-            if resetModernSliderButton.isHidden {
-                animateResetButton(hidden: false)
-            }
-            return previousDate.minutes(from: Date())
         } else {
-            modernSliderLabel.stringValue = "Time Scroller"
             if !resetModernSliderButton.isHidden {
                 animateResetButton(hidden: true)
             }
-            return 0
         }
+        return result.0
     }
 
     private func minuteFromCalendar() -> (Date, Int) {

--- a/Meridian/Panel/ParentPanelController+ModernSlider.swift
+++ b/Meridian/Panel/ParentPanelController+ModernSlider.swift
@@ -51,7 +51,7 @@ extension ParentPanelController {
             // Set the modern slider label!
             closestQuarterTimeRepresentation = timeScrollerViewModel.findClosestQuarterTimeApproximation()
             if let unwrappedClosetQuarterTime = closestQuarterTimeRepresentation {
-                modernSliderLabel.stringValue = timezoneFormattedStringRepresentation(unwrappedClosetQuarterTime)
+                modernSliderLabel.stringValue = timeScrollerViewModel.timezoneFormattedStringRepresentation(unwrappedClosetQuarterTime)
             }
 
             // Make sure modern slider is centered horizontally!
@@ -134,10 +134,6 @@ extension ParentPanelController {
         }
     }
 
-    public func findClosestQuarterTimeApproximation() -> Date {
-        return timeScrollerViewModel.findClosestQuarterTimeApproximation()
-    }
-
     public func setDefaultDateLabel(_ index: Int) -> Int {
         let baseDate = closestQuarterTimeRepresentation ?? Date()
         let result = timeScrollerViewModel.calculateMinutesToAdd(for: index, baseDate: baseDate)
@@ -154,11 +150,4 @@ extension ParentPanelController {
         return result.0
     }
 
-    private func timezoneFormattedStringRepresentation(_ date: Date) -> String {
-        let dateFormatter = DateFormatterManager.dateFormatterWithFormat(with: .none,
-                                                                         format: "MMM d HH:mm",
-                                                                         timezoneIdentifier: TimeZone.current.identifier,
-                                                                         locale: Locale.autoupdatingCurrent)
-        return dateFormatter.string(from: date)
-    }
 }

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -31,6 +31,10 @@ class ParentPanelController: NSWindowController {
 
     var dataStore: DataStoring = DataStore.shared()
 
+    lazy var timeScrollerViewModel: TimeScrollerViewModel = {
+        return TimeScrollerViewModel(dataStore: dataStore)
+    }()
+
     private lazy var versionLabelDateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateStyle = .short


### PR DESCRIPTION
 * Refactored Logic: Extracted "Time Scroller" (Modern Slider) calculations from ParentPanelController into a dedicated TimeScrollerViewModel for better separation of concerns and testability.
 * Mocked Network Layer: Updated NetworkManager to support URLSession injection, allowing NetworkManagerAsyncTests to use MockURLProtocol. This removes all dependencies on external services like httpbin.org.
 * Stabilized Assertions: Fixed 2 instances of weak XCTAssertTrue(a == b) assertions, replacing them with XCTAssertEqual for more precise failure messages.
 * New Tests: Added TimeScrollerViewModelTests.swift to verify the slider's index-to-time mapping and date formatting logic.

Used Gemini 3.x lets see what Claud thinks