### PR TITLE
Fix release.sh empty-array crash on stable releases

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -284,11 +284,13 @@ echo "  Length: $LENGTH"
 
 echo "── Creating GitHub release..."
 RELEASE_BODY="$(echo "$NOTES" | while IFS= read -r line; do echo "- $line"; done)"
-GH_RELEASE_FLAGS=()
+# macOS bash 3.x trips on expanding empty arrays under `set -u`, so split the
+# command on whether the prerelease flag applies instead of using an array.
 if [[ $IS_BETA -eq 1 ]]; then
-    GH_RELEASE_FLAGS+=(--prerelease)
+    gh release create "v$VERSION" "$ZIP_PATH" --title "v$VERSION" --notes "$RELEASE_BODY" --prerelease
+else
+    gh release create "v$VERSION" "$ZIP_PATH" --title "v$VERSION" --notes "$RELEASE_BODY"
 fi
-gh release create "v$VERSION" "$ZIP_PATH" --title "v$VERSION" --notes "$RELEASE_BODY" "${GH_RELEASE_FLAGS[@]}"
 
 echo "── GitHub release created."
 


### PR DESCRIPTION
## Summary

Follow-up to the v2.20.0 release. The PR #101 beta-channel work introduced an empty bash array that breaks every **stable** release under `set -u` on macOS bash 3.2:

```
── Creating GitHub release...
scripts/release.sh: line 291: GH_RELEASE_FLAGS[@]: unbound variable
```

The script aborts after notarization but before `gh release create`, the appcast update, and the Homebrew update — all of which then have to be done by hand. Beta releases were unaffected because the array always had at least one element (`--prerelease`).

For v2.20.0 itself: recovered by running the missing steps manually. Release is live: https://github.com/tpak/Meridian/releases/tag/v2.20.0 — appcast and cask both updated.

## Fix

Replace the array-of-flags pattern with an explicit `if/else` around the two `gh release create` invocations. Same behavior, no array expansion to confuse old bash.

## Test plan

- [x] `bash -n scripts/release.sh` — syntax OK
- [ ] CI green
- [ ] Real exercise: next release (whether beta or stable) runs through to completion without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)