### PR TITLE
Log Sparkle update-check lifecycle

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,16 @@ The release script (`scripts/release.sh`) handles everything:
 
 **Release notes style**: Keep notes short and user-facing. One line per change describing what was fixed or added — not why or how. No internal details (class names, property names, root cause analysis). Write for customers, not developers. Reference closing GitHub issues inline with the relevant change (e.g. "Add keyboard shortcuts (#50)"). Good: "Fix sunrise/sunset not displaying for some timezones". Bad: "Sunrise/sunset was only displayed when selectionType == .city; now checks for coordinates instead".
 
+**Post-release cleanup** (do this after every release):
+```bash
+git fetch --prune origin                              # prune stale remote refs
+git branch --merged main | grep -v '^\*\|  main$'     # list local branches fully merged into main
+# For each merged branch:
+git branch -d <branch>                                # delete local
+git push origin --delete <branch>                     # delete remote (if remote still has it)
+```
+Only delete branches whose PR shows MERGED in `gh pr list --state all`. Never force-delete (`-D`) unless the branch is confirmed merged — use `-d` so git refuses if commits would be lost.
+
 **Prerequisites** (one-time setup, see `developer-id.md`):
 - Developer ID Application certificate in keychain
 - Notarization credentials stored: `xcrun notarytool store-credentials "meridian-notary"`

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -263,4 +263,30 @@ extension AppDelegate: SPUUpdaterDelegate {
         immediateInstallHandler()
         return true
     }
+
+    public func updater(_: SPUUpdater,
+                        mayPerform updateCheck: SPUUpdateCheck) throws {
+        Logger.production("Sparkle: checking for updates (\(describe(updateCheck)))")
+    }
+
+    public func updater(_: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        Logger.production("Sparkle: found update \(item.versionString)")
+    }
+
+    public func updaterDidNotFindUpdate(_: SPUUpdater) {
+        Logger.production("Sparkle: no update available")
+    }
+
+    public func updater(_: SPUUpdater, didAbortWithError error: Error) {
+        Logger.production("Sparkle: update check aborted — \(error.localizedDescription)")
+    }
+
+    private func describe(_ check: SPUUpdateCheck) -> String {
+        switch check {
+        case .updates: return "user-initiated"
+        case .updatesInBackground: return "scheduled"
+        case .updateInformation: return "informational"
+        @unknown default: return "unknown"
+        }
+    }
 }

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -1,32 +1,46 @@
 #!/bin/bash
-# Validates the Sparkle "install on quit" fix for menubar apps.
+# Validates Sparkle update-check logging.
 #
-# Meridian is LSUIElement=true; users rarely quit it, so Sparkle's default
-# silent-install-on-quit never triggers. The fix makes AppDelegate conform
-# to SPUUpdaterDelegate and immediately installs the downloaded update via
-# the willInstallUpdateOnQuit handler.
+# AppDelegate's SPUUpdaterDelegate extension should log when a scheduled or
+# user-initiated check starts, when it finds an update, when it finds none,
+# and when it aborts with an error. Without these hooks, users can't tell
+# from Console.app whether Sparkle is running its scheduled checks at all.
 set -eu
 
 cd "$(dirname "$0")/.."
 
 fail() { echo "FAIL: $1"; exit 1; }
+ok()   { echo "OK:   $1"; }
 
-grep -q "extension AppDelegate: SPUUpdaterDelegate" Meridian/AppDelegate.swift \
-    || fail "AppDelegate does not conform to SPUUpdaterDelegate"
+FILE="Meridian/AppDelegate.swift"
 
-grep -q "willInstallUpdateOnQuit" Meridian/AppDelegate.swift \
-    || fail "willInstallUpdateOnQuit delegate method not implemented"
+grep -qE "mayPerform(UpdateCheck)? " "$FILE"              || fail "check-start hook (mayPerform:) not implemented"
+ok "check-start hook implemented"
 
-grep -q "immediateInstallationBlock\|immediateInstallHandler" Meridian/AppDelegate.swift \
-    || fail "immediateInstallHandler not invoked"
+grep -q 'Sparkle: checking for updates' "$FILE"           || fail "check-start log message missing"
+ok "check-start log message present"
 
-grep -qE "updaterDelegate:\s*self" Meridian/AppDelegate.swift \
-    || fail "updaterController not constructed with self as delegate"
+grep -q "didFindValidUpdate" "$FILE"                      || fail "didFindValidUpdate hook not implemented"
+grep -q 'Sparkle: found update' "$FILE"                   || fail "found-update log message missing"
+ok "found-update hook + log present"
+
+grep -q "updaterDidNotFindUpdate" "$FILE"                 || fail "updaterDidNotFindUpdate hook not implemented"
+grep -q 'Sparkle: no update available' "$FILE"            || fail "no-update log message missing"
+ok "no-update hook + log present"
+
+grep -q "didAbortWithError" "$FILE"                       || fail "didAbortWithError hook not implemented"
+grep -q 'Sparkle: update check aborted' "$FILE"           || fail "abort log message missing"
+ok "abort hook + log present"
+
+# Existing install-on-quit log must still be present (regression guard).
+grep -q "willInstallUpdateOnQuit" "$FILE"                 || fail "willInstallUpdateOnQuit hook regressed"
+ok "existing install-on-quit hook preserved"
 
 # Must compile.
 xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \
     CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= \
     -quiet > /tmp/meridian_build.log 2>&1 \
     || { tail -40 /tmp/meridian_build.log; fail "build failed"; }
+ok "build succeeded"
 
 echo "Validation: all checks passed"


### PR DESCRIPTION
## Summary
- Add `SPUUpdaterDelegate` hooks that log every Sparkle update-check lifecycle event — check start, update found, no update, and abort — so Console.app shows whether scheduled background checks are running
- Document post-release branch cleanup procedure in CLAUDE.md

## Why
Before this change the only Sparkle-related entries in our production log were the startup config line and the install-on-quit line. If a user reported "updates don't work," there was no way to tell from logs whether Sparkle was even firing its scheduled checks.

## Test plan
- [x] `scripts/validate_feature.sh` passes (greps for each hook + log message, then builds)
- [x] Unit tests pass (`xcodebuild test`)
- [x] SwiftLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)