### PR TITLE
Fix Appearance tab crash from stale storyboard outlets

### DIFF
--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -401,8 +401,7 @@
                                                                                 <connections>
                                                                                     <outlet property="currentLocationIndicator" destination="r6M-RL-W27" id="JT0-pd-geS"/>
                                                                                     <outlet property="customName" destination="WD5-zQ-PiS" id="fGw-Z8-CXy"/>
-                                                                                    <outlet property="extraOptions" destination="PsO-qX-ocD" id="jbR-H4-6j8"/>
-                                                                                    <outlet property="noteLabel" destination="lUV-93-e7u" id="QCZ-yG-NfA"/>
+                                                                                    <outlet property="dstLabel" destination="lUV-93-e7u" id="QCZ-yG-NfA"/>
                                                                                     <outlet property="relativeDate" destination="dqz-hf-wTd" id="GYm-cn-Y1L"/>
                                                                                     <outlet property="sunriseImage" destination="2Kk-Xa-pWa" id="fYO-6Y-dqW"/>
                                                                                     <outlet property="sunriseSetTime" destination="kIm-II-xOl" id="op1-ET-w9E"/>


### PR DESCRIPTION
## Summary

Clicking the Appearance tab on shipped 2.19.1 reproducibly crashes the app. Crash report:

```
EXC_BREAKPOINT  Swift runtime failure:
"Unexpectedly found nil while implicitly unwrapping an Optional value"
TimezoneCellView.awakeFromNib()
← AppearanceViewController.tableView(_:viewFor:row:)  (line 359)
```

## Root cause

PR #99 (notes-feature removal) renamed `TimezoneCellView`'s `noteLabel` IBOutlet to `dstLabel` and deleted `extraOptions`. **`Panel.xib` was updated, but `Preferences.storyboard`'s `previewTimezoneCell` was missed** — it still wires to the old names. The unwired `dstLabel` ends up `nil`, and `awakeFromNib()`'s first reference to `dstLabel.setAccessibility(...)` traps. Reproduces on every Mac per user testing.

## Fix

One-line surgery in `Preferences.storyboard`:
- Rename outlet `noteLabel` → `dstLabel` (same destination view `lUV-93-e7u`)
- Delete the orphaned `extraOptions` outlet

## Test plan

- [x] Build locally with `MARKETING_VERSION=2.20.0-beta1`, install to `~/Applications/Meridian-beta.app`, click Appearance — no crash
- [ ] CI green
- [ ] User UAT confirms the Appearance tab opens cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)