### PR TITLE
Fix autoupdate not working for some existing users

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -126,10 +126,28 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func enableAutoUpdateByDefault() {
         let hasSetAutoUpdate = "HasSetAutoUpdateDefault"
-        guard !UserDefaults.standard.bool(forKey: hasSetAutoUpdate) else { return }
-        UserDefaults.standard.set(true, forKey: hasSetAutoUpdate)
-        updaterController.updater.automaticallyChecksForUpdates = true
-        updaterController.updater.automaticallyDownloadsUpdates = true
+        if !UserDefaults.standard.bool(forKey: hasSetAutoUpdate) {
+            UserDefaults.standard.set(true, forKey: hasSetAutoUpdate)
+            updaterController.updater.automaticallyChecksForUpdates = true
+            updaterController.updater.automaticallyDownloadsUpdates = true
+        }
+
+        // Migration: users who went through the pre-2.12.0 broken period may have
+        // automaticallyDownloadsUpdates = true but automaticallyChecksForUpdates = false.
+        // Sparkle requires both to be true for scheduled background checks to run,
+        // so sync them once.
+        let hasFixedAutoUpdateSync = "HasFixedAutoUpdateSync"
+        if !UserDefaults.standard.bool(forKey: hasFixedAutoUpdateSync) {
+            UserDefaults.standard.set(true, forKey: hasFixedAutoUpdateSync)
+            if updaterController.updater.automaticallyDownloadsUpdates {
+                updaterController.updater.automaticallyChecksForUpdates = true
+            }
+        }
+
+        let checks = updaterController.updater.automaticallyChecksForUpdates
+        let downloads = updaterController.updater.automaticallyDownloadsUpdates
+        let interval = updaterController.updater.updateCheckInterval
+        Logger.production("Sparkle autoupdate: checks=\(checks) downloads=\(downloads) interval=\(Int(interval))s")
     }
 
     // MARK: - Dock Menu


### PR DESCRIPTION
## Summary

- Sparkle requires **both** `automaticallyChecksForUpdates` and `automaticallyDownloadsUpdates` to be `true` for scheduled background checks to run
- Users who went through the pre-2.12.0 broken period could end up with only `automaticallyDownloadsUpdates=true`, so Sparkle would find the appcast URL, check on-demand, but never schedule a background check
- Adds a one-time migration (`HasFixedAutoUpdateSync`) that sets `automaticallyChecksForUpdates=true` for any user who has auto-download enabled but checking disabled
- Adds startup logging of both settings + interval so silent failures leave a trace in Console.app

Fixes #75

## Test plan

- [ ] Fresh install: both settings enabled, migration key written, log line emitted
- [ ] Existing user with broken state (checks=false, downloads=true): migration sets checks=true
- [ ] Existing user with both off: migration does not enable checks
- [ ] Migration runs only once (re-launch doesn't change settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)