### PR TITLE
Add direct time entry by double-clicking a timezone cell (#85)

### DIFF
--- a/Meridian/Panel/ParentPanelController+ModernSlider.swift
+++ b/Meridian/Panel/ParentPanelController+ModernSlider.swift
@@ -135,6 +135,25 @@ extension ParentPanelController {
                                    scrollPosition: .centeredHorizontally)
     }
 
+    func jumpToSliderMinutes(_ minutes: Int) {
+        guard modernSlider != nil else {
+            setTimezoneDatasourceSlider(sliderValue: minutes)
+            mainTableView.reloadData()
+            return
+        }
+        let total = modernSlider.numberOfItems(inSection: 0)
+        let center = total / 2
+        let itemsFromCenter = minutes / PanelConstants.minutesPerSliderPoint
+        let target = max(0, min(center + itemsFromCenter, total - 1))
+        currentCenterIndexPath = target
+        let minutesToAdd = setDefaultDateLabel(target)
+        setTimezoneDatasourceSlider(sliderValue: minutesToAdd)
+        mainTableView.reloadData()
+        modernSlider.scrollToItems(at: [IndexPath(item: target, section: 0)], scrollPosition: .centeredHorizontally)
+        setAccessoryButtons(hidden: minutesToAdd == 0)
+        animateResetButton(hidden: minutesToAdd == 0)
+    }
+
     @objc func collectionViewDidScroll(_ notification: NSNotification) {
         guard let contentView = notification.object as? NSClipView else {
             return

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -406,7 +406,9 @@ extension ParentPanelController {
         }
 
         let dataOperation = TimezoneDataOperations(with: model, store: dataStore)
-        cellView.time.stringValue = dataOperation.time(with: futureSliderValue)
+        if !cellView.isEditingTime {
+            cellView.time.stringValue = dataOperation.time(with: futureSliderValue)
+        }
         cellView.sunriseSetTime.stringValue = dataOperation.formattedSunriseTime(with: futureSliderValue)
         cellView.sunriseSetTime.lineBreakMode = .byClipping
 

--- a/Meridian/Panel/UI/TimezoneCellView.swift
+++ b/Meridian/Panel/UI/TimezoneCellView.swift
@@ -28,6 +28,8 @@ class TimezoneCellView: NSTableCellView {
 
     var rowNumber: NSInteger = -1
     var isPopoverDisplayed: Bool = false
+    var timezoneIdentifier: String = ""
+    private(set) var isEditingTime: Bool = false
 
     override func awakeFromNib() {
         if ProcessInfo.processInfo.arguments.contains(UserDefaultKeys.testingLaunchArgument) {
@@ -188,6 +190,10 @@ class TimezoneCellView: NSTableCellView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        if event.clickCount == 2 {
+            beginTimeEntry()
+            return
+        }
         if event.clickCount == 1 {
             // Text is copied in the following format: Chicago - 1625185925
             let clipboardCopy = "\(customName.stringValue) - \(time.stringValue)"
@@ -201,9 +207,91 @@ class TimezoneCellView: NSTableCellView {
         }
     }
 
+    private func beginTimeEntry() {
+        guard !timezoneIdentifier.isEmpty else { return }
+        isEditingTime = true
+        time.isEditable = true
+        time.isBezeled = true
+        time.bezelStyle = .roundedBezel
+        time.delegate = self
+        time.selectText(nil)
+    }
+
+    private func restoreTimeField() {
+        isEditingTime = false
+        time.delegate = nil
+        time.isEditable = false
+        time.isBezeled = false
+    }
+
+    private func commitTimeEntry() {
+        let inputText = time.stringValue
+        restoreTimeField()
+        guard let panelController = PanelController.panel() else { return }
+        let currentOffset = panelController.futureSliderValue
+        let now = Date()
+        let currentSliderDate = Calendar.current.date(byAdding: .minute, value: currentOffset, to: now) ?? now
+        guard let tz = TimeZone(identifier: timezoneIdentifier),
+              let targetDate = parseEnteredTime(inputText, in: tz, relativeTo: currentSliderDate) else {
+            panelController.mainTableView.reloadData()
+            return
+        }
+        let minutesOffset = Int(targetDate.timeIntervalSince(now) / 60.0)
+        panelController.jumpToSliderMinutes(minutesOffset)
+    }
+
+    private func cancelTimeEntry() {
+        restoreTimeField()
+        PanelController.panel()?.mainTableView.reloadData()
+    }
+
+    private func parseEnteredTime(_ input: String, in timezone: TimeZone, relativeTo baseDate: Date) -> Date? {
+        let trimmed = input.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return nil }
+
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = timezone
+        let baseComponents = cal.dateComponents([.year, .month, .day], from: baseDate)
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = timezone
+
+        for format in ["h:mm a", "h:mma", "H:mm", "h:mm", "ha", "h a", "H"] {
+            formatter.dateFormat = format
+            guard let parsed = formatter.date(from: trimmed) else { continue }
+            var comps = baseComponents
+            let timeComps = cal.dateComponents([.hour, .minute], from: parsed)
+            comps.hour = timeComps.hour
+            comps.minute = timeComps.minute
+            comps.second = 0
+            return cal.date(from: comps)
+        }
+        return nil
+    }
+
     override func rightMouseDown(with event: NSEvent) {
         // Pass right-clicks up the responder chain (e.g. to PanelController for Pin to Desktop).
         // The old notes popover was removed in the strip commit; showExtraOptions would crash.
         super.rightMouseDown(with: event)
+    }
+}
+
+extension TimezoneCellView: NSTextFieldDelegate {
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+            commitTimeEntry()
+            return true
+        }
+        if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+            cancelTimeEntry()
+            return true
+        }
+        return false
+    }
+
+    func controlTextDidEndEditing(_ obj: Notification) {
+        guard isEditingTime else { return }
+        cancelTimeEntry()
     }
 }

