### PR TITLE
Add export/import settings (#83)

### DIFF
--- a/Meridian/App/MainMenu.xib
+++ b/Meridian/App/MainMenu.xib
@@ -109,6 +109,25 @@
                             <menuItem isSeparatorItem="YES" id="74">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
+                            <menuItem title="Export Settings…" keyEquivalent="e" id="901">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                <connections>
+                                    <action selector="exportSettings:" target="-1" id="902"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Copy Settings to Clipboard" id="903">
+                                <connections>
+                                    <action selector="copySettingsToClipboard:" target="-1" id="904"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem title="Import Settings…" id="905">
+                                <connections>
+                                    <action selector="importSettings:" target="-1" id="906"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="907">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
                             <menuItem title="Page Setup..." keyEquivalent="P" id="77">
                                 <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -236,6 +236,18 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
+    @IBAction func exportSettings(_: Any?) {
+        SettingsManager.exportSettings()
+    }
+
+    @IBAction func copySettingsToClipboard(_: Any?) {
+        SettingsManager.copySettingsToClipboard()
+    }
+
+    @IBAction func importSettings(_: Any?) {
+        SettingsManager.importSettings()
+    }
+
     func statusItemForPanel() -> StatusItemHandler {
         return statusBarHandler
     }

--- a/Meridian/Meridian.xcodeproj/project.pbxproj
+++ b/Meridian/Meridian.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		35C36F2C2259D6FA002FA5C6 /* PanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F282259D6FA002FA5C6 /* PanelController.swift */; };
 		35C36F372259D7C3002FA5C6 /* AddTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F322259D7C3002FA5C6 /* AddTableViewCell.swift */; };
 		35C36F422259D892002FA5C6 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F3A2259D892002FA5C6 /* Timer.swift */; };
+		5ADE02988FD148209EA2A70A /* SettingsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D856F171624B8EBC360698 /* SettingsManager.swift */; };
 		35C36F452259D892002FA5C6 /* Strings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F3D2259D892002FA5C6 /* Strings.swift */; };
 		35C36F462259D892002FA5C6 /* DataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F3E2259D892002FA5C6 /* DataStore.swift */; };
 		35C36F482259D892002FA5C6 /* NetworkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35C36F402259D892002FA5C6 /* NetworkManager.swift */; };
@@ -169,6 +170,7 @@
 		35C36F282259D6FA002FA5C6 /* PanelController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PanelController.swift; sourceTree = "<group>"; };
 		35C36F322259D7C3002FA5C6 /* AddTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddTableViewCell.swift; sourceTree = "<group>"; };
 		35C36F3A2259D892002FA5C6 /* Timer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Timer.swift; sourceTree = "<group>"; };
+		23D856F171624B8EBC360698 /* SettingsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingsManager.swift; sourceTree = "<group>"; };
 		35C36F3D2259D892002FA5C6 /* Strings.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Strings.swift; sourceTree = "<group>"; };
 		35C36F3E2259D892002FA5C6 /* DataStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStore.swift; sourceTree = "<group>"; };
 		35C36F402259D892002FA5C6 /* NetworkManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NetworkManager.swift; sourceTree = "<group>"; };
@@ -385,6 +387,7 @@
 				35C36F4D2259D981002FA5C6 /* AppDefaults.swift */,
 				35C36F4C2259D981002FA5C6 /* DateFormatterManager.swift */,
 				35C36F3E2259D892002FA5C6 /* DataStore.swift */,
+				23D856F171624B8EBC360698 /* SettingsManager.swift */,
 				9FEC776853CC4796AD9A1DC6 /* GlobalShortcutMonitor.swift */,
 				35C36F402259D892002FA5C6 /* NetworkManager.swift */,
 				35C36F3D2259D892002FA5C6 /* Strings.swift */,
@@ -835,6 +838,7 @@
 				35C36F14225961DA002FA5C6 /* Integer+DateTools.swift in Sources */,
 				35C36F15225961DA002FA5C6 /* TimeChunk.swift in Sources */,
 				35C36F19225961DA002FA5C6 /* Enums.swift in Sources */,
