### PR TITLE
Fix Sparkle auto-install stalling for menubar apps

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -9,7 +9,9 @@ import Sparkle
 open class AppDelegate: NSObject, NSApplicationDelegate {
     internal lazy var panelController = PanelController(windowNibName: .panel)
     private var statusBarHandler: StatusItemHandler!
-    let updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
+    lazy var updaterController: SPUStandardUpdaterController = {
+        SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
+    }()
     private var memoryPressureSource: DispatchSourceMemoryPressure?
     private var backfillTask: Task<Void, Never>?
     private var sentinelTask: Task<Void, Never>?
@@ -244,5 +246,21 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
 
     open func invalidateMenubarTimer(_ showIcon: Bool) {
         statusBarHandler.invalidateTimer(showIcon: showIcon, isSyncing: true)
+    }
+}
+
+// MARK: - Sparkle Auto-Install for Menubar Apps
+
+// Meridian runs with LSUIElement=true, so users rarely quit it. Sparkle's
+// default "silent install on quit" behavior leaves downloaded updates parked
+// indefinitely. Taking control here and invoking the immediate install handler
+// finishes the update by relaunching the process transparently.
+extension AppDelegate: SPUUpdaterDelegate {
+    public func updater(_: SPUUpdater,
+                        willInstallUpdateOnQuit item: SUAppcastItem,
+                        immediateInstallationBlock immediateInstallHandler: @escaping () -> Void) -> Bool {
+        Logger.production("Sparkle: update \(item.versionString) ready; installing and relaunching now")
+        immediateInstallHandler()
+        return true
     }
 }

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Validates the Sparkle "install on quit" fix for menubar apps.
+#
+# Meridian is LSUIElement=true; users rarely quit it, so Sparkle's default
+# silent-install-on-quit never triggers. The fix makes AppDelegate conform
+# to SPUUpdaterDelegate and immediately installs the downloaded update via
+# the willInstallUpdateOnQuit handler.
+set -eu
+
+cd "$(dirname "$0")/.."
+
+fail() { echo "FAIL: $1"; exit 1; }
+
+grep -q "extension AppDelegate: SPUUpdaterDelegate" Meridian/AppDelegate.swift \
+    || fail "AppDelegate does not conform to SPUUpdaterDelegate"
+
+grep -q "willInstallUpdateOnQuit" Meridian/AppDelegate.swift \
+    || fail "willInstallUpdateOnQuit delegate method not implemented"
+
+grep -q "immediateInstallationBlock\|immediateInstallHandler" Meridian/AppDelegate.swift \
+    || fail "immediateInstallHandler not invoked"
+
+grep -qE "updaterDelegate:\s*self" Meridian/AppDelegate.swift \
+    || fail "updaterController not constructed with self as delegate"
+
+# Must compile.
+xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \
+    CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= \
+    -quiet > /tmp/meridian_build.log 2>&1 \
+    || { tail -40 /tmp/meridian_build.log; fail "build failed"; }
+
+echo "Validation: all checks passed"


### PR DESCRIPTION
## Summary

- Meridian is `LSUIElement=true`; users rarely quit it, so Sparkle's silent-install-on-quit never fires. A machine here was still running 2.17.3 four days after 2.17.4 was downloaded, with `Autoupdate` parked waiting for a quit that never came.
- Conform `AppDelegate` to `SPUUpdaterDelegate` and implement `willInstallUpdateOnQuit` to return `true` and immediately invoke the install handler. Sparkle installs and relaunches transparently.

## Why the user sees "Last checked: 4/14"

Sparkle stops scheduling new checks once an update is already queued for install on quit, so the timestamp freezes until the install completes.

## Test plan

- [x] `scripts/validate_feature.sh` — static checks + Debug build
- [x] `xcodebuild test` — all 156 unit tests pass
- [x] `swiftlint` — 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)