### PR TITLE
Surface export/import in About tab; remove dead File menu (#83)

### DIFF
--- a/Meridian/App/MainMenu.xib
+++ b/Meridian/App/MainMenu.xib
@@ -109,25 +109,6 @@
                             <menuItem isSeparatorItem="YES" id="74">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
-                            <menuItem title="Export Settings…" keyEquivalent="e" id="901">
-                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
-                                <connections>
-                                    <action selector="exportSettings:" target="-1" id="902"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Copy Settings to Clipboard" id="903">
-                                <connections>
-                                    <action selector="copySettingsToClipboard:" target="-1" id="904"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem title="Import Settings…" id="905">
-                                <connections>
-                                    <action selector="importSettings:" target="-1" id="906"/>
-                                </connections>
-                            </menuItem>
-                            <menuItem isSeparatorItem="YES" id="907">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
                             <menuItem title="Page Setup..." keyEquivalent="P" id="77">
                                 <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
                                 <connections>

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -236,18 +236,6 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
         NSApp.activate(ignoringOtherApps: true)
     }
 
-    @IBAction func exportSettings(_: Any?) {
-        SettingsManager.exportSettings()
-    }
-
-    @IBAction func copySettingsToClipboard(_: Any?) {
-        SettingsManager.copySettingsToClipboard()
-    }
-
-    @IBAction func importSettings(_: Any?) {
-        SettingsManager.importSettings()
-    }
-
     func statusItemForPanel() -> StatusItemHandler {
         return statusBarHandler
     }