+				5ADE02988FD148209EA2A70A /* SettingsManager.swift in Sources */,
 				35C36F452259D892002FA5C6 /* Strings.swift in Sources */,
 				357391872507277500D30819 /* TimeMarkerViewItem.swift in Sources */,
 				35C36F782259E1D0002FA5C6 /* Foundation + Additions.swift in Sources */,

--- a/Meridian/Overall App/SettingsManager.swift
+++ b/Meridian/Overall App/SettingsManager.swift
@@ -1,0 +1,173 @@
+import Cocoa
+import CoreLoggerKit
+import CoreModelKit
+import UniformTypeIdentifiers
+
+struct SettingsManager {
+    private static let exportDirectory = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".meridian")
+    private static let defaultExportFilename = "meridian-settings.json"
+
+    // Keys exported and imported (excludes startAtLogin — system-level, applied separately)
+    private static let preferenceKeys: [String] = [
+        UserDefaultKeys.selectedTimeZoneFormatKey,
+        UserDefaultKeys.relativeDateKey,
+        UserDefaultKeys.themeKey,
+        UserDefaultKeys.showDayInMenu,
+        UserDefaultKeys.showDateInMenu,
+        UserDefaultKeys.showPlaceInMenu,
+        UserDefaultKeys.displayFutureSliderKey,
+        UserDefaultKeys.showAppInForeground,
+        UserDefaultKeys.sunriseSunsetTime,
+        UserDefaultKeys.userFontSizePreference,
+        UserDefaultKeys.truncateTextLength,
+        UserDefaultKeys.futureSliderRange,
+        UserDefaultKeys.appDisplayOptions,
+        UserDefaultKeys.menubarCompactMode,
+        UserDefaultKeys.defaultMenubarMode,
+    ]
+
+    private enum ExportKey {
+        static let version = "version"
+        static let timezones = "timezones"
+        static let preferences = "preferences"
+    }
+
+    private enum ImportError: LocalizedError {
+        case invalidFormat
+        case unsupportedVersion
+        case invalidTimezoneData
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidFormat: return "The file is not a valid Meridian settings file."
+            case .unsupportedVersion: return "This settings file was created by a newer version of Meridian."
+            case .invalidTimezoneData: return "The settings file contains invalid timezone data."
+            }
+        }
+    }
+
+    // MARK: - Public API
+
+    static func exportSettings() {
+        guard let jsonData = buildJSON() else { return }
+        try? FileManager.default.createDirectory(at: exportDirectory, withIntermediateDirectories: true)
+
+        let panel = NSSavePanel()
+        panel.directoryURL = exportDirectory
+        panel.nameFieldStringValue = defaultExportFilename
+        panel.allowedContentTypes = [UTType.json]
+        panel.prompt = "Export"
+        panel.title = "Export Meridian Settings"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            try jsonData.write(to: url, options: .atomic)
+        } catch {
+            Logger.debug("Settings export failed: \(error)")
+            showAlert("Export failed", detail: error.localizedDescription)
+        }
+    }
+
+    static func copySettingsToClipboard() {
+        guard let jsonData = buildJSON(),
+              let jsonString = String(data: jsonData, encoding: .utf8) else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(jsonString, forType: .string)
+        NSApp.keyWindow?.contentView?.makeToast("Settings copied to clipboard")
+    }
+
+    static func importSettings() {
+        let panel = NSOpenPanel()
+        panel.directoryURL = exportDirectory
+        panel.allowedContentTypes = [UTType.json]
+        panel.prompt = "Import"
+        panel.title = "Import Meridian Settings"
+        panel.allowsMultipleSelection = false
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+
+        do {
+            let data = try Data(contentsOf: url)
+            try applySettings(from: data)
+        } catch {
+            Logger.debug("Settings import failed: \(error)")
+            showAlert("Import failed", detail: error.localizedDescription)
+        }
+    }
+
+    // MARK: - Private
+
+    private static func buildJSON() -> Data? {
+        let timezoneBase64 = DataStore.shared().timezones().map { $0.base64EncodedString() }
+
+        var prefs: [String: Any] = [:]
+        for key in preferenceKeys {
+            if let value = UserDefaults.standard.object(forKey: key) {
+                prefs[key] = value
+            }
+        }
+
+        let payload: [String: Any] = [
+            ExportKey.version: 1,
+            ExportKey.timezones: timezoneBase64,
+            ExportKey.preferences: prefs,
+        ]
+        return try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    private static func applySettings(from data: Data) throws {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw ImportError.invalidFormat
+        }
+        guard let version = json[ExportKey.version] as? Int, version == 1 else {
+            throw ImportError.unsupportedVersion
+        }
+
+        // Validate and decode timezones
+        var timezoneBlobs: [Data] = []
+        if let encoded = json[ExportKey.timezones] as? [String] {
+            for base64 in encoded {
+                guard let blob = Data(base64Encoded: base64),
+                      TimezoneData.customObject(from: blob) != nil else {
+                    throw ImportError.invalidTimezoneData
+                }
+                timezoneBlobs.append(blob)
+            }
+        }
+
+        // Apply preferences
+        if let prefs = json[ExportKey.preferences] as? [String: Any] {
+            for key in preferenceKeys {
+                if let value = prefs[key] {
+                    UserDefaults.standard.set(value, forKey: key)
+                }
+            }
+        }
+
+        // Apply timezones
+        DataStore.shared().setTimezones(timezoneBlobs)
+
+        // Refresh UI
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .customLabelChanged, object: nil)
+            if let panel = PanelController.panel() {
+                panel.updateDefaultPreferences()
+                panel.updateTableContent()
+            }
+            if let statusItem = (NSApp.delegate as? AppDelegate)?.statusItemForPanel() {
+                statusItem.refresh()
+            }
+            NSApp.keyWindow?.contentView?.makeToast("Settings imported")
+        }
+    }
+
+    private static func showAlert(_ message: String, detail: String) {
+        DispatchQueue.main.async {
+            let alert = NSAlert()
+            alert.messageText = message
+            alert.informativeText = detail
+            alert.alertStyle = .warning
+            alert.runModal()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **File > Export Settings…** (⌘⇧E) — saves all settings to a JSON file, defaulting to `~/.meridian/`
- **File > Copy Settings to Clipboard** — copies the same JSON to the clipboard with a toast confirmation
- **File > Import Settings…** — opens a JSON settings file, validates all timezone data before applying, then refreshes the panel, preferences window, and menubar in one shot

## What's exported

All timezone entries plus every user preference: time format, theme, date/day/place in menubar, sunrise/sunset display, font size, text truncation, slider range, compact mode, and float-on-top. `startAtLogin` is intentionally excluded — it's a system-level `SMAppService` registration, not a simple defaults value.

## Implementation

- `SettingsManager.swift` — pure `struct` with three static methods; timezones serialized as base64-encoded `NSKeyedArchiver` blobs inside JSON so the existing `NSSecureCoding` round-trip is preserved
- `AppDelegate` — three `@IBAction` methods that delegate to `SettingsManager`
- `MainMenu.xib` — Export, Copy, and Import items added to the File menu between the existing separator and Page Setup

## Test plan

- [ ] File > Export Settings — confirm save panel opens defaulting to `~/.meridian/`, file saves cleanly
- [ ] Open exported JSON — confirm timezones appear as base64 strings and preference keys are present
- [ ] File > Copy Settings to Clipboard — confirm toast appears and clipboard contains valid JSON
- [ ] File > Import Settings — import a valid file, confirm all timezones and preferences apply and UI refreshes
- [ ] Import a corrupted file — confirm error alert with clear message, no crash
- [ ] Import a file with wrong version field — confirm "unsupported version" alert

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)