### PR TITLE
Add Sparkle beta channel opt-in (closes #98)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,88 @@ Only delete branches whose PR shows MERGED in `gh pr list --state all`. Never fo
 - Notarization credentials stored: `xcrun notarytool store-credentials "meridian-notary"`
 - Sparkle EdDSA key (generated on first use by `sign_update`)
 
+## Local Beta Builds for UAT
+
+Before cutting a real release, build a clearly-labelled beta and run it side-by-side with the production app on the user's machine. Iterate `beta1` → `beta2` → ... on the same feature branch until the user signs off, then merge the PR and run `make release`.
+
+### Why this exists
+Production releases go through Sparkle to every user immediately. The user wants to UAT changes locally before that happens. This workflow keeps `/Applications/Meridian.app` (production) untouched while a `~/Applications/Meridian-beta.app` runs the in-progress build.
+
+### How to build a beta
+
+From the feature branch (do **not** merge to main yet):
+
+```bash
+# 1. Quit any running Meridian (production or previous beta)
+osascript -e 'tell application "Meridian" to quit'
+sleep 2
+
+# 2. Build with version overrides — DO NOT edit project.pbxproj.
+#    Bump the betaN suffix and CURRENT_PROJECT_VERSION on each iteration.
+xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \
+  CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= \
+  MARKETING_VERSION=2.19.1-beta1 CURRENT_PROJECT_VERSION=2191001
+
+# 3. Verify the version stamped into the built bundle
+/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" \
+  "$HOME/Library/Developer/Xcode/DerivedData/Meridian-*/Build/Products/Debug/Meridian.app/Contents/Info.plist"
+
+# 4. Install to ~/Applications (separate from /Applications/Meridian.app)
+rm -rf ~/Applications/Meridian-beta.app
+cp -R "$HOME/Library/Developer/Xcode/DerivedData/Meridian-*/Build/Products/Debug/Meridian.app" \
+  ~/Applications/Meridian-beta.app
+xattr -cr ~/Applications/Meridian-beta.app   # strip quarantine
+open ~/Applications/Meridian-beta.app
+
+# 5. Confirm it's running
+pgrep -lf "Meridian-beta.app/Contents/MacOS/Meridian"
+```
+
+### Conventions
+- **Naming**: `MARKETING_VERSION=X.Y.Z-betaN` (e.g. `2.19.1-beta1`, `2.19.1-beta2`). The user-visible version string in the panel footer reads `vX.Y.Z-betaN` — that's the unambiguous "this is the test build" signal.
+- **Build number**: `CURRENT_PROJECT_VERSION=XYZNNN` (e.g. `2191001` for `2.19.1-beta1`). Doesn't render in the UI; just keeps Sparkle's internal comparison consistent.
+- **Bundle ID stays `com.tpak.Meridian`**: the beta shares UserDefaults with prod, so the user's real timezones and prefs come along for realistic UAT.
+- **Don't sign or notarize**: `CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`. The beta is for the user's own machine; Gatekeeper is satisfied by `xattr -cr`.
+- **Don't bump `project.pbxproj`**: the override is build-time only. The pbxproj retains the most recent released version. This prevents accidentally committing a beta version number to `main`.
+- **Sparkle won't auto-update the beta**: the production appcast tops out at the latest stable release; `2.19.1-beta1 > 2.19.1` lexically, so Sparkle sees nothing newer.
+
+### Iteration cycle
+
+When the user reports a problem with `betaN`:
+
+```bash
+# Make changes on the feature branch, commit, push (so the PR stays current)
+git add ... && git commit -m "..." && git push
+
+# Bump the beta number and rebuild + reinstall
+osascript -e 'tell application "Meridian" to quit' ; sleep 2
+xcodebuild ... MARKETING_VERSION=2.19.1-beta2 CURRENT_PROJECT_VERSION=2191002
+rm -rf ~/Applications/Meridian-beta.app
+cp -R "$HOME/Library/Developer/Xcode/DerivedData/Meridian-*/Build/Products/Debug/Meridian.app" \
+  ~/Applications/Meridian-beta.app
+xattr -cr ~/Applications/Meridian-beta.app
+open ~/Applications/Meridian-beta.app
+```
+
+### Switching back to production
+
+```bash
+osascript -e 'tell application "Meridian" to quit'
+open /Applications/Meridian.app                  # already-installed prod
+# OR
+brew reinstall meridian                          # clean reinstall of latest stable
+```
+
+### When to graduate to a real release
+
+Only after the user explicitly signs off on the latest beta:
+1. Verify CI is green on the PR
+2. `gh pr merge <N> --merge`
+3. `git checkout main && git pull`
+4. `bash scripts/release.sh -n "..." X.Y.Z` (or `make release VERSION=X.Y.Z` for single-line notes)
+
+The released binary is what Sparkle ships to all users; the beta UAT path makes sure that binary's behavior was confirmed by the user first.
+
 ## Coming Back After Months Away
 
 If you haven't touched this project in a while, here's how to get back up to speed and ship an update.
@@ -263,7 +345,7 @@ Before implementing any feature or fix, follow this workflow:
 
 ## Large Refactors — Parallel Agents
 
-For large refactors, use parallel agents to divide the work by concern. Coordinate results and present a unified summary with any conflicts between agents' changes.
+For large refactors, use parallel agents to divide the work by concern. Coordinate results and present a unified summary with any conflicts between agents' changes. Use the most sensible model for those agents to keep costs under control.
 
 **Agent 1 — UI/Storyboard**: Reorganize storyboard layout. Verify all IBOutlet connections are intact by grepping for `@IBOutlet` and matching against storyboard identifiers.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,42 @@ Only after the user explicitly signs off on the latest beta:
 
 The released binary is what Sparkle ships to all users; the beta UAT path makes sure that binary's behavior was confirmed by the user first.
 
+## Sparkle Beta Channel
+
+Meridian has a single Sparkle feed (`appcast.xml`) with two channels: the **default** channel (every user) and the **`beta`** channel (opt-in). Users opt in via the *"Receive beta releases"* checkbox in the About tab. The opt-in is persisted under `UserDefaultKeys.betaUpdatesEnabled` and surfaced to Sparkle through `SPUUpdaterDelegate.allowedChannels(for:)` in `AppDelegate`.
+
+Sparkle's rule: an updater **always** sees default-channel items and additionally sees items in any allowed channel. So a beta opt-in user automatically rolls forward into the GA release once it lands on the default channel — no extra plumbing required.
+
+### Cutting a beta release
+
+```bash
+git checkout main && git pull
+make release VERSION=2.20.0-beta1     # or beta2, beta3, …
+```
+
+The release script auto-detects the `-betaN` suffix and:
+- Tags the GitHub release as **prerelease** (`gh release create --prerelease`)
+- Adds `<sparkle:channel>beta</sparkle:channel>` to the new `appcast.xml` item
+- **Skips** the Homebrew cask update (cask tracks stable only)
+
+Stable users will not see the beta. Users who toggled *Receive beta releases* on will be offered it on their next Sparkle check (or immediately if they just flipped the toggle on — the toggle triggers `checkForUpdateInformation()`).
+
+### Cutting the GA after beta UAT
+
+```bash
+make release VERSION=2.20.0
+```
+
+Same as any other stable release. Beta-channel users see the GA item (no channel tag = default channel = always allowed) and version-compare ranks `2.20.0 > 2.20.0-beta3`, so they upgrade off the beta automatically.
+
+### Beta channel vs. local UAT betas
+
+These are different mechanisms with different audiences:
+- **Local UAT betas** (above) — built with `xcodebuild` overrides, installed to `~/Applications/Meridian-beta.app` on the developer's own machine. No distribution, no Sparkle. For pre-PR sanity checks.
+- **Sparkle beta channel** (this section) — full release pipeline, signed/notarized, distributed via Sparkle to opt-in users. For broader pre-GA testing.
+
+Use a local UAT beta to gain confidence in a feature, then cut a Sparkle beta to widen the test pool, then cut GA.
+
 ## Coming Back After Months Away
 
 If you haven't touched this project in a while, here's how to get back up to speed and ship an update.

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -264,6 +264,14 @@ extension AppDelegate: SPUUpdaterDelegate {
         return true
     }
 
+    // Sparkle channels (issue #98). Stable users see only items with no
+    // <sparkle:channel> tag. Opting in adds the "beta" channel — they then see
+    // beta-tagged items AND default-channel items, so the GA release supersedes
+    // the last beta automatically.
+    public func allowedChannels(for _: SPUUpdater) -> Set<String> {
+        UserDefaults.standard.bool(forKey: UserDefaultKeys.betaUpdatesEnabled) ? ["beta"] : []
+    }
+
     public func updater(_: SPUUpdater,
                         mayPerform updateCheck: SPUUpdateCheck) throws {
         Logger.production("Sparkle: checking for updates (\(describe(updateCheck)))")

--- a/Meridian/MeridianUnitTests/AppDelegateTests.swift
+++ b/Meridian/MeridianUnitTests/AppDelegateTests.swift
@@ -120,6 +120,28 @@ class AppDelegateTests: XCTestCase {
         XCTAssertNotNil(statusItemHandler?.statusItem.button)
     }
 
+    // Sparkle beta channel (issue #98). Verifies the SPUUpdaterDelegate routes
+    // users to the right release channel based on UserDefaultKeys.betaUpdatesEnabled.
+    func testAllowedChannels_optedOutByDefault() throws {
+        let subject = try XCTUnwrap(NSApplication.shared.delegate as? AppDelegate)
+        let priorValue = UserDefaults.standard.bool(forKey: UserDefaultKeys.betaUpdatesEnabled)
+        defer { UserDefaults.standard.set(priorValue, forKey: UserDefaultKeys.betaUpdatesEnabled) }
+
+        UserDefaults.standard.set(false, forKey: UserDefaultKeys.betaUpdatesEnabled)
+        XCTAssertEqual(subject.allowedChannels(for: subject.updaterController.updater), [],
+                       "Stable users must not see beta-tagged appcast items")
+    }
+
+    func testAllowedChannels_optedInExposesBetaChannel() throws {
+        let subject = try XCTUnwrap(NSApplication.shared.delegate as? AppDelegate)
+        let priorValue = UserDefaults.standard.bool(forKey: UserDefaultKeys.betaUpdatesEnabled)
+        defer { UserDefaults.standard.set(priorValue, forKey: UserDefaultKeys.betaUpdatesEnabled) }
+
+        UserDefaults.standard.set(true, forKey: UserDefaultKeys.betaUpdatesEnabled)
+        XCTAssertEqual(subject.allowedChannels(for: subject.updaterController.updater), ["beta"],
+                       "Beta opt-in must allow the \"beta\" channel")
+    }
+
     func testStandardModeMenubarSetup() throws {
         // Integration test: requires DataStore.shared() to drive the live status item handler.
         let olderTimezones = DataStore.shared().timezones()

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -32,6 +32,7 @@ public enum UserDefaultKeys {
     static let switchToCompactModeAlert = "com.tpak.meridian.switchToCompactMode"
     static let appleInterfaceStyleKey = "AppleInterfaceStyle"
     static let debugLoggingEnabled = "com.tpak.meridian.debugLoggingEnabled"
+    static let betaUpdatesEnabled = "com.tpak.meridian.betaUpdatesEnabled"
     static let latitude = "latitude"
     static let longitude = "longitude"
     static let nextUpdate = "nextUpdate"

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -61,6 +61,8 @@ struct AboutView: View {
 
             AutoUpdateToggle()
 
+            BetaChannelToggle()
+
             HStack(spacing: 8) {
                 Text(String(localized: "Check for Updates"))
                     .font(.custom("Avenir-Light", size: 13))
@@ -201,6 +203,33 @@ private struct UpdateCheckControls: View {
             appDelegate.updaterController.checkForUpdates(nil)
         }
         .font(.custom("Avenir-Light", size: 12))
+    }
+}
+
+// Beta channel opt-in (issue #98). When enabled, Sparkle's allowedChannels
+// delegate hands back ["beta"], unlocking pre-release items in appcast.xml.
+// Flipping the toggle on triggers an immediate background check so the user
+// sees a pending beta without waiting for the next scheduled poll.
+private struct BetaChannelToggle: View {
+    @AppStorage(UserDefaultKeys.betaUpdatesEnabled) private var receiveBetas = false
+
+    var body: some View {
+        VStack(alignment: .center, spacing: 4) {
+            Toggle(String(localized: "Receive beta releases"), isOn: $receiveBetas)
+                .font(.custom("Avenir-Book", size: 13))
+                .toggleStyle(.checkbox)
+                .fixedSize()
+                .accessibilityIdentifier("ReceiveBetaReleases")
+                .onChange(of: receiveBetas) { _ in
+                    guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
+                    appDelegate.updaterController.updater.checkForUpdateInformation()
+                }
+
+            Text(String(localized: "Pre-release builds — may have bugs."))
+                .font(.custom("Avenir-Light", size: 11))
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .center)
     }
 }
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -28,14 +28,23 @@ done
 # ── Phase 1: Validate ──────────────────────────────────────────────
 
 if [[ -z "$VERSION" ]]; then
-    echo "Usage: scripts/release.sh [-n \"release notes\"] X.Y.Z"
+    echo "Usage: scripts/release.sh [-n \"release notes\"] X.Y.Z[-betaN]"
     echo "       make release VERSION=X.Y.Z"
+    echo "       make release VERSION=X.Y.Z-beta1   (publishes to Sparkle 'beta' channel)"
     exit 1
 fi
 
-if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-    echo "Error: VERSION must match X.Y.Z pattern (got: $VERSION)"
+# Accept stable (X.Y.Z) and beta (X.Y.Z-betaN) versions.
+# Beta releases publish a prerelease GitHub release, tag the appcast item with
+# <sparkle:channel>beta</sparkle:channel>, and skip the Homebrew cask update.
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta[0-9]+)?$ ]]; then
+    echo "Error: VERSION must match X.Y.Z or X.Y.Z-betaN pattern (got: $VERSION)"
     exit 1
+fi
+
+IS_BETA=0
+if [[ "$VERSION" == *-beta* ]]; then
+    IS_BETA=1
 fi
 
 if [[ "$(git branch --show-current)" != "main" ]]; then
@@ -275,7 +284,11 @@ echo "  Length: $LENGTH"
 
 echo "── Creating GitHub release..."
 RELEASE_BODY="$(echo "$NOTES" | while IFS= read -r line; do echo "- $line"; done)"
-gh release create "v$VERSION" "$ZIP_PATH" --title "v$VERSION" --notes "$RELEASE_BODY"
+GH_RELEASE_FLAGS=()
+if [[ $IS_BETA -eq 1 ]]; then
+    GH_RELEASE_FLAGS+=(--prerelease)
+fi
+gh release create "v$VERSION" "$ZIP_PATH" --title "v$VERSION" --notes "$RELEASE_BODY" "${GH_RELEASE_FLAGS[@]}"
 
 echo "── GitHub release created."
 
@@ -297,9 +310,18 @@ LI_ITEMS="${LI_ITEMS%$'\n'}"
 
 DOWNLOAD_URL="https://github.com/tpak/Meridian/releases/download/v$VERSION/Meridian.app.zip"
 
+# Beta items get a <sparkle:channel>beta</sparkle:channel> tag so only users who
+# enabled "Receive beta releases" in About see them. Stable items omit the tag
+# (the default channel is always allowed).
+CHANNEL_TAG=""
+if [[ $IS_BETA -eq 1 ]]; then
+    CHANNEL_TAG="
+            <sparkle:channel>beta</sparkle:channel>"
+fi
+
 NEW_ITEM="        <item>
             <title>$VERSION</title>
-            <pubDate>$PUB_DATE</pubDate>
+            <pubDate>$PUB_DATE</pubDate>$CHANNEL_TAG
             <sparkle:version>$VERSION</sparkle:version>
             <sparkle:shortVersionString>$VERSION</sparkle:shortVersionString>
             <sparkle:minimumSystemVersion>13.0</sparkle:minimumSystemVersion>
@@ -341,29 +363,34 @@ fi
 echo "── Appcast updated and pushed."
 
 # ── Phase 6: Update Homebrew cask ──────────────────────────────────
+# Skipped for betas — the Homebrew cask tracks stable releases only.
 
-echo "── Updating Homebrew cask..."
-ZIP_SHA256="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
-
-CASK_REPO="tpak/homebrew-tpak"
-CASK_FILE="Casks/meridian.rb"
-
-if FILE_SHA="$(gh api "repos/$CASK_REPO/contents/$CASK_FILE" --jq '.sha' 2>/dev/null)"; then
-    CASK_CONTENT="$(gh api "repos/$CASK_REPO/contents/$CASK_FILE" \
-        --jq '.content' | base64 -d \
-        | sed "s/version \".*\"/version \"$VERSION\"/" \
-        | sed "s/sha256 \".*\"/sha256 \"$ZIP_SHA256\"/")"
-
-    ENCODED="$(printf '%s' "$CASK_CONTENT" | base64)"
-
-    gh api --method PUT "repos/$CASK_REPO/contents/$CASK_FILE" \
-        -f message="Update meridian to v$VERSION" \
-        -f content="$ENCODED" \
-        -f sha="$FILE_SHA" > /dev/null
-
-    echo "── Homebrew cask updated to v$VERSION."
+if [[ $IS_BETA -eq 1 ]]; then
+    echo "── Skipping Homebrew cask update for beta release."
 else
