### PR TITLE
Declutter panel footer + redesign About tab (#81)

### DIFF
--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -35,13 +35,6 @@ class ParentPanelController: NSWindowController {
         return TimeScrollerViewModel(dataStore: dataStore)
     }()
 
-    private lazy var versionLabelDateFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateStyle = .short
-        f.timeStyle = .short
-        return f
-    }()
-
     lazy var oneWindow: OneWindowController? = {
         let preferencesStoryboard = NSStoryboard(name: "Preferences", bundle: nil)
         return preferencesStoryboard.instantiateInitialController() as? OneWindowController
@@ -105,10 +98,6 @@ class ParentPanelController: NSWindowController {
             }
             .store(in: &cancellables)
 
-        NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in self?.updateVersionStatusLabel() }
-            .store(in: &cancellables)
     }
 
     override func awakeFromNib() {
@@ -126,7 +115,7 @@ class ParentPanelController: NSWindowController {
         // Setup copy-all button next to settings button
         setupCopyAllButton()
 
-        // Setup version + last checked label
+        // Setup version label
         updateVersionStatusLabel()
 
         // Setup KVO observers for user default changes
@@ -203,14 +192,7 @@ class ParentPanelController: NSWindowController {
     func updateVersionStatusLabel() {
         guard versionStatusLabel != nil else { return }
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "?"
-        let lastCheckDate = UserDefaults.standard.object(forKey: "SULastCheckTime") as? Date
-        let checkString: String
-        if let date = lastCheckDate {
-            checkString = versionLabelDateFormatter.string(from: date)
-        } else {
-            checkString = "Never"
-        }
-        versionStatusLabel.stringValue = "v\(version) • \(checkString)"
+        versionStatusLabel.stringValue = "v\(version)"
     }
 
     @objc func systemTimezoneDidChange() {

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -50,9 +50,6 @@ struct AboutView: View {
                         metadata: ["Country": Locale.autoupdatingCurrent.region?.identifier ?? ""])
             }
 
-            Divider()
-                .padding(.horizontal, 20)
-
             Toggle(String(localized: "Start at Login"), isOn: $startAtLogin)
                 .font(.custom("Avenir-Book", size: 13))
                 .toggleStyle(.checkbox)
@@ -64,16 +61,13 @@ struct AboutView: View {
 
             AutoUpdateToggle()
 
-            Divider()
-                .padding(.horizontal, 20)
-
-            DebugLoggingSection()
-
             HStack(spacing: 8) {
                 Text(String(localized: "Check for Updates"))
                     .font(.custom("Avenir-Light", size: 13))
                 UpdateCheckControls()
             }
+
+            DebugLoggingSection()
         }
         .padding(20)
         .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Summary
- User feedback on 2.18.1: panel footer was crowded; last-checked timestamp didn't actually sync; About tab had unnecessary dividers and scattered update controls
- **Panel footer**: drop \`• <last-checked>\` suffix → show only \`v<version>\` for clean at-a-glance build identifier
- **About tab**: remove both \`Divider()\` rows; group \"Check for Updates [Picker] [Check Now]\" directly under the AutoUpdate toggle so update controls form one visual cluster; push DebugLoggingSection to the bottom
- Last-checked date is shown only inside the About tab now (under the AutoUpdate checkbox), per user request

## Test plan
- [ ] Open panel → footer reads \`v<version>\` only (e.g. \`v2.19.0-beta1\`), no \`•\` separator
- [ ] Settings → About → no horizontal divider lines anywhere in the column
- [ ] About: AutoUpdate checkbox, then \"Last checked: …\", then \"Check for Updates [Daily/Weekly/Monthly picker] [Check Now]\" form a contiguous group
- [ ] DebugLoggingSection appears below the update group
- [ ] About window still fits all controls without clipping (resize window if needed and confirm layout)

Closes #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)