### PR TITLE
Fix slider sensitivity, button rendering, and ghost-button bugs (#85)

### DIFF
--- a/Meridian/Panel/Modern Slider/ModernSliderViews.swift
+++ b/Meridian/Panel/Modern Slider/ModernSliderViews.swift
@@ -46,6 +46,9 @@ class DraggableClipView: NSClipView {
     private var clickPoint: NSPoint!
     private var trackingArea: NSTrackingArea?
 
+    // Called when the user lifts the mouse after dragging, so the controller can snap to the nearest item.
+    var onDragEnded: (() -> Void)?
+
     override func mouseDown(with event: NSEvent) {
         super.mouseDown(with: event)
         clickPoint = event.locationInWindow
@@ -55,18 +58,19 @@ class DraggableClipView: NSClipView {
             let newEvent = window?.nextEvent(matching: [.leftMouseDragged, .leftMouseUp, .leftMouseDown])
             switch newEvent?.type {
             case .leftMouseDragged:
-                let newPoint = newEvent?.locationInWindow
-                let xCoOrdinate = clickPoint.x - (newPoint?.x ?? 0)
-                let newOrigin = NSPoint(x: bounds.origin.x + xCoOrdinate,
-                                        y: 0)
+                guard let newPoint = newEvent?.locationInWindow else { break }
+                let xDelta = clickPoint.x - newPoint.x
+                let newOrigin = NSPoint(x: bounds.origin.x + xDelta, y: 0)
                 let constrainedRect = constrainBoundsRect(NSRect(origin: newOrigin, size: bounds.size))
                 scroll(to: constrainedRect.origin)
                 superview?.reflectScrolledClipView(self)
+                clickPoint = newPoint
             case .leftMouseDown:
                 clickPoint = event.locationInWindow
             case .leftMouseUp:
                 clickPoint = nil
                 gestureInProgress = false
+                onDragEnded?()
             default:
                 Logger.debug("Default mouse event occurred for \(event.type)")
             }

--- a/Meridian/Panel/ParentPanelController+ModernSlider.swift
+++ b/Meridian/Panel/ParentPanelController+ModernSlider.swift
@@ -29,6 +29,11 @@ extension ParentPanelController {
                 scrollView.scrollerStyle = NSScroller.Style.overlay
             }
 
+            for btn in [goBackwardsButton, goForwardButton] {
+                btn?.imagePosition = .imageOnly
+                btn?.isBordered = false
+                btn?.bezelStyle = .recessed
+            }
             goBackwardsButton.image = NSImage(systemSymbolName: "chevron.left", accessibilityDescription: "Go backwards")
             goForwardButton.image = NSImage(systemSymbolName: "chevron.right", accessibilityDescription: "Go forward")
 
@@ -48,14 +53,23 @@ extension ParentPanelController {
                                                    name: NSView.boundsDidChangeNotification,
                                                    object: modernSlider.superview)
 
+            // Wire up snap-to-grid after a drag gesture ends.
+            if let clipView = modernSlider.superview as? DraggableClipView {
+                clipView.onDragEnded = { [weak self] in
+                    self?.snapSliderToCurrentItem()
+                }
+            }
+
             // Set the modern slider label!
             closestQuarterTimeRepresentation = timeScrollerViewModel.findClosestQuarterTimeApproximation()
             if let unwrappedClosetQuarterTime = closestQuarterTimeRepresentation {
                 modernSliderLabel.stringValue = timeScrollerViewModel.timezoneFormattedStringRepresentation(unwrappedClosetQuarterTime)
             }
 
-            // Make sure modern slider is centered horizontally!
-            let indexPaths: Set<IndexPath> = Set([IndexPath(item: modernSlider.numberOfItems(inSection: 0) / 2, section: 0)])
+            // Make sure modern slider is centered horizontally and seed currentCenterIndexPath.
+            let centerItem = modernSlider.numberOfItems(inSection: 0) / 2
+            currentCenterIndexPath = centerItem
+            let indexPaths: Set<IndexPath> = Set([IndexPath(item: centerItem, section: 0)])
             modernSlider.scrollToItems(at: indexPaths, scrollPosition: .centeredHorizontally)
         }
     }
@@ -68,24 +82,25 @@ extension ParentPanelController {
         navigateModernSliderToSpecificIndex(-1)
     }
 
-    private func animateResetButton(hidden: Bool) {
+    private func animateButton(_ button: NSButton, hidden: Bool) {
+        if !hidden {
+            button.alphaValue = 0
+            button.isHidden = false
+        }
         NSAnimationContext.runAnimationGroup({ context in
             context.duration = 0.5
-            context.timingFunction = CAMediaTimingFunction(name: hidden ? CAMediaTimingFunctionName.easeOut : CAMediaTimingFunctionName.easeIn)
-            resetModernSliderButton.animator().alphaValue = hidden ? 0.0 : 1.0
-        }, completionHandler: { [weak self] in
-            guard let strongSelf = self else { return }
-            strongSelf.resetModernSliderButton.animator().isHidden = hidden
-        })
+            context.timingFunction = CAMediaTimingFunction(name: hidden ? .easeOut : .easeIn)
+            button.animator().alphaValue = hidden ? 0.0 : 1.0
+        }, completionHandler: hidden ? { button.isHidden = true } : nil)
+    }
+
+    private func animateResetButton(hidden: Bool) {
+        animateButton(resetModernSliderButton, hidden: hidden)
     }
 
     private func setAccessoryButtons(hidden: Bool) {
-        NSAnimationContext.runAnimationGroup({ context in
-            context.duration = 0.5
-            context.timingFunction = CAMediaTimingFunction(name: hidden ? CAMediaTimingFunctionName.easeOut : CAMediaTimingFunctionName.easeIn)
-            goForwardButton.animator().alphaValue = hidden ? 0.0 : 1.0
-            goBackwardsButton.animator().alphaValue = hidden ? 0.0 : 1.0
-        }, completionHandler: nil)
+        animateButton(goForwardButton, hidden: hidden)
+        animateButton(goBackwardsButton, hidden: hidden)
     }
 
     @IBAction func resetModernSlider(_: NSButton) {
@@ -105,16 +120,19 @@ extension ParentPanelController {
         }
     }
 
+    private func snapSliderToCurrentItem() {
+        guard currentCenterIndexPath >= 0 else { return }
+        modernSlider.scrollToItems(at: [IndexPath(item: currentCenterIndexPath, section: 0)],
+                                   scrollPosition: .centeredHorizontally)
+    }
+
     private func navigateModernSliderToSpecificIndex(_ index: Int) {
-        guard let contentView = modernSlider.superview as? NSClipView else {
-            return
-        }
-        let changedOrigin = contentView.documentVisibleRect.origin
-        let newPoint = NSPoint(x: changedOrigin.x + contentView.frame.width / 2, y: changedOrigin.y)
-        if let indexPath = modernSlider.indexPathForItem(at: newPoint) {
-            let previousIndexPath = IndexPath(item: indexPath.item + index, section: indexPath.section)
-            modernSlider.scrollToItems(at: Set([previousIndexPath]), scrollPosition: .centeredHorizontally)
-        }
+        guard modernSlider != nil else { return }
+        let total = modernSlider.numberOfItems(inSection: 0)
+        let base = currentCenterIndexPath >= 0 ? currentCenterIndexPath : total / 2
+        let target = max(0, min(base + index, total - 1))
+        modernSlider.scrollToItems(at: [IndexPath(item: target, section: 0)],
+                                   scrollPosition: .centeredHorizontally)
     }
 
     @objc func collectionViewDidScroll(_ notification: NSNotification) {


### PR DESCRIPTION
## Summary

- **Drag accumulation bug**: `DraggableClipView.mouseDown` never updated `clickPoint` between events, so each drag event computed the full offset from the *original* click and added it to the *already-moved* position — exponential sensitivity. Fixed to use per-event delta by updating `clickPoint` after each scroll.
- **Snap to 15-min boundary**: After mouse-up, `onDragEnded` fires so the controller snaps the slider to the nearest item, preventing it from resting visually between marks.
- **Button silent failures**: `navigateModernSliderToSpecificIndex` used `indexPathForItem(at:)` which returns `nil` when the slider rests between items, silently dropping `<<`/`>>` clicks. Now uses `currentCenterIndexPath` (seeded at setup so it's valid from first use).
- **Button rendering**: XIB buttons had `<<`/`>>` text showing alongside SF Symbol chevrons because `imagePosition` was never set to `.imageOnly`. Fixed to icon-only recessed style.
- **Ghost buttons after reset**: `setAccessoryButtons` only set `alphaValue=0` without `isHidden=true`, leaving invisible but clickable buttons. Extracted `animateButton(_:hidden:)` that properly manages `isHidden` before/after animation for both fade-in and fade-out.

## Test plan

- [ ] Drag the slider slowly — confirm 1:1 tracking with the mouse, no runaway acceleration
- [ ] Release the slider mid-drag — confirm it snaps to the nearest 15-min mark
- [ ] Click `<` / `>` buttons while slider is at center (not yet scrolled) — confirm they work immediately
- [ ] Drag slider between items then click `<`/`>` — confirm no silent drop
- [ ] Confirm buttons show only chevron icons, no `<<`/`>>` text
- [ ] Reset slider, confirm forward/back buttons fade out cleanly; scroll again, confirm they fade in without popping

🤖 Generated with [Claude Code](https://claude.com/claude-code)