-    echo "WARNING: Homebrew cask file not found at $CASK_REPO/$CASK_FILE. Skipping cask update."
+    echo "── Updating Homebrew cask..."
+    ZIP_SHA256="$(shasum -a 256 "$ZIP_PATH" | awk '{print $1}')"
+
+    CASK_REPO="tpak/homebrew-tpak"
+    CASK_FILE="Casks/meridian.rb"
+
+    if FILE_SHA="$(gh api "repos/$CASK_REPO/contents/$CASK_FILE" --jq '.sha' 2>/dev/null)"; then
+        CASK_CONTENT="$(gh api "repos/$CASK_REPO/contents/$CASK_FILE" \
+            --jq '.content' | base64 -d \
+            | sed "s/version \".*\"/version \"$VERSION\"/" \
+            | sed "s/sha256 \".*\"/sha256 \"$ZIP_SHA256\"/")"
+
+        ENCODED="$(printf '%s' "$CASK_CONTENT" | base64)"
+
+        gh api --method PUT "repos/$CASK_REPO/contents/$CASK_FILE" \
+            -f message="Update meridian to v$VERSION" \
+            -f content="$ENCODED" \
+            -f sha="$FILE_SHA" > /dev/null
+
+        echo "── Homebrew cask updated to v$VERSION."
+    else
+        echo "WARNING: Homebrew cask file not found at $CASK_REPO/$CASK_FILE. Skipping cask update."
+    fi
 fi
 
 # ── Phase 7: Summary ────────────────────────────────────────────────

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -1,46 +1,103 @@
 #!/bin/bash
