### PR TITLE
Fix last check date sync, label defaulting, tooltips, and Copy All (#81 #82 #84 #86)

### DIFF
--- a/Meridian/Panel/PanelController.swift
+++ b/Meridian/Panel/PanelController.swift
@@ -94,6 +94,7 @@ class PanelController: ParentPanelController {
         let drag = PanelDragHandleView()
         drag.translatesAutoresizingMaskIntoConstraints = false
         drag.isHidden = true
+        drag.toolTip = "Drag to move the panel"
         contentView.addSubview(drag)
         NSLayoutConstraint.activate([
             drag.topAnchor.constraint(equalTo: contentView.topAnchor, constant: PanelLayout.dragHandleTopAnchor),

--- a/Meridian/Panel/ParentPanelController+Actions.swift
+++ b/Meridian/Panel/ParentPanelController+Actions.swift
@@ -31,6 +31,22 @@ extension ParentPanelController {
         window?.contentView?.makeToast("Copied to Clipboard".localized())
     }
 
+    @objc func copyAllTimezonesToClipboard() {
+        let timezones = dataStore.timezoneObjects()
+        guard !timezones.isEmpty else { return }
+
+        let parts = timezones.map { timezone -> String in
+            let ops = TimezoneDataOperations(with: timezone, store: dataStore)
+            let timeStr = ops.time(with: futureSliderValue)
+            let label = timezone.formattedTimezoneLabel()
+            return "\(timeStr) \(label)"
+        }
+        let pasteboard = NSPasteboard.general
+        pasteboard.declareTypes([.string], owner: nil)
+        pasteboard.setString(parts.joined(separator: " / "), forType: .string)
+        window?.contentView?.makeToast("Copied to Clipboard".localized())
+    }
+
     @objc func reportIssue() {
         guard let url = URL(string: AboutUsConstants.GitHubIssuesURL) else { return }
         NSWorkspace.shared.open(url)

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -104,6 +104,11 @@ class ParentPanelController: NSWindowController {
                 self?.modernSlider?.reloadData()
             }
             .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in self?.updateVersionStatusLabel() }
+            .store(in: &cancellables)
     }
 
     override func awakeFromNib() {
@@ -117,6 +122,9 @@ class ParentPanelController: NSWindowController {
 
         // Setup settings button
         settingsButton.image = NSImage(systemSymbolName: "gearshape", accessibilityDescription: "Settings")
+
+        // Setup copy-all button next to settings button
+        setupCopyAllButton()
 
         // Setup version + last checked label
         updateVersionStatusLabel()
@@ -159,6 +167,37 @@ class ParentPanelController: NSWindowController {
         roundedDateView.layer?.cornerRadius = 12.0
         roundedDateView.layer?.masksToBounds = false
         roundedDateView.layer?.backgroundColor = NSColor.controlBackgroundColor.cgColor
+    }
+
+    private func setupCopyAllButton() {
+        guard let footer = settingsButton?.superview else { return }
+
+        // Detach the version label's leading from the settings button so we can insert the copy button between them.
+        let oldLeading = footer.constraints.first {
+            $0.firstItem === versionStatusLabel && $0.firstAttribute == .leading &&
+            $0.secondItem === settingsButton && $0.secondAttribute == .trailing
+        }
+        oldLeading?.isActive = false
+
+        let btn = NSButton()
+        btn.translatesAutoresizingMaskIntoConstraints = false
+        btn.bezelStyle = .recessed
+        btn.isBordered = false
+        btn.imagePosition = .imageOnly
+        btn.image = NSImage(systemSymbolName: "doc.on.doc", accessibilityDescription: "Copy All Timezones")
+        btn.contentTintColor = .secondaryLabelColor
+        btn.toolTip = "Copy all timezones to clipboard"
+        btn.target = self
+        btn.action = #selector(copyAllTimezonesToClipboard)
+        footer.addSubview(btn)
+
+        NSLayoutConstraint.activate([
+            btn.centerYAnchor.constraint(equalTo: footer.centerYAnchor),
+            btn.leadingAnchor.constraint(equalTo: settingsButton.trailingAnchor, constant: 4),
+            btn.widthAnchor.constraint(equalToConstant: 22),
+            btn.heightAnchor.constraint(equalToConstant: 22),
+            versionStatusLabel.leadingAnchor.constraint(equalTo: btn.trailingAnchor, constant: 4)
+        ])
     }
 
     func updateVersionStatusLabel() {

--- a/Meridian/Panel/UI/TimezoneCellView.swift
+++ b/Meridian/Panel/UI/TimezoneCellView.swift
@@ -124,6 +124,7 @@ class TimezoneCellView: NSTableCellView {
 
         extraOptions.image = NSImage(systemSymbolName: "ellipsis.circle", accessibilityDescription: "Options")
         extraOptions.alternateImage = NSImage(systemSymbolName: "ellipsis.circle.fill", accessibilityDescription: "Options")
+        extraOptions.toolTip = "Add a note to this timezone"
 
         currentLocationIndicator.image = NSImage(systemSymbolName: "location.fill", accessibilityDescription: "Current Location")
 

--- a/Meridian/Preferences/General/TimezoneAdditionHandler.swift
+++ b/Meridian/Preferences/General/TimezoneAdditionHandler.swift
@@ -373,12 +373,15 @@ class TimezoneAdditionHandler: NSObject {
     private func cleanupAfterInstallingTimezone() {
         guard let host = host else { return }
         let data = TimezoneData()
-        data.setLabel(UserDefaultKeys.emptyString)
 
         let currentSelection = host.searchResultsDataSource.retrieveSelectedTimezone(host.availableTimezoneTableView.selectedRow)
 
         let metaInfo = metadata(for: currentSelection)
         data.timezoneID = metaInfo.0.name
+
+        let cityComponents = metaInfo.0.name.split(separator: "/")
+        let defaultLabel = cityComponents.last.map { String($0).replacingOccurrences(of: "_", with: " ") } ?? metaInfo.0.name
+        data.setLabel(defaultLabel)
         data.formattedAddress = metaInfo.1.formattedName
         data.selectionType = .timezone
         data.isSystemTimezone = metaInfo.0.name == NSTimeZone.system.identifier


### PR DESCRIPTION
## Summary

- **#81**: Panel footer now refreshes the Sparkle last-check timestamp live via `UserDefaults.didChangeNotification` instead of only on panel open, keeping it in sync with the About screen
- **#82**: When adding a raw timezone (e.g. America/Denver), the label now auto-defaults to the city component ("Denver") instead of empty string; works for multi-level IDs and UTC
- **#84**: Added tooltip "Add a note to this timezone" to the ellipsis options button on each row; added "Drag to move the panel" to the float-mode drag handle so the UI is self-explanatory
- **#86**: Added a Copy All button (doc.on.doc icon) to the panel footer — copies all timezone times at the current slider position as "6:15 PM Denver / 8:15 PM Chicago / ..." to the clipboard

## Test plan

- [ ] Open panel, trigger a Sparkle update check — confirm the footer timestamp updates without reopening the panel
- [ ] Add a raw timezone from the list (e.g. America/New_York) — confirm label field pre-fills with "New York" not empty
- [ ] Add UTC — confirm label shows "UTC"
- [ ] Hover over the ellipsis button on a timezone row — confirm tooltip appears
- [ ] Enable float mode, hover over the dots at the top — confirm "Drag to move the panel" tooltip
- [ ] Scroll the time slider to a non-current time, click the copy button — confirm clipboard contains all timezones at that time in "HH:MM TZ / HH:MM TZ" format

🤖 Generated with [Claude Code](https://claude.com/claude-code)