--- a/Meridian/Panel/UI/TimezoneDataSource.swift
+++ b/Meridian/Panel/UI/TimezoneDataSource.swift
@@ -65,6 +65,7 @@ extension TimezoneDataSource: NSTableViewDataSource, NSTableViewDelegate {
         cellView.sunriseImage.contentTintColor = currentModel.isSunriseOrSunset ? NSColor.systemYellow : NSColor.systemOrange
         cellView.relativeDate.stringValue = operation.date(with: sliderValue, displayType: .panel)
         cellView.rowNumber = row
+        cellView.timezoneIdentifier = currentModel.timezone()
         cellView.customName.stringValue = currentModel.formattedTimezoneLabel()
         cellView.time.stringValue = operation.time(with: sliderValue)
         cellView.noteLabel.toolTip = currentModel.note ?? UserDefaultKeys.emptyString


### PR DESCRIPTION
## Summary

- Double-click the time display in any timezone cell to make it editable
- Type a time in any common format: `7:30 PM`, `7:30 pm`, `19:30`, `7pm`, `7`
- Press **Enter** to jump the slider so all clocks reflect that time
- Press **Escape** or click away to cancel without changing anything
- The slider, label, and << / >> buttons all update correctly, same as dragging

## Implementation

- `TimezoneCellView`: `mouseDown` detects double-click, makes the `time` NSTextField temporarily editable with a rounded bezel. `NSTextFieldDelegate` handles Enter (commit) and Escape (cancel). A `controlTextDidEndEditing` guard also cancels cleanly when focus is lost.
- `TimezoneDataSource`: sets `cellView.timezoneIdentifier` so the cell can resolve the timezone for parsing.
- `ParentPanelController`: guards `updateCell` so the live clock ticker doesn't overwrite text while the user is typing.
- `ParentPanelController+ModernSlider`: new `jumpToSliderMinutes(_:)` scrolls the visual slider to match, triggering the same button/label updates as a manual drag.

## Test plan

- [ ] Double-click a time cell — confirm field becomes editable with a rounded border
- [ ] Type `7:30 PM` and press Enter — confirm slider jumps and all clocks show 7:30 in that timezone
- [ ] Try `19:30`, `7pm`, `7` — confirm all parse correctly
- [ ] Type garbage text and press Enter — confirm graceful cancel (no crash, times unchanged)
- [ ] Press Escape mid-edit — confirm times unchanged
- [ ] Click elsewhere mid-edit — confirm times unchanged
- [ ] Confirm << / >> and Reset buttons appear/disappear correctly after a time entry
- [ ] Confirm single-click still copies to clipboard as before

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)