-# Validates Sparkle update-check logging.
+# Validates the Sparkle beta-channel feature (issue #98).
+# Run from repo root. Exits non-zero if any check fails.
 #
-# AppDelegate's SPUUpdaterDelegate extension should log when a scheduled or
-# user-initiated check starts, when it finds an update, when it finds none,
-# and when it aborts with an error. Without these hooks, users can't tell
-# from Console.app whether Sparkle is running its scheduled checks at all.
-set -eu
-
+# Three groups of checks:
+#   1. App-side wiring (UserDefaultKeys key, AppDelegate delegate, About toggle)
+#   2. Release tooling (version regex, sparkle:channel injection, prerelease, cask skip)
+#   3. Compilation (full xcodebuild)
+set -u
 cd "$(dirname "$0")/.."
 
-fail() { echo "FAIL: $1"; exit 1; }
-ok()   { echo "OK:   $1"; }
+PASS=0
+FAIL=0
+ok()   { echo "  OK:   $1"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL: $1" >&2; FAIL=$((FAIL+1)); }
+section() { echo ""; echo "── $1"; }
 
-FILE="Meridian/AppDelegate.swift"
+# ── 1. App-side wiring ────────────────────────────────────────────────
 
-grep -qE "mayPerform(UpdateCheck)? " "$FILE"              || fail "check-start hook (mayPerform:) not implemented"
-ok "check-start hook implemented"
+section "App: UserDefaultKeys"
+STRINGS_FILE="Meridian/Overall App/Strings.swift"
+grep -q 'static let betaUpdatesEnabled' "$STRINGS_FILE" \
+    && ok "betaUpdatesEnabled key declared in Strings.swift" \
+    || bad "betaUpdatesEnabled key missing in Strings.swift"
 
-grep -q 'Sparkle: checking for updates' "$FILE"           || fail "check-start log message missing"
-ok "check-start log message present"
+section "App: AppDelegate Sparkle channel delegate"
+APPDELEGATE="Meridian/AppDelegate.swift"
+grep -qE 'func allowedChannels\(for[^)]*\) -> Set<String>' "$APPDELEGATE" \
+    && ok "allowedChannels(for:) implemented in AppDelegate" \
+    || bad "allowedChannels(for:) not implemented in AppDelegate"
 
-grep -q "didFindValidUpdate" "$FILE"                      || fail "didFindValidUpdate hook not implemented"
-grep -q 'Sparkle: found update' "$FILE"                   || fail "found-update log message missing"
-ok "found-update hook + log present"
+grep -q 'UserDefaultKeys.betaUpdatesEnabled' "$APPDELEGATE" \
+    && ok "AppDelegate reads UserDefaultKeys.betaUpdatesEnabled" \
+    || bad "AppDelegate does not reference UserDefaultKeys.betaUpdatesEnabled"
 
-grep -q "updaterDidNotFindUpdate" "$FILE"                 || fail "updaterDidNotFindUpdate hook not implemented"
-grep -q 'Sparkle: no update available' "$FILE"            || fail "no-update log message missing"
-ok "no-update hook + log present"
+grep -qE '"beta"' "$APPDELEGATE" \
+    && ok "AppDelegate references the \"beta\" channel literal" \
+    || bad "AppDelegate is missing the \"beta\" channel literal"
 
-grep -q "didAbortWithError" "$FILE"                       || fail "didAbortWithError hook not implemented"
-grep -q 'Sparkle: update check aborted' "$FILE"           || fail "abort log message missing"
-ok "abort hook + log present"
+# Existing Sparkle hooks must be preserved (regression guard).
+grep -q "willInstallUpdateOnQuit" "$APPDELEGATE" \
+    && ok "existing willInstallUpdateOnQuit hook still present" \
+    || bad "willInstallUpdateOnQuit hook was removed"
 
-# Existing install-on-quit log must still be present (regression guard).
-grep -q "willInstallUpdateOnQuit" "$FILE"                 || fail "willInstallUpdateOnQuit hook regressed"
-ok "existing install-on-quit hook preserved"
+section "App: About tab beta toggle"
+ABOUT_VIEW="Meridian/Preferences/About/AboutView.swift"
+grep -q 'UserDefaultKeys.betaUpdatesEnabled' "$ABOUT_VIEW" \
+    && ok "AboutView binds to betaUpdatesEnabled" \
+    || bad "AboutView does not bind to betaUpdatesEnabled"
 
-# Must compile.
-xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \
+grep -qE 'BetaChannelToggle|Receive beta releases|Include beta releases' "$ABOUT_VIEW" \
+    && ok "AboutView declares a beta-channel toggle" \
+    || bad "AboutView has no visible beta toggle (looked for BetaChannelToggle / 'Receive beta releases' / 'Include beta releases')"
+
+# ── 2. Release tooling ───────────────────────────────────────────────
+
+section "Release script: version handling"
+RELEASE="scripts/release.sh"
+
+# Regex must permit X.Y.Z-betaN (look for -beta inside the bash =~ pattern).
+grep -qE 'VERSION.*=~.*-beta' "$RELEASE" \
+    && ok "release.sh version regex permits a -betaN suffix" \
+    || bad "release.sh version regex still rejects -betaN suffixes"
+
+grep -qE 'IS_BETA|is_beta|BETA_RELEASE' "$RELEASE" \
+    && ok "release.sh detects a beta version string" \
+    || bad "release.sh has no beta detection"
+
+section "Release script: appcast channel + prerelease"
+grep -q 'sparkle:channel' "$RELEASE" \
+    && ok "release.sh emits <sparkle:channel> for beta items" \
+    || bad "release.sh does not emit <sparkle:channel>"
+
+grep -q -- '--prerelease' "$RELEASE" \
+    && ok "release.sh passes --prerelease to gh for betas" \
+    || bad "release.sh never passes --prerelease"
+
+section "Release script: skip Homebrew cask for betas"
+# Look for a guard around the Homebrew section that references beta.
+if awk '/Update Homebrew cask/,/Homebrew cask updated/' "$RELEASE" \
+    | grep -qE 'IS_BETA|is_beta|BETA_RELEASE|Skipping cask.*beta|skipping.*cask'; then
+    ok "release.sh skips Homebrew cask update for betas"
+else
+    bad "release.sh always updates Homebrew cask (must skip for betas)"
+fi
+
+# ── 3. Compilation ───────────────────────────────────────────────────
+
+section "Build: xcodebuild Debug (no code signing)"
+if xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \
     CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= \
-    -quiet > /tmp/meridian_build.log 2>&1 \
-    || { tail -40 /tmp/meridian_build.log; fail "build failed"; }
-ok "build succeeded"
+    -quiet > /tmp/meridian_build.log 2>&1; then
+    ok "Debug build succeeded"
+else
+    tail -40 /tmp/meridian_build.log
+    bad "Debug build failed (see /tmp/meridian_build.log)"
+fi
 
-echo "Validation: all checks passed"
+# ── Summary ──────────────────────────────────────────────────────────
+
+echo ""
+echo "=== Validation: $PASS passed, $FAIL failed ==="
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Implements the beta release channel from #98 using **Sparkle 2's built-in `<sparkle:channel>` feature** — a single `appcast.xml` feed with channel-tagged items — instead of the two-feed (`appcast-beta.xml`) approach the issue originally proposed. This is the path the Sparkle maintainers [explicitly recommend](https://sparkle-project.org/documentation/publishing/) over `feedURLString(for:)`, and it makes the beta → GA transition automatic (a beta opt-in user always sees default-channel items, so the GA item supersedes the last beta with no extra plumbing).

### App side
- New `UserDefaultKeys.betaUpdatesEnabled` (default off).
- `SPUUpdaterDelegate.allowedChannels(for:)` returns `["beta"]` when on, `[]` when off.
- About tab: new "Receive beta releases" checkbox grouped with the auto-update controls. Toggling on triggers `checkForUpdateInformation()` so a pending beta surfaces immediately.

### Release pipeline
- `scripts/release.sh` accepts `X.Y.Z-betaN` (regex relaxed; `IS_BETA` flag auto-set from the version).
- For betas: `gh release create --prerelease`, inject `<sparkle:channel>beta</sparkle:channel>` into the new appcast item, **skip the Homebrew cask update** (cask stays on stable).
- Stable releases keep their current behavior end-to-end.

### Tests + validation
- Two new unit tests (`testAllowedChannels_optedOutByDefault`, `testAllowedChannels_optedInExposesBetaChannel`) — green.
- `scripts/validate_feature.sh` rewritten as a 13-check validator covering all wiring + a Debug build — passes 13/13.
- Full unit suite (`-only-testing:MeridianUnitTests -parallel-testing-enabled NO`) — green.
- SwiftLint — no new violations (untouched files have pre-existing warnings).

## Test plan

- [x] `bash scripts/validate_feature.sh` passes
- [x] Full unit suite passes locally
- [x] SwiftLint clean for changed files
- [ ] CI green on this PR
- [ ] Smoke test once merged: cut a `2.20.0-beta1` (next release), verify Sparkle picks it up only with the toggle on; cut GA `2.20.0`, verify beta users transition off automatically

## Out of scope (per #98)

- Beta-only branding/icon
- Separate beta cask
- Maintenance backport branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)