### PR TITLE
Fix last-checked timestamp not updating after automatic update checks

### DIFF
--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -159,6 +159,10 @@ private struct AutoUpdateToggle: View {
                     autoUpdate = updater.automaticallyDownloadsUpdates
                     lastCheckDate = updater.lastUpdateCheckDate
                 }
+                .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
+                    guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+                    lastCheckDate = appDelegate.updaterController.updater.lastUpdateCheckDate
+                }
 
             Text(lastCheckedText)
                 .font(.custom("Avenir-Light", size: 11))


### PR DESCRIPTION
## Summary
- The "Last checked" date in About → Automatically download updates was only read on `onAppear` and never refreshed
- Added `onReceive(UserDefaults.didChangeNotification)` so the timestamp updates whenever Sparkle writes `SULastCheckTime` after a background check

## Test plan
- [ ] Open About tab, note the "Last checked" timestamp
- [ ] Trigger an update check (Check Now button or wait for scheduled check)
- [ ] Verify the "Last checked" timestamp updates without needing to close/reopen the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)