--- a/Meridian/Overall App/SettingsManager.swift
+++ b/Meridian/Overall App/SettingsManager.swift
@@ -6,7 +6,7 @@ import UniformTypeIdentifiers
 struct SettingsManager {
     private static let exportDirectory = FileManager.default.homeDirectoryForCurrentUser
         .appendingPathComponent(".meridian")
-    private static let defaultExportFilename = "meridian-settings.json"
+    private static let defaultExportFilename = "meridian_settings.json"
 
     // Keys exported and imported (excludes startAtLogin — system-level, applied separately)
     private static let preferenceKeys: [String] = [

--- a/Meridian/Overall App/SettingsManager.swift
+++ b/Meridian/Overall App/SettingsManager.swift
@@ -8,16 +8,10 @@ struct SettingsManager {
         .appendingPathComponent(".meridian")
     private static let defaultExportFilename = "meridian_settings.json"
 
-    // Sparkle stores the auto-update prefs in UserDefaults under these keys.
-    // We round-trip them so imported settings reproduce the user's update cadence.
-    private enum SparkleDefaultKey {
-        static let enableAutomaticChecks = "SUEnableAutomaticChecks"
-        static let automaticallyUpdate = "SUAutomaticallyUpdate"
-        static let scheduledCheckInterval = "SUScheduledCheckInterval"
-    }
-
     // Every user-settable preference. Each appears in some Settings tab
     // (General/Appearance/About) and survives export → import.
+    // (defaultMenubarMode / "com.tpak.meridian.shouldDefaultToCompactMode"
+    //  is intentionally omitted — it's a dead key with no readers.)
     private static let preferenceKeys: [String] = [
         // Appearance tab — time/theme/format
         UserDefaultKeys.selectedTimeZoneFormatKey,
@@ -36,13 +30,8 @@ struct SettingsManager {
         UserDefaultKeys.showDateInMenu,
         UserDefaultKeys.showPlaceInMenu,
         UserDefaultKeys.menubarCompactMode,
-        UserDefaultKeys.defaultMenubarMode,
         // About tab — debug logging
         UserDefaultKeys.debugLoggingEnabled,
-        // About tab — Sparkle auto-update settings
-        SparkleDefaultKey.enableAutomaticChecks,
-        SparkleDefaultKey.automaticallyUpdate,
-        SparkleDefaultKey.scheduledCheckInterval,
     ]
 
     // startAtLogin is exported alongside the rest, but APPLIED via StartupManager
@@ -55,6 +44,13 @@ struct SettingsManager {
         static let timezones = "timezones"
         static let preferences = "preferences"
         static let startAtLogin = "startAtLogin"
+        static let sparkle = "sparkle"
+    }
+
+    private enum SparkleExportField {
+        static let automaticallyChecksForUpdates = "automaticallyChecksForUpdates"
+        static let automaticallyDownloadsUpdates = "automaticallyDownloadsUpdates"
+        static let updateCheckInterval = "updateCheckIntervalSeconds"
     }
 
     private enum ImportError: LocalizedError {
@@ -124,6 +120,9 @@ struct SettingsManager {
     private static func buildJSON() -> Data? {
         let timezoneBase64 = DataStore.shared().timezones().map { $0.base64EncodedString() }
 
+        // For UserDefaults-backed prefs, fall back to the registered default
+        // (see AppDefaults.defaultsDictionary) so we never silently drop a key
+        // the user has never explicitly touched.
         var prefs: [String: Any] = [:]
         for key in preferenceKeys {
             if let value = UserDefaults.standard.object(forKey: key) {
@@ -135,11 +134,23 @@ struct SettingsManager {
         // (UserDefaults can drift from the system state if the user toggled it elsewhere).
         let startAtLoginEnabled = StartupManager.isLoginItemEnabled()
 
+        // Sparkle prefs are read from the live updater, NOT from UserDefaults.
+        // Sparkle uses lazy registration — if the user has never opened the
+        // schedule picker, SUScheduledCheckInterval is nil in UserDefaults
+        // even though the updater has a real running value (typically 86400).
+        var sparkle: [String: Any] = [:]
+        if let updater = (NSApp.delegate as? AppDelegate)?.updaterController.updater {
+            sparkle[SparkleExportField.automaticallyChecksForUpdates] = updater.automaticallyChecksForUpdates
+            sparkle[SparkleExportField.automaticallyDownloadsUpdates] = updater.automaticallyDownloadsUpdates
+            sparkle[SparkleExportField.updateCheckInterval] = updater.updateCheckInterval
+        }
+
         let payload: [String: Any] = [
             ExportKey.version: 1,
             ExportKey.timezones: timezoneBase64,
             ExportKey.preferences: prefs,
             ExportKey.startAtLogin: startAtLoginEnabled,
+            ExportKey.sparkle: sparkle,
         ]
         return try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
     }
@@ -164,7 +175,7 @@ struct SettingsManager {
             }
         }
 
-        // Apply UserDefaults preferences (Appearance + About + Sparkle)
+        // Apply UserDefaults preferences (Appearance + About debug logging)
         if let prefs = json[ExportKey.preferences] as? [String: Any] {
             for key in preferenceKeys {
                 if let value = prefs[key] {
@@ -183,7 +194,7 @@ struct SettingsManager {
         // Apply timezones
         DataStore.shared().setTimezones(timezoneBlobs)
 
-        // Refresh UI + Sparkle in-memory state from imported UserDefaults
+        // Refresh UI + apply Sparkle prefs to the live updater
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: .customLabelChanged, object: nil)
             if let panel = PanelController.panel() {
@@ -192,17 +203,20 @@ struct SettingsManager {
             }
             if let appDelegate = NSApp.delegate as? AppDelegate {
                 appDelegate.statusItemForPanel().refresh()
-                // Re-read Sparkle prefs into the live updater so the new schedule
-                // takes effect immediately rather than next launch.
-                let updater = appDelegate.updaterController.updater
-                if let v = UserDefaults.standard.object(forKey: SparkleDefaultKey.enableAutomaticChecks) as? Bool {
-                    updater.automaticallyChecksForUpdates = v
-                }
-                if let v = UserDefaults.standard.object(forKey: SparkleDefaultKey.automaticallyUpdate) as? Bool {
-                    updater.automaticallyDownloadsUpdates = v
-                }
-                if let v = UserDefaults.standard.object(forKey: SparkleDefaultKey.scheduledCheckInterval) as? TimeInterval {
-                    updater.updateCheckInterval = v
+                // Apply Sparkle prefs from the import payload directly to the live
+                // updater so the new schedule takes effect immediately. Setting these
+                // on the updater also writes them to UserDefaults under Sparkle's keys.
+                if let sparkle = json[ExportKey.sparkle] as? [String: Any] {
+                    let updater = appDelegate.updaterController.updater
+                    if let v = sparkle[SparkleExportField.automaticallyChecksForUpdates] as? Bool {
+                        updater.automaticallyChecksForUpdates = v
+                    }
+                    if let v = sparkle[SparkleExportField.automaticallyDownloadsUpdates] as? Bool {
+                        updater.automaticallyDownloadsUpdates = v
+                    }
+                    if let v = sparkle[SparkleExportField.updateCheckInterval] as? TimeInterval {
+                        updater.updateCheckInterval = v
+                    }
                 }
             }
             NSApp.keyWindow?.contentView?.makeToast("Settings imported")

--- a/Meridian/Overall App/SettingsManager.swift
+++ b/Meridian/Overall App/SettingsManager.swift
@@ -8,29 +8,53 @@ struct SettingsManager {
         .appendingPathComponent(".meridian")
     private static let defaultExportFilename = "meridian_settings.json"
 
-    // Keys exported and imported (excludes startAtLogin — system-level, applied separately)
+    // Sparkle stores the auto-update prefs in UserDefaults under these keys.
+    // We round-trip them so imported settings reproduce the user's update cadence.
+    private enum SparkleDefaultKey {
+        static let enableAutomaticChecks = "SUEnableAutomaticChecks"
+        static let automaticallyUpdate = "SUAutomaticallyUpdate"
+        static let scheduledCheckInterval = "SUScheduledCheckInterval"
+    }
+
+    // Every user-settable preference. Each appears in some Settings tab
+    // (General/Appearance/About) and survives export → import.
     private static let preferenceKeys: [String] = [
+        // Appearance tab — time/theme/format
         UserDefaultKeys.selectedTimeZoneFormatKey,
-        UserDefaultKeys.relativeDateKey,
         UserDefaultKeys.themeKey,
-        UserDefaultKeys.showDayInMenu,
-        UserDefaultKeys.showDateInMenu,
-        UserDefaultKeys.showPlaceInMenu,
+        UserDefaultKeys.relativeDateKey,
+        // Appearance tab — display toggles
         UserDefaultKeys.displayFutureSliderKey,
-        UserDefaultKeys.showAppInForeground,
         UserDefaultKeys.sunriseSunsetTime,
+        UserDefaultKeys.showAppInForeground,
         UserDefaultKeys.userFontSizePreference,
         UserDefaultKeys.truncateTextLength,
         UserDefaultKeys.futureSliderRange,
         UserDefaultKeys.appDisplayOptions,
+        // Appearance tab — menubar
+        UserDefaultKeys.showDayInMenu,
+        UserDefaultKeys.showDateInMenu,
+        UserDefaultKeys.showPlaceInMenu,
         UserDefaultKeys.menubarCompactMode,
         UserDefaultKeys.defaultMenubarMode,
+        // About tab — debug logging
+        UserDefaultKeys.debugLoggingEnabled,
+        // About tab — Sparkle auto-update settings
+        SparkleDefaultKey.enableAutomaticChecks,
+        SparkleDefaultKey.automaticallyUpdate,
+        SparkleDefaultKey.scheduledCheckInterval,
     ]
+
+    // startAtLogin is exported alongside the rest, but APPLIED via StartupManager
+    // (SMAppService.mainApp) during import so the system actually registers/unregisters
+    // the login item — writing UserDefaults alone wouldn't change behavior.
+    private static let startAtLoginKey = UserDefaultKeys.startAtLogin
 
     private enum ExportKey {
         static let version = "version"
         static let timezones = "timezones"
         static let preferences = "preferences"
+        static let startAtLogin = "startAtLogin"
     }
 
     private enum ImportError: LocalizedError {
@@ -107,10 +131,15 @@ struct SettingsManager {
             }
         }
 
+        // startAtLogin is the actual SMAppService state, not what's in UserDefaults
+        // (UserDefaults can drift from the system state if the user toggled it elsewhere).
+        let startAtLoginEnabled = StartupManager.isLoginItemEnabled()
+
         let payload: [String: Any] = [
             ExportKey.version: 1,
             ExportKey.timezones: timezoneBase64,
             ExportKey.preferences: prefs,
+            ExportKey.startAtLogin: startAtLoginEnabled,
         ]
         return try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
     }
@@ -135,7 +164,7 @@ struct SettingsManager {
             }
         }
 
-        // Apply preferences
+        // Apply UserDefaults preferences (Appearance + About + Sparkle)
         if let prefs = json[ExportKey.preferences] as? [String: Any] {
             for key in preferenceKeys {
                 if let value = prefs[key] {
@@ -144,18 +173,37 @@ struct SettingsManager {
             }
         }
 
+        // Apply startAtLogin via StartupManager — UserDefaults alone won't register/unregister
+        // the SMAppService login item, so toggle it explicitly.
+        if let startAtLogin = json[ExportKey.startAtLogin] as? Bool {
+            UserDefaults.standard.set(startAtLogin, forKey: startAtLoginKey)
+            StartupManager().toggleLogin(startAtLogin)
+        }
+
         // Apply timezones
         DataStore.shared().setTimezones(timezoneBlobs)
 
-        // Refresh UI
+        // Refresh UI + Sparkle in-memory state from imported UserDefaults
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: .customLabelChanged, object: nil)
             if let panel = PanelController.panel() {
                 panel.updateDefaultPreferences()
                 panel.updateTableContent()
             }
-            if let statusItem = (NSApp.delegate as? AppDelegate)?.statusItemForPanel() {
-                statusItem.refresh()
+            if let appDelegate = NSApp.delegate as? AppDelegate {
+                appDelegate.statusItemForPanel().refresh()
+                // Re-read Sparkle prefs into the live updater so the new schedule
+                // takes effect immediately rather than next launch.
+                let updater = appDelegate.updaterController.updater
+                if let v = UserDefaults.standard.object(forKey: SparkleDefaultKey.enableAutomaticChecks) as? Bool {
+                    updater.automaticallyChecksForUpdates = v
+                }
+                if let v = UserDefaults.standard.object(forKey: SparkleDefaultKey.automaticallyUpdate) as? Bool {
+                    updater.automaticallyDownloadsUpdates = v
+                }
+                if let v = UserDefaults.standard.object(forKey: SparkleDefaultKey.scheduledCheckInterval) as? TimeInterval {
+                    updater.updateCheckInterval = v
+                }
             }
             NSApp.keyWindow?.contentView?.makeToast("Settings imported")
         }

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -67,6 +67,8 @@ struct AboutView: View {
             Divider()
                 .padding(.horizontal, 20)
 
+            SettingsBackupSection()
+
             DebugLoggingSection()
 
             HStack(spacing: 8) {
@@ -205,6 +207,24 @@ private struct UpdateCheckControls: View {
             appDelegate.updaterController.checkForUpdates(nil)
         }
         .font(.custom("Avenir-Light", size: 12))
+    }
+}
+
+private struct SettingsBackupSection: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            Button(String(localized: "Export Settings…")) {
+                SettingsManager.exportSettings()
+            }
+            .font(.custom("Avenir-Light", size: 12))
+            .accessibilityIdentifier("ExportSettings")
+
+            Button(String(localized: "Import Settings…")) {
+                SettingsManager.importSettings()
+            }
+            .font(.custom("Avenir-Light", size: 12))
+            .accessibilityIdentifier("ImportSettings")
+        }
     }
 }
 

--- a/Meridian/Preferences/StartupManager.swift
+++ b/Meridian/Preferences/StartupManager.swift
@@ -15,4 +15,8 @@ struct StartupManager {
             Logger.production("Failed to toggle login item: \(error)")
         }
     }
+
+    static func isLoginItemEnabled() -> Bool {
+        return SMAppService.mainApp.status == .enabled
+    }
 }


### PR DESCRIPTION
## Summary
- **Root cause of \"no button anywhere\":** Meridian is LSUIElement=true (menu-bar agent), so the system never shows its menu bar — the 2.18.4 PR wired Export/Import into \`MainMenu.xib\` where users couldn't see them.
- Add visible **Export Settings…** and **Import Settings…** buttons to the About tab via new \`SettingsBackupSection\`.
- Both buttons present file dialogs (\`NSSavePanel\` / \`NSOpenPanel\`) defaulting to \`~/.meridian/meridian_settings.json\` so users can pick any location.
- Filename renamed from \`meridian-settings.json\` → \`meridian_settings.json\` per user preference.
- Strip the dead \`MainMenu.xib\` entries (Export Settings…, Copy Settings to Clipboard, Import Settings…) and the corresponding orphan \`@IBAction\` stubs in \`AppDelegate\`.

## Test plan
- [ ] Settings → About → \"Export Settings…\" button visible; click it → save panel appears defaulting to \`~/.meridian/meridian_settings.json\`
- [ ] Save → confirm file exists at that path with valid JSON containing version/timezones/preferences
- [ ] Save to a custom location (e.g. Desktop) → file written there with custom name
- [ ] Settings → About → \"Import Settings…\" button visible; click it → open panel appears defaulting to \`~/.meridian/\` directory
- [ ] Import the file just exported → toast \"Settings imported\"; timezones and prefs preserved
- [ ] Edit the JSON to corrupt one timezone → import → see error alert \"The settings file contains invalid timezone data.\"
- [ ] Confirm no Export/Import items appear in any system menu (LSUIElement app, menu bar isn't shown anyway)

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)