### PR TITLE
Modernize inverted-bool/int UserDefaults semantics (#97)

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -176,7 +176,7 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func hideFromDock() {
-        UserDefaults.standard.set(0, forKey: UserDefaultKeys.appDisplayOptions)
+        DataStore.shared().appPresentation = .menubarOnly
         NSApp.setActivationPolicy(.accessory)
     }
 
@@ -196,10 +196,9 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
 
     // Should we have a dock icon or just stay in the menubar?
     private func setActivationPolicy() {
-        let defaults = UserDefaults.standard
-
         let currentActivationPolicy = NSRunningApplication.current.activationPolicy
-        let activationPolicy: NSApplication.ActivationPolicy = defaults.integer(forKey: UserDefaultKeys.appDisplayOptions) == 0 ? .accessory : .regular
+        let activationPolicy: NSApplication.ActivationPolicy =
+            DataStore.shared().appPresentation == .menubarOnly ? .accessory : .regular
 
         if currentActivationPolicy != activationPolicy {
             NSApp.setActivationPolicy(activationPolicy)

--- a/Meridian/Media.xcassets/Accent Color.colorset/Contents.json
+++ b/Meridian/Media.xcassets/Accent Color.colorset/Contents.json
@@ -2,12 +2,12 @@
   "colors" : [
     {
       "color" : {
-        "color-space" : "extended-srgb",
+        "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.999",
-          "green" : "0.000",
-          "red" : "0.092"
+          "alpha" : "0.850",
+          "blue" : "0.353",
+          "green" : "0.420",
+          "red" : "0.106"
         }
       },
       "idiom" : "universal"
@@ -20,12 +20,12 @@
         }
       ],
       "color" : {
-        "color-space" : "extended-srgb",
+        "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "0.109",
-          "green" : "0.958",
-          "red" : "0.071"
+          "alpha" : "0.850",
+          "blue" : "0.353",
+          "green" : "0.420",
+          "red" : "0.106"
         }
       },
       "idiom" : "universal"

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -506,3 +506,338 @@ class MeridianUnitTests: XCTestCase {
         XCTAssertEqual(restored?.longitude, original.longitude, "longitude should match")
     }
 }
+
+// MARK: - Typed accessor tests (issue #97)
+
+class DataStoreTypedAccessorsTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+    private var store: DataStore!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "com.tpak.meridian.tests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = DataStore(with: defaults)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        store = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: showSunriseSunset (inverted bool)
+
+    func testShowSunriseSunset_legacyShowReturnsTrue() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.sunriseSunsetTime)
+        XCTAssertTrue(store.showSunriseSunset)
+    }
+
+    func testShowSunriseSunset_legacyHideReturnsFalse() {
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.sunriseSunsetTime)
+        XCTAssertFalse(store.showSunriseSunset)
+    }
+
+    func testShowSunriseSunset_missingKeyReturnsFalse() {
+        XCTAssertFalse(store.showSunriseSunset)
+    }
+
+    func testShowSunriseSunset_writeTrueStoresZero() {
+        store.showSunriseSunset = true
+        XCTAssertEqual((defaults.object(forKey: UserDefaultKeys.sunriseSunsetTime) as? NSNumber)?.intValue, 0)
+    }
+
+    func testShowSunriseSunset_writeFalseStoresOne() {
+        store.showSunriseSunset = false
+        XCTAssertEqual((defaults.object(forKey: UserDefaultKeys.sunriseSunsetTime) as? NSNumber)?.intValue, 1)
+    }
+
+    func testShowSunriseSunset_roundTrip() {
+        store.showSunriseSunset = true
+        XCTAssertTrue(store.showSunriseSunset)
+        store.showSunriseSunset = false
+        XCTAssertFalse(store.showSunriseSunset)
+    }
+
+    // MARK: showFutureSlider (inverted bool)
+
+    func testShowFutureSlider_legacyShowReturnsTrue() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.displayFutureSliderKey)
+        XCTAssertTrue(store.showFutureSlider)
+    }
+
+    func testShowFutureSlider_legacyHideReturnsFalse() {
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.displayFutureSliderKey)
+        XCTAssertFalse(store.showFutureSlider)
+    }
+
+    func testShowFutureSlider_roundTrip() {
+        store.showFutureSlider = true
+        XCTAssertTrue(store.showFutureSlider)
+        store.showFutureSlider = false
+        XCTAssertFalse(store.showFutureSlider)
+    }
+
+    // MARK: showDayInMenubar (inverted bool, plain Int storage)
+
+    func testShowDayInMenubar_legacyShowReturnsTrue() {
+        defaults.set(0, forKey: UserDefaultKeys.showDayInMenu)
+        XCTAssertTrue(store.showDayInMenubar)
+    }
+
+    func testShowDayInMenubar_legacyHideReturnsFalse() {
+        defaults.set(1, forKey: UserDefaultKeys.showDayInMenu)
+        XCTAssertFalse(store.showDayInMenubar)
+    }
+
+    func testShowDayInMenubar_roundTrip() {
+        store.showDayInMenubar = true
+        XCTAssertTrue(store.showDayInMenubar)
+        store.showDayInMenubar = false
+        XCTAssertFalse(store.showDayInMenubar)
+    }
+
+    // MARK: showDateInMenubar (inverted bool, plain Int storage)
+
+    func testShowDateInMenubar_legacyShowReturnsTrue() {
+        defaults.set(0, forKey: UserDefaultKeys.showDateInMenu)
+        XCTAssertTrue(store.showDateInMenubar)
+    }
+
+    func testShowDateInMenubar_legacyHideReturnsFalse() {
+        defaults.set(1, forKey: UserDefaultKeys.showDateInMenu)
+        XCTAssertFalse(store.showDateInMenubar)
+    }
+
+    func testShowDateInMenubar_roundTrip() {
+        store.showDateInMenubar = true
+        XCTAssertTrue(store.showDateInMenubar)
+        store.showDateInMenubar = false
+        XCTAssertFalse(store.showDateInMenubar)
+    }
+
+    // MARK: showPlaceNameInMenubar (inverted bool, NSNumber storage)
+
+    func testShowPlaceNameInMenubar_legacyShowReturnsTrue() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.showPlaceInMenu)
+        XCTAssertTrue(store.showPlaceNameInMenubar)
+    }
+
+    func testShowPlaceNameInMenubar_legacyHideReturnsFalse() {
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.showPlaceInMenu)
+        XCTAssertFalse(store.showPlaceNameInMenubar)
+    }
+
+    func testShowPlaceNameInMenubar_roundTrip() {
+        store.showPlaceNameInMenubar = true
+        XCTAssertTrue(store.showPlaceNameInMenubar)
+        store.showPlaceNameInMenubar = false
+        XCTAssertFalse(store.showPlaceNameInMenubar)
+    }
+
+    // MARK: floatOnTop (NON-inverted bool, 1=on)
+
+    func testFloatOnTop_legacyOnReturnsTrue() {
+        defaults.set(1, forKey: UserDefaultKeys.showAppInForeground)
+        XCTAssertTrue(store.floatOnTop)
+    }
+
+    func testFloatOnTop_legacyOffReturnsFalse() {
+        defaults.set(0, forKey: UserDefaultKeys.showAppInForeground)
+        XCTAssertFalse(store.floatOnTop)
+    }
+
+    func testFloatOnTop_writeTrueStoresOne() {
+        store.floatOnTop = true
+        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.showAppInForeground), 1)
+    }
+
+    func testFloatOnTop_writeFalseStoresZero() {
+        store.floatOnTop = false
+        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.showAppInForeground), 0)
+    }
+
+    func testFloatOnTop_roundTrip() {
+        store.floatOnTop = true
+        XCTAssertTrue(store.floatOnTop)
+        store.floatOnTop = false
+        XCTAssertFalse(store.floatOnTop)
+    }
+
+    // MARK: menubarMode (enum)
+
+    func testMenubarMode_legacyCompactReturnsCompact() {
+        defaults.set(0, forKey: UserDefaultKeys.menubarCompactMode)
+        XCTAssertEqual(store.menubarMode, .compact)
+    }
+
+    func testMenubarMode_legacyStandardReturnsStandard() {
+        defaults.set(1, forKey: UserDefaultKeys.menubarCompactMode)
+        XCTAssertEqual(store.menubarMode, .standard)
+    }
+
+    func testMenubarMode_missingKeyReturnsStandardDefault() {
+        XCTAssertEqual(store.menubarMode, .standard)
+    }
+
+    func testMenubarMode_invalidRawFallsBackToStandard() {
+        defaults.set(99, forKey: UserDefaultKeys.menubarCompactMode)
+        XCTAssertEqual(store.menubarMode, .standard)
+    }
+
+    func testMenubarMode_roundTrip() {
+        store.menubarMode = .compact
+        XCTAssertEqual(store.menubarMode, .compact)
+        store.menubarMode = .standard
+        XCTAssertEqual(store.menubarMode, .standard)
+    }
+
+    // MARK: theme (enum)
+
+    func testTheme_legacyValuesMapCorrectly() {
+        defaults.set(0, forKey: UserDefaultKeys.themeKey)
+        XCTAssertEqual(store.theme, .light)
+        defaults.set(1, forKey: UserDefaultKeys.themeKey)
+        XCTAssertEqual(store.theme, .dark)
+        defaults.set(2, forKey: UserDefaultKeys.themeKey)
+        XCTAssertEqual(store.theme, .system)
+    }
+
+    func testTheme_missingKeyReturnsLightDefault() {
+        XCTAssertEqual(store.theme, .light)
+    }
+
+    func testTheme_roundTrip() {
+        store.theme = .dark
+        XCTAssertEqual(store.theme, .dark)
+        store.theme = .system
+        XCTAssertEqual(store.theme, .system)
+    }
+
+    // MARK: relativeDateDisplay (enum)
+
+    func testRelativeDateDisplay_legacyValuesMapCorrectly() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.relativeDateKey)
+        XCTAssertEqual(store.relativeDateDisplay, .relative)
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.relativeDateKey)
+        XCTAssertEqual(store.relativeDateDisplay, .actual)
+        defaults.set(NSNumber(value: 2), forKey: UserDefaultKeys.relativeDateKey)
+        XCTAssertEqual(store.relativeDateDisplay, .date)
+        defaults.set(NSNumber(value: 3), forKey: UserDefaultKeys.relativeDateKey)
+        XCTAssertEqual(store.relativeDateDisplay, .hidden)
+    }
+
+    func testRelativeDateDisplay_roundTrip() {
+        store.relativeDateDisplay = .actual
+        XCTAssertEqual(store.relativeDateDisplay, .actual)
+        store.relativeDateDisplay = .hidden
+        XCTAssertEqual(store.relativeDateDisplay, .hidden)
+    }
+
+    // MARK: appPresentation (enum)
+
+    func testAppPresentation_legacyMenubarOnlyReturnsMenubarOnly() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.appDisplayOptions)
+        XCTAssertEqual(store.appPresentation, .menubarOnly)
+    }
+
+    func testAppPresentation_legacyMenubarAndDockReturnsMenubarAndDock() {
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.appDisplayOptions)
+        XCTAssertEqual(store.appPresentation, .menubarAndDock)
+    }
+
+    func testAppPresentation_roundTrip() {
+        store.appPresentation = .menubarAndDock
+        XCTAssertEqual(store.appPresentation, .menubarAndDock)
+        store.appPresentation = .menubarOnly
+        XCTAssertEqual(store.appPresentation, .menubarOnly)
+    }
+
+    // MARK: timeFormat (enum)
+
+    func testTimeFormat_legacyValuesMapCorrectly() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
+        XCTAssertEqual(store.timeFormat, .twelveHour)
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
+        XCTAssertEqual(store.timeFormat, .twentyFourHour)
+        defaults.set(NSNumber(value: 11), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
+        XCTAssertEqual(store.timeFormat, .epoch)
+    }
+
+    func testTimeFormat_separatorIndexFallsBackToTwelveHour() {
+        // Index 2 is the "-- With Seconds --" separator row, which should never
+        // be selectable but defend against a stored value reaching us anyway.
+        defaults.set(NSNumber(value: 2), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
+        XCTAssertEqual(store.timeFormat, .twelveHour)
+    }
+
+    func testTimeFormat_roundTrip() {
+        store.timeFormat = .twentyFourHourWithSeconds
+        XCTAssertEqual(store.timeFormat, .twentyFourHourWithSeconds)
+    }
+
+    // MARK: parity with shouldDisplay()
+
+    // These prove the typed accessors return the same value as the existing
+    // shouldDisplay(_:) switch — so commit #3 can sweep call sites without
+    // introducing behavior changes.
+
+    func testParity_sunrise() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.sunriseSunsetTime)
+        XCTAssertEqual(store.showSunriseSunset, store.shouldDisplay(.sunrise))
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.sunriseSunsetTime)
+        XCTAssertEqual(store.showSunriseSunset, store.shouldDisplay(.sunrise))
+    }
+
+    func testParity_futureSlider() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.displayFutureSliderKey)
+        XCTAssertEqual(store.showFutureSlider, store.shouldDisplay(.futureSlider))
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.displayFutureSliderKey)
+        XCTAssertEqual(store.showFutureSlider, store.shouldDisplay(.futureSlider))
+    }
+
+    func testParity_dayInMenubar() {
+        defaults.set(0, forKey: UserDefaultKeys.showDayInMenu)
+        XCTAssertEqual(store.showDayInMenubar, store.shouldDisplay(.dayInMenubar))
+        defaults.set(1, forKey: UserDefaultKeys.showDayInMenu)
+        XCTAssertEqual(store.showDayInMenubar, store.shouldDisplay(.dayInMenubar))
+    }
+
+    func testParity_dateInMenubar() {
+        defaults.set(0, forKey: UserDefaultKeys.showDateInMenu)
+        XCTAssertEqual(store.showDateInMenubar, store.shouldDisplay(.dateInMenubar))
+        defaults.set(1, forKey: UserDefaultKeys.showDateInMenu)
+        XCTAssertEqual(store.showDateInMenubar, store.shouldDisplay(.dateInMenubar))
+    }
+
+    func testParity_placeNameInMenubar() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.showPlaceInMenu)
+        XCTAssertEqual(store.showPlaceNameInMenubar, store.shouldDisplay(.placeInMenubar))
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.showPlaceInMenu)
+        XCTAssertEqual(store.showPlaceNameInMenubar, store.shouldDisplay(.placeInMenubar))
+    }
+
+    func testParity_floatOnTop() {
+        defaults.set(1, forKey: UserDefaultKeys.showAppInForeground)
+        XCTAssertEqual(store.floatOnTop, store.shouldDisplay(.showAppInForeground))
+        defaults.set(0, forKey: UserDefaultKeys.showAppInForeground)
+        XCTAssertEqual(store.floatOnTop, store.shouldDisplay(.showAppInForeground))
+    }
+
+    func testParity_menubarMode() {
+        defaults.set(0, forKey: UserDefaultKeys.menubarCompactMode)
+        XCTAssertEqual(store.menubarMode == .compact, store.shouldDisplay(.menubarCompactMode))
+        defaults.set(1, forKey: UserDefaultKeys.menubarCompactMode)
+        XCTAssertEqual(store.menubarMode == .compact, store.shouldDisplay(.menubarCompactMode))
+    }
+
+    func testParity_appPresentation() {
+        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.appDisplayOptions)
+        XCTAssertEqual(store.appPresentation == .menubarOnly, store.shouldDisplay(.appDisplayOptions))
+        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.appDisplayOptions)
+        XCTAssertEqual(store.appPresentation == .menubarOnly, store.shouldDisplay(.appDisplayOptions))
+    }
+}

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -905,3 +905,252 @@ class BoolSemanticsMigrationTests: XCTestCase {
         XCTAssertEqual(store.relativeDateDisplay, .hidden)
     }
 }
+
+// MARK: - SettingsManager v1/v2 schema tests (issue #97)
+
+class SettingsManagerVersioningTests: XCTestCase {
+    // SettingsManager.buildJSON / applySettings touch DataStore.shared() — the
+    // singleton — so we save+restore around each test to avoid leaking state.
+    private struct PreservedState {
+        let showSunriseSunset: Bool
+        let showFutureSlider: Bool
+        let showDayInMenubar: Bool
+        let showDateInMenubar: Bool
+        let showPlaceNameInMenubar: Bool
+        let floatOnTop: Bool
+        let menubarMode: MenubarMode
+        let theme: Theme
+        let relativeDateDisplay: RelativeDateDisplay
+        let appPresentation: AppPresentation
+        let timeFormat: TimeFormat
+    }
+
+    private var preserved: PreservedState!
+
+    override func setUp() {
+        super.setUp()
+        let s = DataStore.shared()
+        preserved = PreservedState(
+            showSunriseSunset: s.showSunriseSunset,
+            showFutureSlider: s.showFutureSlider,
+            showDayInMenubar: s.showDayInMenubar,
+            showDateInMenubar: s.showDateInMenubar,
+            showPlaceNameInMenubar: s.showPlaceNameInMenubar,
+            floatOnTop: s.floatOnTop,
+            menubarMode: s.menubarMode,
+            theme: s.theme,
+            relativeDateDisplay: s.relativeDateDisplay,
+            appPresentation: s.appPresentation,
+            timeFormat: s.timeFormat
+        )
+    }
+
+    override func tearDown() {
+        let s = DataStore.shared()
+        s.showSunriseSunset = preserved.showSunriseSunset
+        s.showFutureSlider = preserved.showFutureSlider
+        s.showDayInMenubar = preserved.showDayInMenubar
+        s.showDateInMenubar = preserved.showDateInMenubar
+        s.showPlaceNameInMenubar = preserved.showPlaceNameInMenubar
+        s.floatOnTop = preserved.floatOnTop
+        s.menubarMode = preserved.menubarMode
+        s.theme = preserved.theme
+        s.relativeDateDisplay = preserved.relativeDateDisplay
+        s.appPresentation = preserved.appPresentation
+        s.timeFormat = preserved.timeFormat
+        super.tearDown()
+    }
+
+    private func parse(_ data: Data) -> [String: Any]? {
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    // MARK: export — v2 schema
+
+    func testExport_versionIs2() {
+        guard let data = SettingsManager.buildJSON(), let json = parse(data) else {
+            XCTFail("buildJSON returned no data")
+            return
+        }
+        XCTAssertEqual(json["version"] as? Int, 2)
+    }
+
+    func testExport_boolsAreEmittedAsBools() {
+        let s = DataStore.shared()
+        s.showSunriseSunset = true
+        s.showFutureSlider = false
+        s.showDayInMenubar = true
+        s.showDateInMenubar = false
+        s.showPlaceNameInMenubar = true
+        s.floatOnTop = false
+
+        guard let data = SettingsManager.buildJSON(),
+              let json = parse(data),
+              let prefs = json["preferences"] as? [String: Any] else {
+            XCTFail("export failed")
+            return
+        }
+        XCTAssertEqual(prefs["showSunriseSunset"] as? Bool, true)
+        XCTAssertEqual(prefs["showFutureSlider"] as? Bool, false)
+        XCTAssertEqual(prefs["showDayInMenubar"] as? Bool, true)
+        XCTAssertEqual(prefs["showDateInMenubar"] as? Bool, false)
+        XCTAssertEqual(prefs["showPlaceNameInMenubar"] as? Bool, true)
+        XCTAssertEqual(prefs["floatOnTop"] as? Bool, false)
+    }
+
+    func testExport_enumsAreEmittedAsNamedStrings() {
+        let s = DataStore.shared()
+        s.menubarMode = .compact
+        s.theme = .dark
+        s.relativeDateDisplay = .actual
+        s.appPresentation = .menubarAndDock
+        s.timeFormat = .twentyFourHourWithSeconds
+
+        guard let data = SettingsManager.buildJSON(),
+              let json = parse(data),
+              let prefs = json["preferences"] as? [String: Any] else {
+            XCTFail("export failed")
+            return
+        }
+        XCTAssertEqual(prefs["menubarMode"] as? String, "compact")
+        XCTAssertEqual(prefs["theme"] as? String, "dark")
+        XCTAssertEqual(prefs["relativeDateDisplay"] as? String, "actual")
+        XCTAssertEqual(prefs["appPresentation"] as? String, "menubarAndDock")
+        XCTAssertEqual(prefs["timeFormat"] as? String, "twentyFourHourWithSeconds")
+    }
+
+    // The original user complaint motivating issue #97 — exported JSON had
+    // "showSunriseSetTime: 0" for a setting the user had toggled on. This
+    // test pins the new behavior so it doesn't regress.
+    func testExport_userComplaintExample_sunriseTrueExportedAsTrue() {
+        DataStore.shared().showSunriseSunset = true
+        guard let data = SettingsManager.buildJSON(),
+              let json = parse(data),
+              let prefs = json["preferences"] as? [String: Any] else {
+            XCTFail("export failed")
+            return
+        }
+        XCTAssertEqual(prefs["showSunriseSunset"] as? Bool, true)
+        XCTAssertNil(prefs["showSunriseSetTime"], "Legacy key string should not appear in v2 export")
+    }
+
+    // MARK: import — v2 round-trip
+
+    func testImport_v2RoundTrip() throws {
+        // Set known typed state, export, mutate, import back, verify.
+        let s = DataStore.shared()
+        s.showSunriseSunset = true
+        s.showFutureSlider = false
+        s.menubarMode = .compact
+        s.theme = .dark
+        s.relativeDateDisplay = .hidden
+        s.timeFormat = .twentyFourHour
+        s.floatOnTop = true
+
+        guard let data = SettingsManager.buildJSON() else {
+            XCTFail("export failed")
+            return
+        }
+
+        // Mutate to confirm import actually overwrites.
+        s.showSunriseSunset = false
+        s.showFutureSlider = true
+        s.menubarMode = .standard
+        s.theme = .light
+        s.relativeDateDisplay = .relative
+        s.timeFormat = .twelveHour
+        s.floatOnTop = false
+
+        try SettingsManager.applySettings(from: data)
+
+        XCTAssertTrue(s.showSunriseSunset)
+        XCTAssertFalse(s.showFutureSlider)
+        XCTAssertEqual(s.menubarMode, .compact)
+        XCTAssertEqual(s.theme, .dark)
+        XCTAssertEqual(s.relativeDateDisplay, .hidden)
+        XCTAssertEqual(s.timeFormat, .twentyFourHour)
+        XCTAssertTrue(s.floatOnTop)
+    }
+
+    // MARK: import — v1 back-compat (2.19/2.20 export files)
+
+    func testImport_v1LegacyExportConvertsInversion() throws {
+        // Build a v1 payload by hand — this is what 2.19/2.20 wrote.
+        let v1: [String: Any] = [
+            "version": 1,
+            "preferences": [
+                "showSunriseSetTime": 0,         // legacy 0 = show
+                "displayFutureSlider": 1,        // legacy 1 = hide
+                "showDay": 0,                    // legacy 0 = show
+                "showDate": 1,                   // legacy 1 = hide
+                "showPlaceName": 0,              // legacy 0 = show
+                "displayAppAsForegroundApp": 1,  // legacy 1 = float
+                "is24HourFormatSelected": 4,     // 24-hour with seconds
+                "defaultTheme": 2,               // System
+                "relativeDate": 3,               // Hidden
+                "com.tpak.meridian.appDisplayOptions": 1,
+                "com.tpak.meridian.menubarCompactMode": 0
+            ],
+            "timezones": [String](),
+            "startAtLogin": false,
+            "sparkle": [String: Any]()
+        ]
+        let data = try JSONSerialization.data(withJSONObject: v1)
+
+        // Reset typed state to defaults so we can detect the v1 import wrote.
+        let s = DataStore.shared()
+        s.showSunriseSunset = false
+        s.showFutureSlider = true
+        s.showDayInMenubar = false
+        s.showDateInMenubar = true
+        s.showPlaceNameInMenubar = false
+        s.floatOnTop = false
+        s.timeFormat = .twelveHour
+        s.theme = .light
+        s.relativeDateDisplay = .relative
+        s.appPresentation = .menubarOnly
+        s.menubarMode = .standard
+
+        try SettingsManager.applySettings(from: data)
+
+        XCTAssertTrue(s.showSunriseSunset, "legacy 0 (show) should map to true")
+        XCTAssertFalse(s.showFutureSlider, "legacy 1 (hide) should map to false")
+        XCTAssertTrue(s.showDayInMenubar)
+        XCTAssertFalse(s.showDateInMenubar)
+        XCTAssertTrue(s.showPlaceNameInMenubar)
+        XCTAssertTrue(s.floatOnTop, "legacy 1 (float) should map to true (non-inverted)")
+        XCTAssertEqual(s.timeFormat, .twentyFourHourWithSeconds)
+        XCTAssertEqual(s.theme, .system)
+        XCTAssertEqual(s.relativeDateDisplay, .hidden)
+        XCTAssertEqual(s.appPresentation, .menubarAndDock)
+        XCTAssertEqual(s.menubarMode, .compact)
+    }
+
+    // MARK: import — error paths
+
+    func testImport_unsupportedVersionThrows() {
+        let payload: [String: Any] = ["version": 99, "preferences": [String: Any]()]
+        let data = try! JSONSerialization.data(withJSONObject: payload)
+        XCTAssertThrowsError(try SettingsManager.applySettings(from: data))
+    }
+
+    func testImport_invalidJSONThrows() {
+        let data = Data("not json".utf8)
+        XCTAssertThrowsError(try SettingsManager.applySettings(from: data))
+    }
+
+    func testImport_unknownEnumNameLeavesValueUnchanged() throws {
+        DataStore.shared().menubarMode = .standard
+        let payload: [String: Any] = [
+            "version": 2,
+            "preferences": ["menubarMode": "totallyMadeUp"],
+            "timezones": [String](),
+            "startAtLogin": false,
+            "sparkle": [String: Any]()
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        try SettingsManager.applySettings(from: data)
+        // Unknown enum name should not crash and should not corrupt the value.
+        XCTAssertEqual(DataStore.shared().menubarMode, .standard)
+    }
+}

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -529,162 +529,91 @@ class DataStoreTypedAccessorsTests: XCTestCase {
         super.tearDown()
     }
 
-    // MARK: showSunriseSunset (inverted bool)
+    // MARK: bools — read
 
-    func testShowSunriseSunset_legacyShowReturnsTrue() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.sunriseSunsetTime)
+    func testShowSunriseSunset_readsNewKey() {
+        defaults.set(true, forKey: UserDefaultKeys.showSunriseSunset)
         XCTAssertTrue(store.showSunriseSunset)
-    }
-
-    func testShowSunriseSunset_legacyHideReturnsFalse() {
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.sunriseSunsetTime)
+        defaults.set(false, forKey: UserDefaultKeys.showSunriseSunset)
         XCTAssertFalse(store.showSunriseSunset)
     }
 
-    func testShowSunriseSunset_missingKeyReturnsFalse() {
-        XCTAssertFalse(store.showSunriseSunset)
-    }
-
-    func testShowSunriseSunset_writeTrueStoresZero() {
-        store.showSunriseSunset = true
-        XCTAssertEqual((defaults.object(forKey: UserDefaultKeys.sunriseSunsetTime) as? NSNumber)?.intValue, 0)
-    }
-
-    func testShowSunriseSunset_writeFalseStoresOne() {
-        store.showSunriseSunset = false
-        XCTAssertEqual((defaults.object(forKey: UserDefaultKeys.sunriseSunsetTime) as? NSNumber)?.intValue, 1)
-    }
-
-    func testShowSunriseSunset_roundTrip() {
-        store.showSunriseSunset = true
-        XCTAssertTrue(store.showSunriseSunset)
-        store.showSunriseSunset = false
-        XCTAssertFalse(store.showSunriseSunset)
-    }
-
-    // MARK: showFutureSlider (inverted bool)
-
-    func testShowFutureSlider_legacyShowReturnsTrue() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.displayFutureSliderKey)
+    func testShowFutureSlider_readsNewKey() {
+        defaults.set(true, forKey: UserDefaultKeys.showFutureSlider)
         XCTAssertTrue(store.showFutureSlider)
-    }
-
-    func testShowFutureSlider_legacyHideReturnsFalse() {
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.displayFutureSliderKey)
+        defaults.set(false, forKey: UserDefaultKeys.showFutureSlider)
         XCTAssertFalse(store.showFutureSlider)
     }
 
-    func testShowFutureSlider_roundTrip() {
-        store.showFutureSlider = true
-        XCTAssertTrue(store.showFutureSlider)
+    func testShowDayInMenubar_readsNewKey() {
+        defaults.set(true, forKey: UserDefaultKeys.showDayInMenubar)
+        XCTAssertTrue(store.showDayInMenubar)
+    }
+
+    func testShowDateInMenubar_readsNewKey() {
+        defaults.set(true, forKey: UserDefaultKeys.showDateInMenubar)
+        XCTAssertTrue(store.showDateInMenubar)
+    }
+
+    func testShowPlaceNameInMenubar_readsNewKey() {
+        defaults.set(true, forKey: UserDefaultKeys.showPlaceNameInMenubar)
+        XCTAssertTrue(store.showPlaceNameInMenubar)
+    }
+
+    func testFloatOnTop_readsNewKey() {
+        defaults.set(true, forKey: UserDefaultKeys.floatOnTop)
+        XCTAssertTrue(store.floatOnTop)
+        defaults.set(false, forKey: UserDefaultKeys.floatOnTop)
+        XCTAssertFalse(store.floatOnTop)
+    }
+
+    // MARK: bools — write
+
+    func testShowSunriseSunset_writeStoresBool() {
+        store.showSunriseSunset = true
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.showSunriseSunset))
+        store.showSunriseSunset = false
+        XCTAssertFalse(defaults.bool(forKey: UserDefaultKeys.showSunriseSunset))
+    }
+
+    func testFloatOnTop_writeStoresBool() {
+        store.floatOnTop = true
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.floatOnTop))
+    }
+
+    // MARK: bools — round-trip
+
+    func testBoolAccessors_roundTrip() {
+        store.showSunriseSunset = true
         store.showFutureSlider = false
-        XCTAssertFalse(store.showFutureSlider)
-    }
-
-    // MARK: showDayInMenubar (inverted bool, plain Int storage)
-
-    func testShowDayInMenubar_legacyShowReturnsTrue() {
-        defaults.set(0, forKey: UserDefaultKeys.showDayInMenu)
-        XCTAssertTrue(store.showDayInMenubar)
-    }
-
-    func testShowDayInMenubar_legacyHideReturnsFalse() {
-        defaults.set(1, forKey: UserDefaultKeys.showDayInMenu)
-        XCTAssertFalse(store.showDayInMenubar)
-    }
-
-    func testShowDayInMenubar_roundTrip() {
         store.showDayInMenubar = true
-        XCTAssertTrue(store.showDayInMenubar)
-        store.showDayInMenubar = false
-        XCTAssertFalse(store.showDayInMenubar)
-    }
-
-    // MARK: showDateInMenubar (inverted bool, plain Int storage)
-
-    func testShowDateInMenubar_legacyShowReturnsTrue() {
-        defaults.set(0, forKey: UserDefaultKeys.showDateInMenu)
-        XCTAssertTrue(store.showDateInMenubar)
-    }
-
-    func testShowDateInMenubar_legacyHideReturnsFalse() {
-        defaults.set(1, forKey: UserDefaultKeys.showDateInMenu)
-        XCTAssertFalse(store.showDateInMenubar)
-    }
-
-    func testShowDateInMenubar_roundTrip() {
-        store.showDateInMenubar = true
-        XCTAssertTrue(store.showDateInMenubar)
         store.showDateInMenubar = false
-        XCTAssertFalse(store.showDateInMenubar)
-    }
-
-    // MARK: showPlaceNameInMenubar (inverted bool, NSNumber storage)
-
-    func testShowPlaceNameInMenubar_legacyShowReturnsTrue() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.showPlaceInMenu)
-        XCTAssertTrue(store.showPlaceNameInMenubar)
-    }
-
-    func testShowPlaceNameInMenubar_legacyHideReturnsFalse() {
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.showPlaceInMenu)
-        XCTAssertFalse(store.showPlaceNameInMenubar)
-    }
-
-    func testShowPlaceNameInMenubar_roundTrip() {
         store.showPlaceNameInMenubar = true
+        store.floatOnTop = true
+
+        XCTAssertTrue(store.showSunriseSunset)
+        XCTAssertFalse(store.showFutureSlider)
+        XCTAssertTrue(store.showDayInMenubar)
+        XCTAssertFalse(store.showDateInMenubar)
         XCTAssertTrue(store.showPlaceNameInMenubar)
-        store.showPlaceNameInMenubar = false
-        XCTAssertFalse(store.showPlaceNameInMenubar)
-    }
-
-    // MARK: floatOnTop (NON-inverted bool, 1=on)
-
-    func testFloatOnTop_legacyOnReturnsTrue() {
-        defaults.set(1, forKey: UserDefaultKeys.showAppInForeground)
         XCTAssertTrue(store.floatOnTop)
     }
 
-    func testFloatOnTop_legacyOffReturnsFalse() {
-        defaults.set(0, forKey: UserDefaultKeys.showAppInForeground)
-        XCTAssertFalse(store.floatOnTop)
-    }
+    // MARK: enums
 
-    func testFloatOnTop_writeTrueStoresOne() {
-        store.floatOnTop = true
-        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.showAppInForeground), 1)
-    }
-
-    func testFloatOnTop_writeFalseStoresZero() {
-        store.floatOnTop = false
-        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.showAppInForeground), 0)
-    }
-
-    func testFloatOnTop_roundTrip() {
-        store.floatOnTop = true
-        XCTAssertTrue(store.floatOnTop)
-        store.floatOnTop = false
-        XCTAssertFalse(store.floatOnTop)
-    }
-
-    // MARK: menubarMode (enum)
-
-    func testMenubarMode_legacyCompactReturnsCompact() {
-        defaults.set(0, forKey: UserDefaultKeys.menubarCompactMode)
+    func testMenubarMode_readsCanonicalKey() {
+        defaults.set(MenubarMode.compact.rawValue, forKey: UserDefaultKeys.menubarCompactMode)
         XCTAssertEqual(store.menubarMode, .compact)
-    }
-
-    func testMenubarMode_legacyStandardReturnsStandard() {
-        defaults.set(1, forKey: UserDefaultKeys.menubarCompactMode)
-        XCTAssertEqual(store.menubarMode, .standard)
-    }
-
-    func testMenubarMode_missingKeyReturnsStandardDefault() {
+        defaults.set(MenubarMode.standard.rawValue, forKey: UserDefaultKeys.menubarCompactMode)
         XCTAssertEqual(store.menubarMode, .standard)
     }
 
     func testMenubarMode_invalidRawFallsBackToStandard() {
         defaults.set(99, forKey: UserDefaultKeys.menubarCompactMode)
+        XCTAssertEqual(store.menubarMode, .standard)
+    }
+
+    func testMenubarMode_missingKeyReturnsStandard() {
         XCTAssertEqual(store.menubarMode, .standard)
     }
 
@@ -695,58 +624,18 @@ class DataStoreTypedAccessorsTests: XCTestCase {
         XCTAssertEqual(store.menubarMode, .standard)
     }
 
-    // MARK: theme (enum)
-
-    func testTheme_legacyValuesMapCorrectly() {
-        defaults.set(0, forKey: UserDefaultKeys.themeKey)
-        XCTAssertEqual(store.theme, .light)
-        defaults.set(1, forKey: UserDefaultKeys.themeKey)
-        XCTAssertEqual(store.theme, .dark)
-        defaults.set(2, forKey: UserDefaultKeys.themeKey)
-        XCTAssertEqual(store.theme, .system)
+    func testTheme_allCases() {
+        for theme: Theme in [.light, .dark, .system] {
+            store.theme = theme
+            XCTAssertEqual(store.theme, theme)
+        }
     }
 
-    func testTheme_missingKeyReturnsLightDefault() {
-        XCTAssertEqual(store.theme, .light)
-    }
-
-    func testTheme_roundTrip() {
-        store.theme = .dark
-        XCTAssertEqual(store.theme, .dark)
-        store.theme = .system
-        XCTAssertEqual(store.theme, .system)
-    }
-
-    // MARK: relativeDateDisplay (enum)
-
-    func testRelativeDateDisplay_legacyValuesMapCorrectly() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.relativeDateKey)
-        XCTAssertEqual(store.relativeDateDisplay, .relative)
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.relativeDateKey)
-        XCTAssertEqual(store.relativeDateDisplay, .actual)
-        defaults.set(NSNumber(value: 2), forKey: UserDefaultKeys.relativeDateKey)
-        XCTAssertEqual(store.relativeDateDisplay, .date)
-        defaults.set(NSNumber(value: 3), forKey: UserDefaultKeys.relativeDateKey)
-        XCTAssertEqual(store.relativeDateDisplay, .hidden)
-    }
-
-    func testRelativeDateDisplay_roundTrip() {
-        store.relativeDateDisplay = .actual
-        XCTAssertEqual(store.relativeDateDisplay, .actual)
-        store.relativeDateDisplay = .hidden
-        XCTAssertEqual(store.relativeDateDisplay, .hidden)
-    }
-
-    // MARK: appPresentation (enum)
-
-    func testAppPresentation_legacyMenubarOnlyReturnsMenubarOnly() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.appDisplayOptions)
-        XCTAssertEqual(store.appPresentation, .menubarOnly)
-    }
-
-    func testAppPresentation_legacyMenubarAndDockReturnsMenubarAndDock() {
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.appDisplayOptions)
-        XCTAssertEqual(store.appPresentation, .menubarAndDock)
+    func testRelativeDateDisplay_allCases() {
+        for value: RelativeDateDisplay in [.relative, .actual, .date, .hidden] {
+            store.relativeDateDisplay = value
+            XCTAssertEqual(store.relativeDateDisplay, value)
+        }
     }
 
     func testAppPresentation_roundTrip() {
@@ -756,88 +645,263 @@ class DataStoreTypedAccessorsTests: XCTestCase {
         XCTAssertEqual(store.appPresentation, .menubarOnly)
     }
 
-    // MARK: timeFormat (enum)
-
-    func testTimeFormat_legacyValuesMapCorrectly() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
-        XCTAssertEqual(store.timeFormat, .twelveHour)
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
-        XCTAssertEqual(store.timeFormat, .twentyFourHour)
-        defaults.set(NSNumber(value: 11), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
-        XCTAssertEqual(store.timeFormat, .epoch)
+    func testTimeFormat_allValidIndices() {
+        let cases: [TimeFormat] = [
+            .twelveHour, .twentyFourHour,
+            .twelveHourWithSeconds, .twentyFourHourWithSeconds,
+            .twelveHourWithLeadingZero, .twelveHourWithLeadingZeroAndSeconds,
+            .twelveHourWithoutAmPm, .twelveHourWithoutAmPmAndSeconds,
+            .epoch,
+        ]
+        for value in cases {
+            store.timeFormat = value
+            XCTAssertEqual(store.timeFormat, value, "round-trip failed for \(value)")
+        }
     }
 
-    func testTimeFormat_separatorIndexFallsBackToTwelveHour() {
-        // Index 2 is the "-- With Seconds --" separator row, which should never
-        // be selectable but defend against a stored value reaching us anyway.
-        defaults.set(NSNumber(value: 2), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
-        XCTAssertEqual(store.timeFormat, .twelveHour)
-    }
-
-    func testTimeFormat_roundTrip() {
-        store.timeFormat = .twentyFourHourWithSeconds
-        XCTAssertEqual(store.timeFormat, .twentyFourHourWithSeconds)
+    func testTimeFormat_separatorRawFallsBackToTwelveHour() {
+        // Indices 2/5/8 are disabled separator rows; if a stale value lands
+        // there we should not crash, just fall back.
+        for separatorRaw in [2, 5, 8] {
+            defaults.set(separatorRaw, forKey: UserDefaultKeys.timeFormat)
+            XCTAssertEqual(store.timeFormat, .twelveHour)
+        }
     }
 
     // MARK: parity with shouldDisplay()
 
-    // These prove the typed accessors return the same value as the existing
-    // shouldDisplay(_:) switch — so commit #3 can sweep call sites without
-    // introducing behavior changes.
+    // shouldDisplay(_:) now delegates to typed accessors; these asserts make
+    // sure that delegation never drifts.
 
     func testParity_sunrise() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.sunriseSunsetTime)
+        store.showSunriseSunset = true
         XCTAssertEqual(store.showSunriseSunset, store.shouldDisplay(.sunrise))
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.sunriseSunsetTime)
+        store.showSunriseSunset = false
         XCTAssertEqual(store.showSunriseSunset, store.shouldDisplay(.sunrise))
     }
 
     func testParity_futureSlider() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.displayFutureSliderKey)
+        store.showFutureSlider = true
         XCTAssertEqual(store.showFutureSlider, store.shouldDisplay(.futureSlider))
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.displayFutureSliderKey)
+        store.showFutureSlider = false
         XCTAssertEqual(store.showFutureSlider, store.shouldDisplay(.futureSlider))
     }
 
     func testParity_dayInMenubar() {
-        defaults.set(0, forKey: UserDefaultKeys.showDayInMenu)
+        store.showDayInMenubar = true
         XCTAssertEqual(store.showDayInMenubar, store.shouldDisplay(.dayInMenubar))
-        defaults.set(1, forKey: UserDefaultKeys.showDayInMenu)
+        store.showDayInMenubar = false
         XCTAssertEqual(store.showDayInMenubar, store.shouldDisplay(.dayInMenubar))
     }
 
     func testParity_dateInMenubar() {
-        defaults.set(0, forKey: UserDefaultKeys.showDateInMenu)
+        store.showDateInMenubar = true
         XCTAssertEqual(store.showDateInMenubar, store.shouldDisplay(.dateInMenubar))
-        defaults.set(1, forKey: UserDefaultKeys.showDateInMenu)
+        store.showDateInMenubar = false
         XCTAssertEqual(store.showDateInMenubar, store.shouldDisplay(.dateInMenubar))
     }
 
     func testParity_placeNameInMenubar() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.showPlaceInMenu)
+        store.showPlaceNameInMenubar = true
         XCTAssertEqual(store.showPlaceNameInMenubar, store.shouldDisplay(.placeInMenubar))
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.showPlaceInMenu)
+        store.showPlaceNameInMenubar = false
         XCTAssertEqual(store.showPlaceNameInMenubar, store.shouldDisplay(.placeInMenubar))
     }
 
     func testParity_floatOnTop() {
-        defaults.set(1, forKey: UserDefaultKeys.showAppInForeground)
+        store.floatOnTop = true
         XCTAssertEqual(store.floatOnTop, store.shouldDisplay(.showAppInForeground))
-        defaults.set(0, forKey: UserDefaultKeys.showAppInForeground)
+        store.floatOnTop = false
         XCTAssertEqual(store.floatOnTop, store.shouldDisplay(.showAppInForeground))
     }
 
     func testParity_menubarMode() {
-        defaults.set(0, forKey: UserDefaultKeys.menubarCompactMode)
-        XCTAssertEqual(store.menubarMode == .compact, store.shouldDisplay(.menubarCompactMode))
-        defaults.set(1, forKey: UserDefaultKeys.menubarCompactMode)
-        XCTAssertEqual(store.menubarMode == .compact, store.shouldDisplay(.menubarCompactMode))
+        store.menubarMode = .compact
+        XCTAssertTrue(store.shouldDisplay(.menubarCompactMode))
+        store.menubarMode = .standard
+        XCTAssertFalse(store.shouldDisplay(.menubarCompactMode))
     }
 
     func testParity_appPresentation() {
-        defaults.set(NSNumber(value: 0), forKey: UserDefaultKeys.appDisplayOptions)
-        XCTAssertEqual(store.appPresentation == .menubarOnly, store.shouldDisplay(.appDisplayOptions))
-        defaults.set(NSNumber(value: 1), forKey: UserDefaultKeys.appDisplayOptions)
-        XCTAssertEqual(store.appPresentation == .menubarOnly, store.shouldDisplay(.appDisplayOptions))
+        store.appPresentation = .menubarOnly
+        XCTAssertTrue(store.shouldDisplay(.appDisplayOptions))
+        store.appPresentation = .menubarAndDock
+        XCTAssertFalse(store.shouldDisplay(.appDisplayOptions))
+    }
+}
+
+// MARK: - BoolSemanticsMigration tests (issue #97)
+
+class BoolSemanticsMigrationTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var suiteName: String!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "com.tpak.meridian.migration.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        super.tearDown()
+    }
+
+    // MARK: idempotency
+
+    // The persistent domain excludes the global registration domain (which
+    // the host app's launch populates via register(defaults:)), so it's
+    // the right lens for "did the migration actually persist a write".
+    private func persistent() -> [String: Any] {
+        defaults.persistentDomain(forName: suiteName) ?? [:]
+    }
+
+    func testFreshInstall_noOpButSetsFlag() {
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.boolSemanticsMigrationV1))
+        // The only persistent write should be the flag — migration didn't
+        // touch any new key because no legacy values were present.
+        let p = persistent()
+        XCTAssertNil(p[UserDefaultKeys.showSunriseSunset])
+        XCTAssertNil(p[UserDefaultKeys.floatOnTop])
+        XCTAssertNil(p[UserDefaultKeys.timeFormat])
+        XCTAssertNotNil(p[UserDefaultKeys.boolSemanticsMigrationV1])
+    }
+
+    func testIdempotent_secondRunIsNoOp() {
+        // First run: flag set, no legacy values present.
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+        // Now plant legacy keys — second run should ignore them because the
+        // flag is set, so no new-key writes should happen.
+        defaults.set(0, forKey: UserDefaultKeys.sunriseSunsetTime)
+        defaults.set(1, forKey: UserDefaultKeys.showAppInForeground)
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+        let p = persistent()
+        XCTAssertNil(p[UserDefaultKeys.showSunriseSunset])
+        XCTAssertNil(p[UserDefaultKeys.floatOnTop])
+        // Legacy keys are still where the test left them — second run did
+        // not migrate them away.
+        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.sunriseSunsetTime), 0)
+    }
+
+    // MARK: inverted bools
+
+    func testInvertedBool_legacyZeroBecomesTrue() {
+        // 0 = show in legacy
+        defaults.set(0, forKey: UserDefaultKeys.sunriseSunsetTime)
+        defaults.set(0, forKey: UserDefaultKeys.displayFutureSliderKey)
+        defaults.set(0, forKey: UserDefaultKeys.showDayInMenu)
+        defaults.set(0, forKey: UserDefaultKeys.showDateInMenu)
+        defaults.set(0, forKey: UserDefaultKeys.showPlaceInMenu)
+
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.showSunriseSunset))
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.showFutureSlider))
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.showDayInMenubar))
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.showDateInMenubar))
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.showPlaceNameInMenubar))
+    }
+
+    func testInvertedBool_legacyOneBecomesFalse() {
+        defaults.set(1, forKey: UserDefaultKeys.sunriseSunsetTime)
+        defaults.set(1, forKey: UserDefaultKeys.displayFutureSliderKey)
+        defaults.set(1, forKey: UserDefaultKeys.showDayInMenu)
+        defaults.set(1, forKey: UserDefaultKeys.showDateInMenu)
+        defaults.set(1, forKey: UserDefaultKeys.showPlaceInMenu)
+
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+
+        XCTAssertFalse(defaults.bool(forKey: UserDefaultKeys.showSunriseSunset))
+        XCTAssertFalse(defaults.bool(forKey: UserDefaultKeys.showFutureSlider))
+        XCTAssertFalse(defaults.bool(forKey: UserDefaultKeys.showDayInMenubar))
+        XCTAssertFalse(defaults.bool(forKey: UserDefaultKeys.showDateInMenubar))
+        XCTAssertFalse(defaults.bool(forKey: UserDefaultKeys.showPlaceNameInMenubar))
+    }
+
+    func testInvertedBool_legacyKeysRemovedAfterMigration() {
+        defaults.set(0, forKey: UserDefaultKeys.sunriseSunsetTime)
+        defaults.set(1, forKey: UserDefaultKeys.showDayInMenu)
+
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+
+        XCTAssertNil(defaults.object(forKey: UserDefaultKeys.sunriseSunsetTime))
+        XCTAssertNil(defaults.object(forKey: UserDefaultKeys.showDayInMenu))
+    }
+
+    // MARK: non-inverted bool
+
+    func testFloatOnTop_legacyOneBecomesTrue() {
+        defaults.set(1, forKey: UserDefaultKeys.showAppInForeground)
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.floatOnTop))
+        XCTAssertNil(defaults.object(forKey: UserDefaultKeys.showAppInForeground))
+    }
+
+    func testFloatOnTop_legacyZeroBecomesFalse() {
+        defaults.set(0, forKey: UserDefaultKeys.showAppInForeground)
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+        XCTAssertFalse(defaults.bool(forKey: UserDefaultKeys.floatOnTop))
+        XCTAssertNil(defaults.object(forKey: UserDefaultKeys.showAppInForeground))
+    }
+
+    // MARK: time format rename
+
+    func testTimeFormat_legacyValueCopiedToNewKey() {
+        defaults.set(NSNumber(value: 7), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.timeFormat), 7)
+        XCTAssertNil(defaults.object(forKey: UserDefaultKeys.selectedTimeZoneFormatKey))
+    }
+
+    // MARK: untouched keys
+
+    func testUntouchedKeys_themeAndRelativeDateAndAppDisplayAndMenubarMode() {
+        defaults.set(2, forKey: UserDefaultKeys.themeKey)
+        defaults.set(3, forKey: UserDefaultKeys.relativeDateKey)
+        defaults.set(1, forKey: UserDefaultKeys.appDisplayOptions)
+        defaults.set(0, forKey: UserDefaultKeys.menubarCompactMode)
+
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+
+        // Migration must not touch already-correct enum keys.
+        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.themeKey), 2)
+        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.relativeDateKey), 3)
+        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.appDisplayOptions), 1)
+        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.menubarCompactMode), 0)
+    }
+
+    // MARK: integration with typed accessors
+
+    func testEndToEnd_legacyValuesReadableViaTypedAccessorsAfterMigration() {
+        // Plant the full legacy schema for an upgrading user.
+        defaults.set(0, forKey: UserDefaultKeys.sunriseSunsetTime)         // show
+        defaults.set(1, forKey: UserDefaultKeys.displayFutureSliderKey)    // hide
+        defaults.set(0, forKey: UserDefaultKeys.showDayInMenu)             // show
+        defaults.set(1, forKey: UserDefaultKeys.showDateInMenu)            // hide
+        defaults.set(0, forKey: UserDefaultKeys.showPlaceInMenu)           // show
+        defaults.set(1, forKey: UserDefaultKeys.showAppInForeground)       // float
+        defaults.set(NSNumber(value: 4), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
+        defaults.set(0, forKey: UserDefaultKeys.menubarCompactMode)        // compact
+        defaults.set(1, forKey: UserDefaultKeys.appDisplayOptions)         // dock
+        defaults.set(2, forKey: UserDefaultKeys.themeKey)                  // system
+        defaults.set(3, forKey: UserDefaultKeys.relativeDateKey)           // hidden
+
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+
+        let store = DataStore(with: defaults)
+        XCTAssertTrue(store.showSunriseSunset)
+        XCTAssertFalse(store.showFutureSlider)
+        XCTAssertTrue(store.showDayInMenubar)
+        XCTAssertFalse(store.showDateInMenubar)
+        XCTAssertTrue(store.showPlaceNameInMenubar)
+        XCTAssertTrue(store.floatOnTop)
+        XCTAssertEqual(store.timeFormat, .twentyFourHourWithSeconds)
+        XCTAssertEqual(store.menubarMode, .compact)
+        XCTAssertEqual(store.appPresentation, .menubarAndDock)
+        XCTAssertEqual(store.theme, .system)
+        XCTAssertEqual(store.relativeDateDisplay, .hidden)
     }
 }

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -1074,6 +1074,22 @@ class SettingsManagerVersioningTests: XCTestCase {
 
     // MARK: import — v1 back-compat (2.19/2.20 export files)
 
+    func testExport_betaUpdatesEnabledRoundTrip() throws {
+        UserDefaults.standard.set(true, forKey: UserDefaultKeys.betaUpdatesEnabled)
+        defer { UserDefaults.standard.removeObject(forKey: UserDefaultKeys.betaUpdatesEnabled) }
+        guard let data = SettingsManager.buildJSON(),
+              let json = parse(data),
+              let prefs = json["preferences"] as? [String: Any] else {
+            XCTFail("export failed")
+            return
+        }
+        XCTAssertEqual(prefs["betaUpdatesEnabled"] as? Bool, true)
+
+        UserDefaults.standard.set(false, forKey: UserDefaultKeys.betaUpdatesEnabled)
+        try SettingsManager.applySettings(from: data)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: UserDefaultKeys.betaUpdatesEnabled))
+    }
+
     func testImport_v1LegacyExportConvertsInversion() throws {
         // Build a v1 payload by hand — this is what 2.19/2.20 wrote.
         let v1: [String: Any] = [
@@ -1089,7 +1105,8 @@ class SettingsManagerVersioningTests: XCTestCase {
                 "defaultTheme": 2,               // System
                 "relativeDate": 3,               // Hidden
                 "com.tpak.meridian.appDisplayOptions": 1,
-                "com.tpak.meridian.menubarCompactMode": 0
+                "com.tpak.meridian.menubarCompactMode": 0,
+                "com.tpak.meridian.betaUpdatesEnabled": true
             ],
             "timezones": [String](),
             "startAtLogin": false,
@@ -1124,6 +1141,8 @@ class SettingsManagerVersioningTests: XCTestCase {
         XCTAssertEqual(s.relativeDateDisplay, .hidden)
         XCTAssertEqual(s.appPresentation, .menubarAndDock)
         XCTAssertEqual(s.menubarMode, .compact)
+        XCTAssertTrue(UserDefaults.standard.bool(forKey: UserDefaultKeys.betaUpdatesEnabled))
+        UserDefaults.standard.removeObject(forKey: UserDefaultKeys.betaUpdatesEnabled)
     }
 
     // MARK: import — error paths

--- a/Meridian/Overall App/AppDefaults.swift
+++ b/Meridian/Overall App/AppDefaults.swift
@@ -17,28 +17,98 @@ class AppDefaults {
     private class func initializeDefaults(with store: DataStore, defaults: UserDefaults) {
         let timezones = store.timezones()
 
-        // Register the usual suspects
+        // Migrate legacy inverted-bool / int-encoded keys to typed storage
+        // BEFORE registering defaults — migration only acts on user-set values
+        // (object(forKey:) returning non-nil from the persistent domain), so
+        // running it before register(defaults:) keeps registered fallbacks
+        // out of the migration's read path.
+        runBoolSemanticsMigration(on: defaults)
+
         defaults.register(defaults: defaultsDictionary())
 
         store.setTimezones(timezones)
     }
 
+    /// One-time migration that converts legacy inverted-bool and int-encoded
+    /// preference keys to the modernized typed schema (issue #97). Idempotent:
+    /// guarded by `UserDefaultKeys.boolSemanticsMigrationV1`. Public for tests.
+    class func runBoolSemanticsMigration(on defaults: UserDefaults) {
+        guard !defaults.bool(forKey: UserDefaultKeys.boolSemanticsMigrationV1) else {
+            return
+        }
+
+        // Inverted bools: legacy 0 = show, 1 = hide → typed Bool (true = show).
+        migrateInvertedBool(legacy: UserDefaultKeys.sunriseSunsetTime,
+                            target: UserDefaultKeys.showSunriseSunset,
+                            in: defaults)
+        migrateInvertedBool(legacy: UserDefaultKeys.displayFutureSliderKey,
+                            target: UserDefaultKeys.showFutureSlider,
+                            in: defaults)
+        migrateInvertedBool(legacy: UserDefaultKeys.showDayInMenu,
+                            target: UserDefaultKeys.showDayInMenubar,
+                            in: defaults)
+        migrateInvertedBool(legacy: UserDefaultKeys.showDateInMenu,
+                            target: UserDefaultKeys.showDateInMenubar,
+                            in: defaults)
+        migrateInvertedBool(legacy: UserDefaultKeys.showPlaceInMenu,
+                            target: UserDefaultKeys.showPlaceNameInMenubar,
+                            in: defaults)
+
+        // Non-inverted bool: legacy 1 = floatOnTop, 0 = menubar.
+        if let legacyValue = defaults.object(forKey: UserDefaultKeys.showAppInForeground) as? Int {
+            defaults.set(legacyValue == 1, forKey: UserDefaultKeys.floatOnTop)
+            defaults.removeObject(forKey: UserDefaultKeys.showAppInForeground)
+        }
+
+        // Wide enum: time format index moves to a clearer key but keeps its
+        // Int storage (raw value matches NSPopUpButton selectedIndex).
+        if let legacyValue = defaults.object(forKey: UserDefaultKeys.selectedTimeZoneFormatKey) as? NSNumber {
+            defaults.set(legacyValue.intValue, forKey: UserDefaultKeys.timeFormat)
+            defaults.removeObject(forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
+        }
+
+        // theme, relativeDate, appDisplayOptions, menubarCompactMode keep
+        // their existing key strings — they're already namespaced and not
+        // semantically inverted. The typed accessors layer enums over them
+        // without renaming.
+
+        defaults.set(true, forKey: UserDefaultKeys.boolSemanticsMigrationV1)
+    }
+
+    private class func migrateInvertedBool(legacy: String, target: String, in defaults: UserDefaults) {
+        // Read the persistent value only — register(defaults:) hasn't been
+        // called yet, so object(forKey:) returns nil iff the user never set
+        // this key explicitly. In that case we leave both keys untouched and
+        // let the new key's registered default take over below.
+        guard let object = defaults.object(forKey: legacy) else { return }
+        let legacyInt = (object as? NSNumber)?.intValue ?? (object as? Int) ?? 1
+        defaults.set(legacyInt == 0, forKey: target)
+        defaults.removeObject(forKey: legacy)
+    }
+
     private class func defaultsDictionary() -> [String: Any] {
-        return [UserDefaultKeys.themeKey: 0,
-                UserDefaultKeys.displayFutureSliderKey: 0,
-                UserDefaultKeys.selectedTimeZoneFormatKey: 0, // 12-hour format
-                UserDefaultKeys.relativeDateKey: 0,
-                UserDefaultKeys.showDayInMenu: 0,
-                UserDefaultKeys.showDateInMenu: 1,
-                UserDefaultKeys.showPlaceInMenu: 0,
-                UserDefaultKeys.startAtLogin: 0,
-                UserDefaultKeys.sunriseSunsetTime: 1,
-                UserDefaultKeys.userFontSizePreference: AppDefaultValues.defaultUserFontSize,
-                UserDefaultKeys.showAppInForeground: 0,
-                UserDefaultKeys.futureSliderRange: AppDefaultValues.defaultFutureSliderRange,
-                UserDefaultKeys.truncateTextLength: AppDefaultValues.defaultTruncateTextLength,
-                UserDefaultKeys.appDisplayOptions: 0,
-                UserDefaultKeys.menubarCompactMode: 1]
+        return [
+            // Already-correct enum keys — names unchanged.
+            UserDefaultKeys.themeKey: Theme.light.rawValue,
+            UserDefaultKeys.relativeDateKey: RelativeDateDisplay.relative.rawValue,
+            UserDefaultKeys.appDisplayOptions: AppPresentation.menubarOnly.rawValue,
+            UserDefaultKeys.menubarCompactMode: MenubarMode.standard.rawValue,
+
+            // Modernized typed keys (issue #97).
+            UserDefaultKeys.showSunriseSunset: false,
+            UserDefaultKeys.showFutureSlider: true,
+            UserDefaultKeys.showDayInMenubar: true,
+            UserDefaultKeys.showDateInMenubar: false,
+            UserDefaultKeys.showPlaceNameInMenubar: true,
+            UserDefaultKeys.floatOnTop: false,
+            UserDefaultKeys.timeFormat: TimeFormat.twelveHour.rawValue,
+
+            // Untouched.
+            UserDefaultKeys.startAtLogin: 0,
+            UserDefaultKeys.userFontSizePreference: AppDefaultValues.defaultUserFontSize,
+            UserDefaultKeys.futureSliderRange: AppDefaultValues.defaultFutureSliderRange,
+            UserDefaultKeys.truncateTextLength: AppDefaultValues.defaultTruncateTextLength
+        ]
     }
 }
 

--- a/Meridian/Overall App/DataStore.swift
+++ b/Meridian/Overall App/DataStore.swift
@@ -176,3 +176,163 @@ class DataStore: NSObject, DataStoring {
         return value == 0
     }
 }
+
+// MARK: - Typed preference enums (issue #97)
+
+enum MenubarMode: Int, Codable {
+    case compact = 0
+    case standard = 1
+}
+
+enum Theme: Int, Codable {
+    case light = 0
+    case dark = 1
+    case system = 2
+}
+
+enum RelativeDateDisplay: Int, Codable {
+    case relative = 0
+    case actual = 1
+    case date = 2
+    case hidden = 3
+}
+
+enum AppPresentation: Int, Codable {
+    case menubarOnly = 0
+    case menubarAndDock = 1
+}
+
+// Indices match the popup item order in
+// AppearanceViewController.setupTimeFormatPopup(); 2/5/8 are disabled
+// separator rows and intentionally have no enum case.
+enum TimeFormat: Int, Codable {
+    case twelveHour = 0
+    case twentyFourHour = 1
+    case twelveHourWithSeconds = 3
+    case twentyFourHourWithSeconds = 4
+    case twelveHourWithLeadingZero = 6
+    case twelveHourWithLeadingZeroAndSeconds = 7
+    case twelveHourWithoutAmPm = 9
+    case twelveHourWithoutAmPmAndSeconds = 10
+    case epoch = 11
+}
+
+// MARK: - Typed accessors (issue #97)
+
+// These wrap the legacy inverted/Int storage with type-safe APIs. They read
+// and write the same UserDefaults keys as the existing shouldDisplay(_:)
+// switch, so behavior is unchanged — they exist so callers can stop
+// re-implementing the inversion at every read site. A subsequent commit
+// migrates storage to native Bool / enum-rawValue keys and renames legacy
+// keys; the accessors are the seam where that swap happens.
+extension DataStore {
+    // Inverted bools — legacy storage: 0 = show, 1 = hide.
+    var showSunriseSunset: Bool {
+        get {
+            guard let value = userDefaults.object(forKey: UserDefaultKeys.sunriseSunsetTime) as? NSNumber else {
+                return false
+            }
+            return value.intValue == 0
+        }
+        set {
+            userDefaults.set(NSNumber(value: newValue ? 0 : 1), forKey: UserDefaultKeys.sunriseSunsetTime)
+        }
+    }
+
+    var showFutureSlider: Bool {
+        get {
+            guard let value = userDefaults.object(forKey: UserDefaultKeys.displayFutureSliderKey) as? NSNumber else {
+                return false
+            }
+            return value.intValue != 1
+        }
+        set {
+            userDefaults.set(NSNumber(value: newValue ? 0 : 1), forKey: UserDefaultKeys.displayFutureSliderKey)
+        }
+    }
+
+    var showDayInMenubar: Bool {
+        get { userDefaults.integer(forKey: UserDefaultKeys.showDayInMenu) == 0 }
+        set { userDefaults.set(newValue ? 0 : 1, forKey: UserDefaultKeys.showDayInMenu) }
+    }
+
+    var showDateInMenubar: Bool {
+        get { userDefaults.integer(forKey: UserDefaultKeys.showDateInMenu) == 0 }
+        set { userDefaults.set(newValue ? 0 : 1, forKey: UserDefaultKeys.showDateInMenu) }
+    }
+
+    var showPlaceNameInMenubar: Bool {
+        get {
+            guard let value = userDefaults.object(forKey: UserDefaultKeys.showPlaceInMenu) as? NSNumber else {
+                return false
+            }
+            return value.intValue == 0
+        }
+        set {
+            userDefaults.set(NSNumber(value: newValue ? 0 : 1), forKey: UserDefaultKeys.showPlaceInMenu)
+        }
+    }
+
+    // Non-inverted bool — legacy storage: 1 = float, 0 = menubar.
+    var floatOnTop: Bool {
+        get { userDefaults.integer(forKey: UserDefaultKeys.showAppInForeground) == 1 }
+        set { userDefaults.set(newValue ? 1 : 0, forKey: UserDefaultKeys.showAppInForeground) }
+    }
+
+    // Enums — raw int storage matches the popup/segment selectedIndex.
+    var menubarMode: MenubarMode {
+        get {
+            guard let raw = userDefaults.object(forKey: UserDefaultKeys.menubarCompactMode) as? Int else {
+                return .standard
+            }
+            return MenubarMode(rawValue: raw) ?? .standard
+        }
+        set { userDefaults.set(newValue.rawValue, forKey: UserDefaultKeys.menubarCompactMode) }
+    }
+
+    var theme: Theme {
+        get {
+            guard let raw = userDefaults.object(forKey: UserDefaultKeys.themeKey) as? Int else {
+                return .light
+            }
+            return Theme(rawValue: raw) ?? .light
+        }
+        set { userDefaults.set(newValue.rawValue, forKey: UserDefaultKeys.themeKey) }
+    }
+
+    var relativeDateDisplay: RelativeDateDisplay {
+        get {
+            guard let raw = (userDefaults.object(forKey: UserDefaultKeys.relativeDateKey) as? NSNumber)?.intValue else {
+                return .relative
+            }
+            return RelativeDateDisplay(rawValue: raw) ?? .relative
+        }
+        set {
+            userDefaults.set(NSNumber(value: newValue.rawValue), forKey: UserDefaultKeys.relativeDateKey)
+        }
+    }
+
+    var appPresentation: AppPresentation {
+        get {
+            guard let value = userDefaults.object(forKey: UserDefaultKeys.appDisplayOptions) as? NSNumber else {
+                return .menubarOnly
+            }
+            return AppPresentation(rawValue: value.intValue) ?? .menubarOnly
+        }
+        set {
+            userDefaults.set(NSNumber(value: newValue.rawValue), forKey: UserDefaultKeys.appDisplayOptions)
+        }
+    }
+
+    var timeFormat: TimeFormat {
+        get {
+            guard let raw = (userDefaults.object(forKey: UserDefaultKeys.selectedTimeZoneFormatKey) as? NSNumber)?.intValue else {
+                return .twelveHour
+            }
+            return TimeFormat(rawValue: raw) ?? .twelveHour
+        }
+        set {
+            userDefaults.set(NSNumber(value: newValue.rawValue), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
+        }
+    }
+}

--- a/Meridian/Overall App/DataStore.swift
+++ b/Meridian/Overall App/DataStore.swift
@@ -129,51 +129,29 @@ class DataStore: NSObject, DataStoring {
     }
 
     func timezoneFormat() -> NSNumber {
-        return userDefaults.object(forKey: UserDefaultKeys.selectedTimeZoneFormatKey) as? NSNumber ?? NSNumber(value: 0)
+        return NSNumber(value: timeFormat.rawValue)
     }
 
     func isBufferRequiredForTwelveHourFormats() -> Bool {
         return DataStore.timeFormatsWithSuffix.contains(timezoneFormat())
     }
 
+    // shouldDisplay(_:) is the legacy entry point — kept for source-compat
+    // with call sites we haven't swept yet (see commit 3/5 of issue #97). It
+    // now delegates to the typed accessors so the underlying storage details
+    // live in exactly one place.
     func shouldDisplay(_ type: ViewType) -> Bool {
         switch type {
-        case .futureSlider:
-            let hidden = 1
-            return (retrieve(key: UserDefaultKeys.displayFutureSliderKey) as? NSNumber).map { $0.intValue != hidden } ?? false
-        case .twelveHour:
-            return shouldDisplayHelper(UserDefaultKeys.selectedTimeZoneFormatKey)
-        case .sunrise:
-            return shouldDisplayHelper(UserDefaultKeys.sunriseSunsetTime)
-        case .showAppInForeground:
-            return userDefaults.integer(forKey: UserDefaultKeys.showAppInForeground) == 1
-        case .dateInMenubar:
-            return shouldDisplayNonObjectHelper(UserDefaultKeys.showDateInMenu)
-        case .placeInMenubar:
-            return shouldDisplayHelper(UserDefaultKeys.showPlaceInMenu)
-        case .dayInMenubar:
-            return shouldDisplayNonObjectHelper(UserDefaultKeys.showDayInMenu)
-        case .appDisplayOptions:
-            return shouldDisplayHelper(UserDefaultKeys.appDisplayOptions)
-        case .menubarCompactMode:
-            return (retrieve(key: UserDefaultKeys.menubarCompactMode) as? Int) == 0
+        case .futureSlider:        return showFutureSlider
+        case .twelveHour:          return timeFormat == .twelveHour
+        case .sunrise:             return showSunriseSunset
+        case .showAppInForeground: return floatOnTop
+        case .dateInMenubar:       return showDateInMenubar
+        case .placeInMenubar:      return showPlaceNameInMenubar
+        case .dayInMenubar:        return showDayInMenubar
+        case .appDisplayOptions:   return appPresentation == .menubarOnly
+        case .menubarCompactMode:  return menubarMode == .compact
         }
-    }
-
-    // MARK: Private
-
-    private func shouldDisplayHelper(_ key: String) -> Bool {
-        guard let value = retrieve(key: key) as? NSNumber else {
-            return false
-        }
-        return value.isEqual(to: NSNumber(value: 0))
-    }
-
-    // MARK: Some values are stored as plain integers; objectForKey: will return nil, so using integerForKey:
-
-    private func shouldDisplayNonObjectHelper(_ key: String) -> Bool {
-        let value = userDefaults.integer(forKey: key)
-        return value == 0
     }
 }
 
@@ -219,120 +197,65 @@ enum TimeFormat: Int, Codable {
 
 // MARK: - Typed accessors (issue #97)
 
-// These wrap the legacy inverted/Int storage with type-safe APIs. They read
-// and write the same UserDefaults keys as the existing shouldDisplay(_:)
-// switch, so behavior is unchanged — they exist so callers can stop
-// re-implementing the inversion at every read site. A subsequent commit
-// migrates storage to native Bool / enum-rawValue keys and renames legacy
-// keys; the accessors are the seam where that swap happens.
+// Type-safe preference surface backed by modernized UserDefaults keys.
+// Storage was migrated from the legacy inverted-bool / int-encoded keys by
+// AppDefaults.runBoolSemanticsMigration on first launch of the modernized
+// build. Defaults for missing keys come from AppDefaults.defaultsDictionary.
 extension DataStore {
-    // Inverted bools — legacy storage: 0 = show, 1 = hide.
+    // Bools.
     var showSunriseSunset: Bool {
-        get {
-            guard let value = userDefaults.object(forKey: UserDefaultKeys.sunriseSunsetTime) as? NSNumber else {
-                return false
-            }
-            return value.intValue == 0
-        }
-        set {
-            userDefaults.set(NSNumber(value: newValue ? 0 : 1), forKey: UserDefaultKeys.sunriseSunsetTime)
-        }
+        get { userDefaults.bool(forKey: UserDefaultKeys.showSunriseSunset) }
+        set { userDefaults.set(newValue, forKey: UserDefaultKeys.showSunriseSunset) }
     }
 
     var showFutureSlider: Bool {
-        get {
-            guard let value = userDefaults.object(forKey: UserDefaultKeys.displayFutureSliderKey) as? NSNumber else {
-                return false
-            }
-            return value.intValue != 1
-        }
-        set {
-            userDefaults.set(NSNumber(value: newValue ? 0 : 1), forKey: UserDefaultKeys.displayFutureSliderKey)
-        }
+        get { userDefaults.bool(forKey: UserDefaultKeys.showFutureSlider) }
+        set { userDefaults.set(newValue, forKey: UserDefaultKeys.showFutureSlider) }
     }
 
     var showDayInMenubar: Bool {
-        get { userDefaults.integer(forKey: UserDefaultKeys.showDayInMenu) == 0 }
-        set { userDefaults.set(newValue ? 0 : 1, forKey: UserDefaultKeys.showDayInMenu) }
+        get { userDefaults.bool(forKey: UserDefaultKeys.showDayInMenubar) }
+        set { userDefaults.set(newValue, forKey: UserDefaultKeys.showDayInMenubar) }
     }
 
     var showDateInMenubar: Bool {
-        get { userDefaults.integer(forKey: UserDefaultKeys.showDateInMenu) == 0 }
-        set { userDefaults.set(newValue ? 0 : 1, forKey: UserDefaultKeys.showDateInMenu) }
+        get { userDefaults.bool(forKey: UserDefaultKeys.showDateInMenubar) }
+        set { userDefaults.set(newValue, forKey: UserDefaultKeys.showDateInMenubar) }
     }
 
     var showPlaceNameInMenubar: Bool {
-        get {
-            guard let value = userDefaults.object(forKey: UserDefaultKeys.showPlaceInMenu) as? NSNumber else {
-                return false
-            }
-            return value.intValue == 0
-        }
-        set {
-            userDefaults.set(NSNumber(value: newValue ? 0 : 1), forKey: UserDefaultKeys.showPlaceInMenu)
-        }
+        get { userDefaults.bool(forKey: UserDefaultKeys.showPlaceNameInMenubar) }
+        set { userDefaults.set(newValue, forKey: UserDefaultKeys.showPlaceNameInMenubar) }
     }
 
-    // Non-inverted bool — legacy storage: 1 = float, 0 = menubar.
     var floatOnTop: Bool {
-        get { userDefaults.integer(forKey: UserDefaultKeys.showAppInForeground) == 1 }
-        set { userDefaults.set(newValue ? 1 : 0, forKey: UserDefaultKeys.showAppInForeground) }
+        get { userDefaults.bool(forKey: UserDefaultKeys.floatOnTop) }
+        set { userDefaults.set(newValue, forKey: UserDefaultKeys.floatOnTop) }
     }
 
-    // Enums — raw int storage matches the popup/segment selectedIndex.
+    // Enums (Int-backed; raw values match the popup/segment selectedIndex).
     var menubarMode: MenubarMode {
-        get {
-            guard let raw = userDefaults.object(forKey: UserDefaultKeys.menubarCompactMode) as? Int else {
-                return .standard
-            }
-            return MenubarMode(rawValue: raw) ?? .standard
-        }
+        get { MenubarMode(rawValue: userDefaults.integer(forKey: UserDefaultKeys.menubarCompactMode)) ?? .standard }
         set { userDefaults.set(newValue.rawValue, forKey: UserDefaultKeys.menubarCompactMode) }
     }
 
     var theme: Theme {
-        get {
-            guard let raw = userDefaults.object(forKey: UserDefaultKeys.themeKey) as? Int else {
-                return .light
-            }
-            return Theme(rawValue: raw) ?? .light
-        }
+        get { Theme(rawValue: userDefaults.integer(forKey: UserDefaultKeys.themeKey)) ?? .light }
         set { userDefaults.set(newValue.rawValue, forKey: UserDefaultKeys.themeKey) }
     }
 
     var relativeDateDisplay: RelativeDateDisplay {
-        get {
-            guard let raw = (userDefaults.object(forKey: UserDefaultKeys.relativeDateKey) as? NSNumber)?.intValue else {
-                return .relative
-            }
-            return RelativeDateDisplay(rawValue: raw) ?? .relative
-        }
-        set {
-            userDefaults.set(NSNumber(value: newValue.rawValue), forKey: UserDefaultKeys.relativeDateKey)
-        }
+        get { RelativeDateDisplay(rawValue: userDefaults.integer(forKey: UserDefaultKeys.relativeDateKey)) ?? .relative }
+        set { userDefaults.set(newValue.rawValue, forKey: UserDefaultKeys.relativeDateKey) }
     }
 
     var appPresentation: AppPresentation {
-        get {
-            guard let value = userDefaults.object(forKey: UserDefaultKeys.appDisplayOptions) as? NSNumber else {
-                return .menubarOnly
-            }
-            return AppPresentation(rawValue: value.intValue) ?? .menubarOnly
-        }
-        set {
-            userDefaults.set(NSNumber(value: newValue.rawValue), forKey: UserDefaultKeys.appDisplayOptions)
-        }
+        get { AppPresentation(rawValue: userDefaults.integer(forKey: UserDefaultKeys.appDisplayOptions)) ?? .menubarOnly }
+        set { userDefaults.set(newValue.rawValue, forKey: UserDefaultKeys.appDisplayOptions) }
     }
 
     var timeFormat: TimeFormat {
-        get {
-            guard let raw = (userDefaults.object(forKey: UserDefaultKeys.selectedTimeZoneFormatKey) as? NSNumber)?.intValue else {
-                return .twelveHour
-            }
-            return TimeFormat(rawValue: raw) ?? .twelveHour
-        }
-        set {
-            userDefaults.set(NSNumber(value: newValue.rawValue), forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
-        }
+        get { TimeFormat(rawValue: userDefaults.integer(forKey: UserDefaultKeys.timeFormat)) ?? .twelveHour }
+        set { userDefaults.set(newValue.rawValue, forKey: UserDefaultKeys.timeFormat) }
     }
 }

--- a/Meridian/Overall App/DataStore.swift
+++ b/Meridian/Overall App/DataStore.swift
@@ -157,25 +157,25 @@ class DataStore: NSObject, DataStoring {
 
 // MARK: - Typed preference enums (issue #97)
 
-enum MenubarMode: Int, Codable {
+enum MenubarMode: Int, Codable, CaseIterable {
     case compact = 0
     case standard = 1
 }
 
-enum Theme: Int, Codable {
+enum Theme: Int, Codable, CaseIterable {
     case light = 0
     case dark = 1
     case system = 2
 }
 
-enum RelativeDateDisplay: Int, Codable {
+enum RelativeDateDisplay: Int, Codable, CaseIterable {
     case relative = 0
     case actual = 1
     case date = 2
     case hidden = 3
 }
 
-enum AppPresentation: Int, Codable {
+enum AppPresentation: Int, Codable, CaseIterable {
     case menubarOnly = 0
     case menubarAndDock = 1
 }
@@ -183,7 +183,7 @@ enum AppPresentation: Int, Codable {
 // Indices match the popup item order in
 // AppearanceViewController.setupTimeFormatPopup(); 2/5/8 are disabled
 // separator rows and intentionally have no enum case.
-enum TimeFormat: Int, Codable {
+enum TimeFormat: Int, Codable, CaseIterable {
     case twelveHour = 0
     case twentyFourHour = 1
     case twelveHourWithSeconds = 3
@@ -193,6 +193,47 @@ enum TimeFormat: Int, Codable {
     case twelveHourWithoutAmPm = 9
     case twelveHourWithoutAmPmAndSeconds = 10
     case epoch = 11
+}
+
+// Stable string name for typed preference enums. Used by SettingsManager v2
+// JSON export ("compact" instead of 0). Names are derived from the Swift
+// case identifier — keep them stable across releases since users' export
+// files persist them.
+extension MenubarMode { var jsonName: String { String(describing: self) } }
+extension Theme { var jsonName: String { String(describing: self) } }
+extension RelativeDateDisplay { var jsonName: String { String(describing: self) } }
+extension AppPresentation { var jsonName: String { String(describing: self) } }
+extension TimeFormat { var jsonName: String { String(describing: self) } }
+
+extension MenubarMode {
+    init?(jsonName: String) {
+        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
+        self = match
+    }
+}
+extension Theme {
+    init?(jsonName: String) {
+        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
+        self = match
+    }
+}
+extension RelativeDateDisplay {
+    init?(jsonName: String) {
+        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
+        self = match
+    }
+}
+extension AppPresentation {
+    init?(jsonName: String) {
+        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
+        self = match
+    }
+}
+extension TimeFormat {
+    init?(jsonName: String) {
+        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
+        self = match
+    }
 }
 
 // MARK: - Typed accessors (issue #97)

--- a/Meridian/Overall App/SettingsManager.swift
+++ b/Meridian/Overall App/SettingsManager.swift
@@ -12,26 +12,33 @@ struct SettingsManager {
     // (General/Appearance/About) and survives export → import.
     // (defaultMenubarMode / "com.tpak.meridian.shouldDefaultToCompactMode"
     //  is intentionally omitted — it's a dead key with no readers.)
+    // Modernized typed keys (issue #97). The bool semantics migration in
+    // AppDefaults moves user data to these on first launch of 2.21+ and
+    // deletes the legacy showSunriseSetTime / displayFutureSlider / showDay
+    // / showDate / showPlaceName / displayAppAsForegroundApp /
+    // is24HourFormatSelected keys. Export/import operate on the new keys.
+    // Commit 5/5 of issue #97 layers a typed JSON schema (named bools and
+    // enum cases) over this; for now the values are still raw Bool / Int.
     private static let preferenceKeys: [String] = [
         // Appearance tab — time/theme/format
-        UserDefaultKeys.selectedTimeZoneFormatKey,
+        UserDefaultKeys.timeFormat,
         UserDefaultKeys.themeKey,
         UserDefaultKeys.relativeDateKey,
         // Appearance tab — display toggles
-        UserDefaultKeys.displayFutureSliderKey,
-        UserDefaultKeys.sunriseSunsetTime,
-        UserDefaultKeys.showAppInForeground,
+        UserDefaultKeys.showFutureSlider,
+        UserDefaultKeys.showSunriseSunset,
+        UserDefaultKeys.floatOnTop,
         UserDefaultKeys.userFontSizePreference,
         UserDefaultKeys.truncateTextLength,
         UserDefaultKeys.futureSliderRange,
         UserDefaultKeys.appDisplayOptions,
         // Appearance tab — menubar
-        UserDefaultKeys.showDayInMenu,
-        UserDefaultKeys.showDateInMenu,
-        UserDefaultKeys.showPlaceInMenu,
+        UserDefaultKeys.showDayInMenubar,
+        UserDefaultKeys.showDateInMenubar,
+        UserDefaultKeys.showPlaceNameInMenubar,
         UserDefaultKeys.menubarCompactMode,
         // About tab — debug logging
-        UserDefaultKeys.debugLoggingEnabled,
+        UserDefaultKeys.debugLoggingEnabled
     ]
 
     // startAtLogin is exported alongside the rest, but APPLIED via StartupManager

--- a/Meridian/Overall App/SettingsManager.swift
+++ b/Meridian/Overall App/SettingsManager.swift
@@ -12,35 +12,6 @@ struct SettingsManager {
     // (General/Appearance/About) and survives export → import.
     // (defaultMenubarMode / "com.tpak.meridian.shouldDefaultToCompactMode"
     //  is intentionally omitted — it's a dead key with no readers.)
-    // Modernized typed keys (issue #97). The bool semantics migration in
-    // AppDefaults moves user data to these on first launch of 2.21+ and
-    // deletes the legacy showSunriseSetTime / displayFutureSlider / showDay
-    // / showDate / showPlaceName / displayAppAsForegroundApp /
-    // is24HourFormatSelected keys. Export/import operate on the new keys.
-    // Commit 5/5 of issue #97 layers a typed JSON schema (named bools and
-    // enum cases) over this; for now the values are still raw Bool / Int.
-    private static let preferenceKeys: [String] = [
-        // Appearance tab — time/theme/format
-        UserDefaultKeys.timeFormat,
-        UserDefaultKeys.themeKey,
-        UserDefaultKeys.relativeDateKey,
-        // Appearance tab — display toggles
-        UserDefaultKeys.showFutureSlider,
-        UserDefaultKeys.showSunriseSunset,
-        UserDefaultKeys.floatOnTop,
-        UserDefaultKeys.userFontSizePreference,
-        UserDefaultKeys.truncateTextLength,
-        UserDefaultKeys.futureSliderRange,
-        UserDefaultKeys.appDisplayOptions,
-        // Appearance tab — menubar
-        UserDefaultKeys.showDayInMenubar,
-        UserDefaultKeys.showDateInMenubar,
-        UserDefaultKeys.showPlaceNameInMenubar,
-        UserDefaultKeys.menubarCompactMode,
-        // About tab — debug logging
-        UserDefaultKeys.debugLoggingEnabled
-    ]
-
     // startAtLogin is exported alongside the rest, but APPLIED via StartupManager
     // (SMAppService.mainApp) during import so the system actually registers/unregisters
     // the login item — writing UserDefaults alone wouldn't change behavior.
@@ -124,27 +95,63 @@ struct SettingsManager {
 
     // MARK: - Private
 
-    private static func buildJSON() -> Data? {
-        let timezoneBase64 = DataStore.shared().timezones().map { $0.base64EncodedString() }
+    // Issue #97 — v2 JSON keys. Stable string identifiers used in the
+    // exported file. Keep these constants frozen across releases since
+    // users' export files persist them.
+    private enum V2Key {
+        static let showSunriseSunset = "showSunriseSunset"
+        static let showFutureSlider = "showFutureSlider"
+        static let showDayInMenubar = "showDayInMenubar"
+        static let showDateInMenubar = "showDateInMenubar"
+        static let showPlaceNameInMenubar = "showPlaceNameInMenubar"
+        static let floatOnTop = "floatOnTop"
+        static let menubarMode = "menubarMode"
+        static let theme = "theme"
+        static let relativeDateDisplay = "relativeDateDisplay"
+        static let appPresentation = "appPresentation"
+        static let timeFormat = "timeFormat"
+        static let userFontSize = "userFontSize"
+        static let truncateTextLength = "truncateTextLength"
+        static let futureSliderRange = "futureSliderRange"
+        static let debugLoggingEnabled = "debugLoggingEnabled"
+    }
 
-        // For UserDefaults-backed prefs, fall back to the registered default
-        // (see AppDefaults.defaultsDictionary) so we never silently drop a key
-        // the user has never explicitly touched.
-        var prefs: [String: Any] = [:]
-        for key in preferenceKeys {
-            if let value = UserDefaults.standard.object(forKey: key) {
-                prefs[key] = value
-            }
-        }
+    // Build a v2 JSON payload — bools are emitted as bools, enums as named
+    // case strings ("compact", "twelveHour", etc.) instead of raw ints.
+    // The user's complaint that motivated issue #97 — exported settings
+    // showing "showSunriseSetTime: 0" for a setting that was on — is
+    // resolved here: same value is now exported as "showSunriseSunset": true.
+    // Internal so SettingsManagerVersioningTests can verify the v2 schema
+    // and v1-back-compat decoding without going through the file picker.
+    static func buildJSON() -> Data? {
+        let store = DataStore.shared()
+        let timezoneBase64 = store.timezones().map { $0.base64EncodedString() }
+        let defaults = UserDefaults.standard
 
-        // startAtLogin is the actual SMAppService state, not what's in UserDefaults
-        // (UserDefaults can drift from the system state if the user toggled it elsewhere).
+        let prefs: [String: Any] = [
+            V2Key.showSunriseSunset: store.showSunriseSunset,
+            V2Key.showFutureSlider: store.showFutureSlider,
+            V2Key.showDayInMenubar: store.showDayInMenubar,
+            V2Key.showDateInMenubar: store.showDateInMenubar,
+            V2Key.showPlaceNameInMenubar: store.showPlaceNameInMenubar,
+            V2Key.floatOnTop: store.floatOnTop,
+            V2Key.menubarMode: store.menubarMode.jsonName,
+            V2Key.theme: store.theme.jsonName,
+            V2Key.relativeDateDisplay: store.relativeDateDisplay.jsonName,
+            V2Key.appPresentation: store.appPresentation.jsonName,
+            V2Key.timeFormat: store.timeFormat.jsonName,
+            V2Key.userFontSize: defaults.integer(forKey: UserDefaultKeys.userFontSizePreference),
+            V2Key.truncateTextLength: defaults.integer(forKey: UserDefaultKeys.truncateTextLength),
+            V2Key.futureSliderRange: defaults.integer(forKey: UserDefaultKeys.futureSliderRange),
+            V2Key.debugLoggingEnabled: defaults.bool(forKey: UserDefaultKeys.debugLoggingEnabled)
+        ]
+
+        // startAtLogin reflects the actual SMAppService state, not UserDefaults.
         let startAtLoginEnabled = StartupManager.isLoginItemEnabled()
 
-        // Sparkle prefs are read from the live updater, NOT from UserDefaults.
-        // Sparkle uses lazy registration — if the user has never opened the
-        // schedule picker, SUScheduledCheckInterval is nil in UserDefaults
-        // even though the updater has a real running value (typically 86400).
+        // Sparkle prefs come from the live updater because Sparkle registers
+        // its defaults lazily — UserDefaults can be nil even when the updater
+        // has a real running interval value.
         var sparkle: [String: Any] = [:]
         if let updater = (NSApp.delegate as? AppDelegate)?.updaterController.updater {
             sparkle[SparkleExportField.automaticallyChecksForUpdates] = updater.automaticallyChecksForUpdates
@@ -153,24 +160,26 @@ struct SettingsManager {
         }
 
         let payload: [String: Any] = [
-            ExportKey.version: 1,
+            ExportKey.version: 2,
             ExportKey.timezones: timezoneBase64,
             ExportKey.preferences: prefs,
             ExportKey.startAtLogin: startAtLoginEnabled,
-            ExportKey.sparkle: sparkle,
+            ExportKey.sparkle: sparkle
         ]
         return try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
     }
 
-    private static func applySettings(from data: Data) throws {
+    static func applySettings(from data: Data) throws {
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw ImportError.invalidFormat
         }
-        guard let version = json[ExportKey.version] as? Int, version == 1 else {
-            throw ImportError.unsupportedVersion
-        }
 
-        // Validate and decode timezones
+        // version: 1 came from 2.19/2.20; version: 2 is post-#97. We accept
+        // either so users importing older export files still get correct
+        // values (with the inversion undone).
+        let version = json[ExportKey.version] as? Int ?? 0
+
+        // Validate and decode timezones (format unchanged across versions).
         var timezoneBlobs: [Data] = []
         if let encoded = json[ExportKey.timezones] as? [String] {
             for base64 in encoded {
@@ -182,26 +191,23 @@ struct SettingsManager {
             }
         }
 
-        // Apply UserDefaults preferences (Appearance + About debug logging)
         if let prefs = json[ExportKey.preferences] as? [String: Any] {
-            for key in preferenceKeys {
-                if let value = prefs[key] {
-                    UserDefaults.standard.set(value, forKey: key)
-                }
+            switch version {
+            case 1: applyV1Preferences(prefs)
+            case 2: applyV2Preferences(prefs)
+            default: throw ImportError.unsupportedVersion
             }
         }
 
-        // Apply startAtLogin via StartupManager — UserDefaults alone won't register/unregister
-        // the SMAppService login item, so toggle it explicitly.
+        // Apply startAtLogin via StartupManager — UserDefaults alone won't
+        // register/unregister the SMAppService login item.
         if let startAtLogin = json[ExportKey.startAtLogin] as? Bool {
             UserDefaults.standard.set(startAtLogin, forKey: startAtLoginKey)
             StartupManager().toggleLogin(startAtLogin)
         }
 
-        // Apply timezones
         DataStore.shared().setTimezones(timezoneBlobs)
 
-        // Refresh UI + apply Sparkle prefs to the live updater
         DispatchQueue.main.async {
             NotificationCenter.default.post(name: .customLabelChanged, object: nil)
             if let panel = PanelController.panel() {
@@ -210,9 +216,6 @@ struct SettingsManager {
             }
             if let appDelegate = NSApp.delegate as? AppDelegate {
                 appDelegate.statusItemForPanel().refresh()
-                // Apply Sparkle prefs from the import payload directly to the live
-                // updater so the new schedule takes effect immediately. Setting these
-                // on the updater also writes them to UserDefaults under Sparkle's keys.
                 if let sparkle = json[ExportKey.sparkle] as? [String: Any] {
                     let updater = appDelegate.updaterController.updater
                     if let v = sparkle[SparkleExportField.automaticallyChecksForUpdates] as? Bool {
@@ -227,6 +230,73 @@ struct SettingsManager {
                 }
             }
             NSApp.keyWindow?.contentView?.makeToast("Settings imported")
+        }
+    }
+
+    // v1 — legacy raw-int preferences from 2.19/2.20 export files.
+    // Read the legacy keys, apply via typed accessors so the inversion is
+    // undone exactly once on import. We do NOT write the legacy UserDefaults
+    // keys here — migration runs at every launch, but post-2.21 imports
+    // should put data directly into the modernized schema.
+    private static func applyV1Preferences(_ prefs: [String: Any]) {
+        let store = DataStore.shared()
+        let defaults = UserDefaults.standard
+
+        // Inverted bools — legacy 0 = show, 1 = hide.
+        if let v = prefs["showSunriseSetTime"] as? Int { store.showSunriseSunset = (v == 0) }
+        if let v = prefs["displayFutureSlider"] as? Int { store.showFutureSlider = (v == 0) }
+        if let v = prefs["showDay"] as? Int { store.showDayInMenubar = (v == 0) }
+        if let v = prefs["showDate"] as? Int { store.showDateInMenubar = (v == 0) }
+        if let v = prefs["showPlaceName"] as? Int { store.showPlaceNameInMenubar = (v == 0) }
+
+        // Non-inverted bool — legacy 1 = float.
+        if let v = prefs["displayAppAsForegroundApp"] as? Int { store.floatOnTop = (v == 1) }
+
+        // Time format — value semantics unchanged, just key rename.
+        if let v = prefs["is24HourFormatSelected"] as? Int { store.timeFormat = TimeFormat(rawValue: v) ?? .twelveHour }
+
+        // Already-correct enum keys (kept by name in the legacy export too).
+        if let v = prefs["defaultTheme"] as? Int { store.theme = Theme(rawValue: v) ?? .light }
+        if let v = prefs["relativeDate"] as? Int { store.relativeDateDisplay = RelativeDateDisplay(rawValue: v) ?? .relative }
+        if let v = prefs["com.tpak.meridian.appDisplayOptions"] as? Int { store.appPresentation = AppPresentation(rawValue: v) ?? .menubarOnly }
+        if let v = prefs["com.tpak.meridian.menubarCompactMode"] as? Int { store.menubarMode = MenubarMode(rawValue: v) ?? .standard }
+
+        // Untouched — copy raw values.
+        if let v = prefs["userFontSize"] { defaults.set(v, forKey: UserDefaultKeys.userFontSizePreference) }
+        if let v = prefs["truncateTextLength"] { defaults.set(v, forKey: UserDefaultKeys.truncateTextLength) }
+        if let v = prefs["sliderDayRange"] { defaults.set(v, forKey: UserDefaultKeys.futureSliderRange) }
+        if let v = prefs["com.tpak.meridian.debugLoggingEnabled"] as? Bool {
+            defaults.set(v, forKey: UserDefaultKeys.debugLoggingEnabled)
+        }
+    }
+
+    // v2 — typed bools and named enums, no inversion.
+    private static func applyV2Preferences(_ prefs: [String: Any]) {
+        let store = DataStore.shared()
+        let defaults = UserDefaults.standard
+
+        // Bools — write directly.
+        if let v = prefs[V2Key.showSunriseSunset] as? Bool { store.showSunriseSunset = v }
+        if let v = prefs[V2Key.showFutureSlider] as? Bool { store.showFutureSlider = v }
+        if let v = prefs[V2Key.showDayInMenubar] as? Bool { store.showDayInMenubar = v }
+        if let v = prefs[V2Key.showDateInMenubar] as? Bool { store.showDateInMenubar = v }
+        if let v = prefs[V2Key.showPlaceNameInMenubar] as? Bool { store.showPlaceNameInMenubar = v }
+        if let v = prefs[V2Key.floatOnTop] as? Bool { store.floatOnTop = v }
+
+        // Enums — parse the case name string. Unknown names fall through to
+        // existing value (typed accessor leaves the underlying key alone).
+        if let s = prefs[V2Key.menubarMode] as? String, let m = MenubarMode(jsonName: s) { store.menubarMode = m }
+        if let s = prefs[V2Key.theme] as? String, let t = Theme(jsonName: s) { store.theme = t }
+        if let s = prefs[V2Key.relativeDateDisplay] as? String, let r = RelativeDateDisplay(jsonName: s) { store.relativeDateDisplay = r }
+        if let s = prefs[V2Key.appPresentation] as? String, let a = AppPresentation(jsonName: s) { store.appPresentation = a }
+        if let s = prefs[V2Key.timeFormat] as? String, let t = TimeFormat(jsonName: s) { store.timeFormat = t }
+
+        // Untouched — copy raw values.
+        if let v = prefs[V2Key.userFontSize] { defaults.set(v, forKey: UserDefaultKeys.userFontSizePreference) }
+        if let v = prefs[V2Key.truncateTextLength] { defaults.set(v, forKey: UserDefaultKeys.truncateTextLength) }
+        if let v = prefs[V2Key.futureSliderRange] { defaults.set(v, forKey: UserDefaultKeys.futureSliderRange) }
+        if let v = prefs[V2Key.debugLoggingEnabled] as? Bool {
+            defaults.set(v, forKey: UserDefaultKeys.debugLoggingEnabled)
         }
     }
 

--- a/Meridian/Overall App/SettingsManager.swift
+++ b/Meridian/Overall App/SettingsManager.swift
@@ -114,6 +114,7 @@ struct SettingsManager {
         static let truncateTextLength = "truncateTextLength"
         static let futureSliderRange = "futureSliderRange"
         static let debugLoggingEnabled = "debugLoggingEnabled"
+        static let betaUpdatesEnabled = "betaUpdatesEnabled"
     }
 
     // Build a v2 JSON payload — bools are emitted as bools, enums as named
@@ -143,7 +144,8 @@ struct SettingsManager {
             V2Key.userFontSize: defaults.integer(forKey: UserDefaultKeys.userFontSizePreference),
             V2Key.truncateTextLength: defaults.integer(forKey: UserDefaultKeys.truncateTextLength),
             V2Key.futureSliderRange: defaults.integer(forKey: UserDefaultKeys.futureSliderRange),
-            V2Key.debugLoggingEnabled: defaults.bool(forKey: UserDefaultKeys.debugLoggingEnabled)
+            V2Key.debugLoggingEnabled: defaults.bool(forKey: UserDefaultKeys.debugLoggingEnabled),
+            V2Key.betaUpdatesEnabled: defaults.bool(forKey: UserDefaultKeys.betaUpdatesEnabled)
         ]
 
         // startAtLogin reflects the actual SMAppService state, not UserDefaults.
@@ -268,6 +270,9 @@ struct SettingsManager {
         if let v = prefs["com.tpak.meridian.debugLoggingEnabled"] as? Bool {
             defaults.set(v, forKey: UserDefaultKeys.debugLoggingEnabled)
         }
+        if let v = prefs["com.tpak.meridian.betaUpdatesEnabled"] as? Bool {
+            defaults.set(v, forKey: UserDefaultKeys.betaUpdatesEnabled)
+        }
     }
 
     // v2 — typed bools and named enums, no inversion.
@@ -297,6 +302,9 @@ struct SettingsManager {
         if let v = prefs[V2Key.futureSliderRange] { defaults.set(v, forKey: UserDefaultKeys.futureSliderRange) }
         if let v = prefs[V2Key.debugLoggingEnabled] as? Bool {
             defaults.set(v, forKey: UserDefaultKeys.debugLoggingEnabled)
+        }
+        if let v = prefs[V2Key.betaUpdatesEnabled] as? Bool {
+            defaults.set(v, forKey: UserDefaultKeys.betaUpdatesEnabled)
         }
     }
 

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -42,13 +42,22 @@ public enum UserDefaultKeys {
     // AppDefaults.runBoolSemanticsMigration moves user data from the legacy
     // keys to these on first launch of the modernized build, then deletes
     // the legacy keys.
-    static let showSunriseSunset = "com.tpak.meridian.showSunriseSunset"
-    static let showFutureSlider = "com.tpak.meridian.showFutureSlider"
-    static let showDayInMenubar = "com.tpak.meridian.showDayInMenubar"
-    static let showDateInMenubar = "com.tpak.meridian.showDateInMenubar"
-    static let showPlaceNameInMenubar = "com.tpak.meridian.showPlaceNameInMenubar"
-    static let floatOnTop = "com.tpak.meridian.floatOnTop"
-    static let timeFormat = "com.tpak.meridian.timeFormat"
+    //
+    // Names intentionally do NOT use the com.tpak.meridian.* prefix used by
+    // other namespaced keys (appDisplayOptions, menubarCompactMode, etc.).
+    // Two reasons: (1) NSUserDefaultsController storyboard bindings of the
+    // form values.<key> traverse dots as nested keypaths and don't work
+    // cleanly for dotted keys; (2) @objc dynamic var floatOnTop on
+    // UserDefaults can only emit KVO notifications for keypath \.floatOnTop
+    // when the underlying UserDefaults key string matches the property
+    // identifier, which can't contain dots.
+    static let showSunriseSunset = "showSunriseSunset"
+    static let showFutureSlider = "showFutureSlider"
+    static let showDayInMenubar = "showDayInMenubar"
+    static let showDateInMenubar = "showDateInMenubar"
+    static let showPlaceNameInMenubar = "showPlaceNameInMenubar"
+    static let floatOnTop = "floatOnTop"
+    static let timeFormat = "timeFormat"
 
     // One-time migration flag. Set after runBoolSemanticsMigration completes
     // its first successful pass; read on every launch to make the migration

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -36,4 +36,22 @@ public enum UserDefaultKeys {
     static let latitude = "latitude"
     static let longitude = "longitude"
     static let nextUpdate = "nextUpdate"
+
+    // MARK: - Modernized typed-storage keys (issue #97)
+    // These replace the legacy inverted-bool / int-encoded keys above.
+    // AppDefaults.runBoolSemanticsMigration moves user data from the legacy
+    // keys to these on first launch of the modernized build, then deletes
+    // the legacy keys.
+    static let showSunriseSunset = "com.tpak.meridian.showSunriseSunset"
+    static let showFutureSlider = "com.tpak.meridian.showFutureSlider"
+    static let showDayInMenubar = "com.tpak.meridian.showDayInMenubar"
+    static let showDateInMenubar = "com.tpak.meridian.showDateInMenubar"
+    static let showPlaceNameInMenubar = "com.tpak.meridian.showPlaceNameInMenubar"
+    static let floatOnTop = "com.tpak.meridian.floatOnTop"
+    static let timeFormat = "com.tpak.meridian.timeFormat"
+
+    // One-time migration flag. Set after runBoolSemanticsMigration completes
+    // its first successful pass; read on every launch to make the migration
+    // idempotent.
+    static let boolSemanticsMigrationV1 = "com.tpak.meridian.boolSemanticsMigrationV1"
 }

--- a/Meridian/Overall App/UserDefaults + KVOExtensions.swift
+++ b/Meridian/Overall App/UserDefaults + KVOExtensions.swift
@@ -3,10 +3,6 @@
 import Cocoa
 
 extension UserDefaults {
-    @objc dynamic var displayFutureSlider: Int {
-        return integer(forKey: UserDefaultKeys.displayFutureSliderKey)
-    }
-
     @objc dynamic var userFontSize: Int {
         return integer(forKey: UserDefaultKeys.userFontSizePreference)
     }
@@ -15,8 +11,14 @@ extension UserDefaults {
         return integer(forKey: UserDefaultKeys.futureSliderRange)
     }
 
-    // Property name must match the UserDefaults key string for KVO notifications to fire.
-    @objc dynamic var displayAppAsForegroundApp: Int {
-        return integer(forKey: UserDefaultKeys.showAppInForeground)
+    // For KVO notifications to fire, the property name must match the
+    // UserDefaults key string. Combine subscribers in PanelController and
+    // ParentPanelController watch these to react to user toggles.
+    @objc dynamic var floatOnTop: Bool {
+        return bool(forKey: UserDefaultKeys.floatOnTop)
+    }
+
+    @objc dynamic var showFutureSlider: Bool {
+        return bool(forKey: UserDefaultKeys.showFutureSlider)
     }
 }

--- a/Meridian/Panel/PanelController.swift
+++ b/Meridian/Panel/PanelController.swift
@@ -138,7 +138,7 @@ class PanelController: ParentPanelController {
     }
 
     private func setupFloatingModeObserver() {
-        UserDefaults.standard.publisher(for: \.displayAppAsForegroundApp)
+        UserDefaults.standard.publisher(for: \.floatOnTop)
             .receive(on: RunLoop.main)
             .dropFirst()
             .sink { [weak self] _ in
@@ -189,12 +189,8 @@ class PanelController: ParentPanelController {
 
         if dataStore.timezones().isEmpty || dataStore.shouldDisplay(.futureSlider) == false {
             modernContainerView.isHidden = true
-        } else if let value = dataStore.retrieve(key: UserDefaultKeys.displayFutureSliderKey) as? NSNumber, modernContainerView != nil {
-            if value.intValue == 1 {
-                modernContainerView.isHidden = true
-            } else if value.intValue == 0 {
-                modernContainerView.isHidden = false
-            }
+        } else if modernContainerView != nil {
+            modernContainerView.isHidden = !dataStore.shouldDisplay(.futureSlider)
         }
 
         // Reset future slider value to zero
@@ -263,38 +259,28 @@ class PanelController: ParentPanelController {
         PerfLogger.endMarker("Set Panel Frame")
     }
 
-    /// Groups all panel-open display preferences for structured logging, replacing 8 separate NSNumber guard bindings.
+    /// Groups all panel-open display preferences for structured logging.
     private struct LogDisplayPreferences {
-        let theme: NSNumber
-        let displayFutureSlider: NSNumber
-        let showAppInForeground: NSNumber
-        let relativeDateKey: NSNumber
-        let fontSize: NSNumber
-        let sunriseTime: NSNumber
-        let showDayInMenu: NSNumber
-        let showDateInMenu: NSNumber
-        let showPlaceInMenu: NSNumber
+        let theme: Theme
+        let displayFutureSlider: Bool
+        let floatOnTop: Bool
+        let relativeDateDisplay: RelativeDateDisplay
+        let fontSize: Int
+        let showSunriseSunset: Bool
+        let showDayInMenubar: Bool
+        let showDateInMenubar: Bool
+        let showPlaceNameInMenubar: Bool
 
-        init?(from store: DataStoring) {
-            guard let theme = store.retrieve(key: UserDefaultKeys.themeKey) as? NSNumber,
-                  let displayFutureSlider = store.retrieve(key: UserDefaultKeys.displayFutureSliderKey) as? NSNumber,
-                  let showAppInForeground = store.retrieve(key: UserDefaultKeys.showAppInForeground) as? NSNumber,
-                  let relativeDateKey = store.retrieve(key: UserDefaultKeys.relativeDateKey) as? NSNumber,
-                  let fontSize = store.retrieve(key: UserDefaultKeys.userFontSizePreference) as? NSNumber,
-                  let sunriseTime = store.retrieve(key: UserDefaultKeys.sunriseSunsetTime) as? NSNumber,
-                  let showDayInMenu = store.retrieve(key: UserDefaultKeys.showDayInMenu) as? NSNumber,
-                  let showDateInMenu = store.retrieve(key: UserDefaultKeys.showDateInMenu) as? NSNumber,
-                  let showPlaceInMenu = store.retrieve(key: UserDefaultKeys.showPlaceInMenu) as? NSNumber
-            else { return nil }
-            self.theme = theme
-            self.displayFutureSlider = displayFutureSlider
-            self.showAppInForeground = showAppInForeground
-            self.relativeDateKey = relativeDateKey
-            self.fontSize = fontSize
-            self.sunriseTime = sunriseTime
-            self.showDayInMenu = showDayInMenu
-            self.showDateInMenu = showDateInMenu
-            self.showPlaceInMenu = showPlaceInMenu
+        init(from store: DataStore) {
+            theme = store.theme
+            displayFutureSlider = store.showFutureSlider
+            floatOnTop = store.floatOnTop
+            relativeDateDisplay = store.relativeDateDisplay
+            fontSize = (store.retrieve(key: UserDefaultKeys.userFontSizePreference) as? NSNumber)?.intValue ?? 4
+            showSunriseSunset = store.showSunriseSunset
+            showDayInMenubar = store.showDayInMenubar
+            showDateInMenubar = store.showDateInMenubar
+            showPlaceNameInMenubar = store.showPlaceNameInMenubar
         }
     }
 
@@ -303,29 +289,36 @@ class PanelController: ParentPanelController {
 
         let preferences = dataStore.timezones()
 
-        guard let prefs = LogDisplayPreferences(from: dataStore),
-              let country = Locale.autoupdatingCurrent.region?.identifier
-        else {
+        guard let country = Locale.autoupdatingCurrent.region?.identifier else {
             return
         }
+        let prefs = LogDisplayPreferences(from: DataStore.shared())
 
-        var relativeDate = "Relative"
-        if prefs.relativeDateKey.isEqual(to: NSNumber(value: 1)) {
-            relativeDate = "Actual Day"
-        } else if prefs.relativeDateKey.isEqual(to: NSNumber(value: 2)) {
-            relativeDate = "Date"
+        let themeName: String
+        switch prefs.theme {
+        case .light: themeName = "Light"
+        case .dark: themeName = "Dark"
+        case .system: themeName = "System"
+        }
+
+        let relativeDateName: String
+        switch prefs.relativeDateDisplay {
+        case .relative: relativeDateName = "Relative"
+        case .actual: relativeDateName = "Actual Day"
+        case .date: relativeDateName = "Date"
+        case .hidden: relativeDateName = "Hidden"
         }
 
         let panelEvent: [String: Any] = [
-            "Theme": prefs.theme.isEqual(to: NSNumber(value: 0)) ? "Default" : "Black",
-            "Display Future Slider": prefs.displayFutureSlider.isEqual(to: NSNumber(value: 0)) ? "Yes" : "No",
-            "Meridian mode": prefs.showAppInForeground.isEqual(to: NSNumber(value: 0)) ? "Menubar" : "Floating",
-            "Relative Date": relativeDate,
+            "Theme": themeName,
+            "Display Future Slider": prefs.displayFutureSlider,
+            "Meridian mode": prefs.floatOnTop ? "Floating" : "Menubar",
+            "Relative Date": relativeDateName,
             "Font Size": prefs.fontSize,
-            "Sunrise Sunset": prefs.sunriseTime.isEqual(to: NSNumber(value: 0)) ? "Yes" : "No",
-            "Show Day in Menu": prefs.showDayInMenu.isEqual(to: NSNumber(value: 0)) ? "Yes" : "No",
-            "Show Date in Menu": prefs.showDateInMenu.isEqual(to: NSNumber(value: 0)) ? "Yes" : "No",
-            "Show Place in Menu": prefs.showPlaceInMenu.isEqual(to: NSNumber(value: 0)) ? "Yes" : "No",
+            "Sunrise Sunset": prefs.showSunriseSunset,
+            "Show Day in Menu": prefs.showDayInMenubar,
+            "Show Date in Menu": prefs.showDateInMenubar,
+            "Show Place in Menu": prefs.showPlaceNameInMenubar,
             "Country": country,
             "Number of Timezones": preferences.count
         ]
@@ -462,8 +455,7 @@ class PanelController: ParentPanelController {
     }
 
     @objc func toggleFloatingMode() {
-        let newValue = isFloatingMode ? 0 : 1
-        UserDefaults.standard.set(newValue, forKey: UserDefaultKeys.showAppInForeground)
+        DataStore.shared().floatOnTop = !isFloatingMode
         applyWindowMode()
     }
 

--- a/Meridian/Panel/ParentPanelController+Layout.swift
+++ b/Meridian/Panel/ParentPanelController+Layout.swift
@@ -109,16 +109,11 @@ extension ParentPanelController {
             scrollViewHeight.constant = (screenHeight() - PanelLayoutConstants.screenEdgeBuffer)
         }
 
+        // Past this guard the slider is visible; the height adjustment below
+        // shrinks the scroll view to make room for it.
         guard dataStore.shouldDisplay(.futureSlider) else { return }
-        let isModernSliderDisplayed = dataStore.retrieve(key: UserDefaultKeys.displayFutureSliderKey) as? NSNumber ?? 0
-        if isModernSliderDisplayed == 0 {
-            if scrollViewHeight.constant >= (screenHeight() - PanelLayoutConstants.sliderVisibleScreenBuffer) {
-                scrollViewHeight.constant = (screenHeight() - PanelLayoutConstants.sliderHiddenScreenBuffer)
-            }
-        } else {
-            if scrollViewHeight.constant >= (screenHeight() - PanelLayoutConstants.sliderVisibleScreenBuffer) {
-                scrollViewHeight.constant = (screenHeight() - PanelLayoutConstants.sliderVisibleScreenBuffer)
-            }
+        if scrollViewHeight.constant >= (screenHeight() - PanelLayoutConstants.sliderVisibleScreenBuffer) {
+            scrollViewHeight.constant = (screenHeight() - PanelLayoutConstants.sliderHiddenScreenBuffer)
         }
     }
 }

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -11,11 +11,6 @@ struct PanelConstants {
     static let minutesPerSliderPoint = 15
 }
 
-private enum FutureSliderDisplayState: Int {
-    case visible = 0
-    case hidden = 1
-}
-
 class ParentPanelController: NSWindowController {
     var cancellables = Set<AnyCancellable>()
 
@@ -68,12 +63,11 @@ class ParentPanelController: NSWindowController {
     }
 
     private func setupObservers() {
-        UserDefaults.standard.publisher(for: \.displayFutureSlider)
+        UserDefaults.standard.publisher(for: \.showFutureSlider)
             .receive(on: RunLoop.main)
-            .sink { [weak self] changedValue in
+            .sink { [weak self] visible in
                 guard let self = self, let containerView = self.modernContainerView else { return }
-                let state = FutureSliderDisplayState(rawValue: changedValue)
-                containerView.isHidden = (state == .hidden)
+                containerView.isHidden = !visible
             }
             .store(in: &cancellables)
 
@@ -140,11 +134,7 @@ class ParentPanelController: NSWindowController {
     }
 
     private func configureSliderVisibility(containerView: ModernSliderContainerView) {
-        guard let futureSliderValue = dataStore.retrieve(key: UserDefaultKeys.displayFutureSliderKey) as? NSNumber else {
-            containerView.isHidden = true
-            return
-        }
-        containerView.isHidden = (futureSliderValue.intValue == FutureSliderDisplayState.hidden.rawValue)
+        containerView.isHidden = !dataStore.shouldDisplay(.futureSlider)
     }
 
     private func setupRoundedDateView() {

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -159,7 +159,12 @@ private struct AutoUpdateToggle: View {
                 }
                 .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
                     guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
-                    lastCheckDate = appDelegate.updaterController.updater.lastUpdateCheckDate
+                    let updater = appDelegate.updaterController.updater
+                    lastCheckDate = updater.lastUpdateCheckDate
+                    // Re-read autoUpdate so a settings import reflects in the
+                    // toggle without requiring the user to leave & re-enter
+                    // the About tab.
+                    autoUpdate = updater.automaticallyDownloadsUpdates
                 }
 
             Text(lastCheckedText)

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -182,9 +182,8 @@ class AppearanceViewController: ParentViewController {
     }
 
     @IBAction func timeFormatSelectionChanged(_ sender: NSPopUpButton) {
-        let selection = NSNumber(value: sender.indexOfSelectedItem)
-
-        UserDefaults.standard.set(selection, forKey: UserDefaultKeys.selectedTimeZoneFormatKey)
+        let index = sender.indexOfSelectedItem
+        DataStore.shared().timeFormat = TimeFormat(rawValue: index) ?? .twelveHour
         refresh(panel: true)
 
         if let selectedFormat = sender.selectedItem?.title,
@@ -272,9 +271,10 @@ class AppearanceViewController: ParentViewController {
     }
 
     @IBAction func floatOnTopChanged(_ sender: NSSegmentedControl) {
-        let value = sender.selectedSegment == 0 ? 1 : 0
-        UserDefaults.standard.set(value, forKey: UserDefaultKeys.showAppInForeground)
-        Logger.debug("Float on Top: \(value == 1 ? "Enabled" : "Disabled")")
+        // Segment 0 = "Yes" (float on), Segment 1 = "No" (menubar).
+        let enabled = sender.selectedSegment == 0
+        DataStore.shared().floatOnTop = enabled
+        Logger.debug("Float on Top: \(enabled ? "Enabled" : "Disabled")")
     }
 
     private func refresh(panel: Bool) {

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -33,6 +33,10 @@ class AppearanceViewController: ParentViewController {
     @IBOutlet var appDisplayControl: NSSegmentedControl!
     @IBOutlet var floatOnTopControl: NSSegmentedControl!
     @IBOutlet var floatOnTopLabel: NSTextField!
+    // Issue #97 — explicit outlets so viewWillAppear can set initial segments
+    // for controls that previously used Cocoa bindings to legacy keys.
+    @IBOutlet var sunriseControl: NSSegmentedControl!
+    @IBOutlet var futureSliderControl: NSSegmentedControl!
 
     private static let sliderDayValues = [1, 2, 3, 4, 5, 6, 7, 14, 30, 90]
 
@@ -122,17 +126,20 @@ class AppearanceViewController: ParentViewController {
             }
         }
 
-        let shouldDisplayCompact = dataStore.shouldDisplay(.menubarCompactMode)
-        menubarMode.setSelected(true, forSegment: shouldDisplayCompact ? 0 : 1)
-
-        // True is Menubar Only and False is Menubar + Dock
-        let appDisplayOptions = dataStore.shouldDisplay(.appDisplayOptions)
-        appDisplayControl.setSelected(true, forSegment: appDisplayOptions ? 0 : 1)
-
-        // True means float on top enabled
-        let floatOnTop = dataStore.shouldDisplay(.showAppInForeground)
-        floatOnTopControl.setSelected(true, forSegment: floatOnTop ? 0 : 1)
-
+        // Issue #97 — segmented controls used to read their initial state via
+        // Cocoa bindings to legacy UserDefaults keys; bindings were removed so
+        // we set initial state from the typed accessors here. The convention is
+        // segment 0 = Yes/show/compact, segment 1 = No/hide/standard, matching
+        // the storyboard's segment labels.
+        let store = DataStore.shared()
+        menubarMode.setSelected(true, forSegment: store.menubarMode == .compact ? 0 : 1)
+        appDisplayControl.setSelected(true, forSegment: store.appPresentation == .menubarOnly ? 0 : 1)
+        floatOnTopControl.setSelected(true, forSegment: store.floatOnTop ? 0 : 1)
+        sunriseControl.setSelected(true, forSegment: store.showSunriseSunset ? 0 : 1)
+        futureSliderControl.setSelected(true, forSegment: store.showFutureSlider ? 0 : 1)
+        includeDayInMenubarControl.setSelected(true, forSegment: store.showDayInMenubar ? 0 : 1)
+        includeDateInMenubarControl.setSelected(true, forSegment: store.showDateInMenubar ? 0 : 1)
+        includePlaceNameControl.setSelected(true, forSegment: store.showPlaceNameInMenubar ? 0 : 1)
     }
 
     @IBOutlet var timeFormatLabel: NSTextField!
@@ -250,21 +257,29 @@ class AppearanceViewController: ParentViewController {
         previewPanelTableView.reloadData()
     }
 
-    @IBAction func showFutureSlider(_: Any) {
+    @IBAction func showFutureSlider(_ sender: NSSegmentedControl) {
+        // Segment 0 = "Show", Segment 1 = "Hide".
+        DataStore.shared().showFutureSlider = sender.selectedSegment == 0
         refresh(panel: false)
     }
 
     @IBAction func showSunriseSunset(_ sender: NSSegmentedControl) {
-        Logger.debug("Sunrise Sunset: IsItDisplayed=\(sender.selectedSegment == 0 ? "YES" : "NO")")
+        let enabled = sender.selectedSegment == 0
+        DataStore.shared().showSunriseSunset = enabled
+        Logger.debug("Sunrise Sunset: IsItDisplayed=\(enabled ? "YES" : "NO")")
         refresh(panel: true)
         previewPanelTableView.reloadData()
     }
 
     @IBAction func changeAppDisplayOptions(_ sender: NSSegmentedControl) {
-        if sender.selectedSegment == 0 {
+        // Segment 0 = Menubar only, Segment 1 = Menubar + Dock.
+        let presentation: AppPresentation = sender.selectedSegment == 0 ? .menubarOnly : .menubarAndDock
+        DataStore.shared().appPresentation = presentation
+        switch presentation {
+        case .menubarOnly:
             Logger.debug("Dock Mode: Selection=Menubar")
             NSApp.setActivationPolicy(.accessory)
-        } else {
+        case .menubarAndDock:
             Logger.debug("Dock Mode: Selection=Menubar and Dock")
             NSApp.setActivationPolicy(.regular)
         }
@@ -292,15 +307,18 @@ class AppearanceViewController: ParentViewController {
         }
     }
 
-    @IBAction func displayDayInMenubarAction(_: Any) {
+    @IBAction func displayDayInMenubarAction(_ sender: NSSegmentedControl) {
+        DataStore.shared().showDayInMenubar = sender.selectedSegment == 0
         updateStatusItem()
     }
 
-    @IBAction func displayDateInMenubarAction(_: Any) {
+    @IBAction func displayDateInMenubarAction(_ sender: NSSegmentedControl) {
+        DataStore.shared().showDateInMenubar = sender.selectedSegment == 0
         updateStatusItem()
     }
 
-    @IBAction func displayPlaceInMenubarAction(_: Any) {
+    @IBAction func displayPlaceInMenubarAction(_ sender: NSSegmentedControl) {
+        DataStore.shared().showPlaceNameInMenubar = sender.selectedSegment == 0
         updateStatusItem()
     }
 
@@ -317,15 +335,18 @@ class AppearanceViewController: ParentViewController {
     }
 
     @IBAction func menubarModeChanged(_ sender: NSSegmentedControl) {
+        let mode: MenubarMode = sender.selectedSegment == 0 ? .compact : .standard
+        DataStore.shared().menubarMode = mode
+
         guard let statusItem = (NSApplication.shared.delegate as? AppDelegate)?.statusItemForPanel() else {
             return
         }
-
         statusItem.setupStatusItem()
 
-        if sender.selectedSegment == 0 {
+        switch mode {
+        case .compact:
             Logger.debug("Switched to Compact Mode: Context=In Appearance View")
-        } else {
+        case .standard:
             Logger.debug("Switched to Standard Mode: Context=In Appearance View")
         }
     }

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -140,6 +140,12 @@ class AppearanceViewController: ParentViewController {
         includeDayInMenubarControl.setSelected(true, forSegment: store.showDayInMenubar ? 0 : 1)
         includeDateInMenubarControl.setSelected(true, forSegment: store.showDateInMenubar ? 0 : 1)
         includePlaceNameControl.setSelected(true, forSegment: store.showPlaceNameInMenubar ? 0 : 1)
+
+        // Time format popup binding to is24HourFormatSelected was dropped
+        // because the migration deletes that key — refresh the popup
+        // selection from the typed accessor here so it tracks imports and
+        // tab re-entry.
+        timeFormat.selectItem(at: store.timezoneFormat().intValue)
     }
 
     @IBOutlet var timeFormatLabel: NSTextField!

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -146,6 +146,11 @@ class AppearanceViewController: ParentViewController {
         // selection from the typed accessor here so it tracks imports and
         // tab re-entry.
         timeFormat.selectItem(at: store.timezoneFormat().intValue)
+
+        // The preview table renders sample rows using TimezoneDataOperations
+        // which reads the live time format. Settings import doesn't notify
+        // this view controller, so refresh on tab re-entry.
+        previewPanelTableView.reloadData()
     }
 
     @IBOutlet var timeFormatLabel: NSTextField!

--- a/Meridian/Preferences/General/PreferencesViewController.swift
+++ b/Meridian/Preferences/General/PreferencesViewController.swift
@@ -309,7 +309,7 @@ extension PreferencesViewController: NSTableViewDataSource, NSTableViewDelegate 
         guard response == .alertFirstButtonReturn else { return }
 
         OperationQueue.main.addOperation {
-            UserDefaults.standard.set(0, forKey: UserDefaultKeys.menubarCompactMode)
+            DataStore.shared().menubarMode = .compact
 
             if alert.suppressionButton?.state == .on {
                 UserDefaults.standard.set(true, forKey: UserDefaultKeys.longStatusBarWarningMessage)

--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -223,7 +223,6 @@
                                                                 </segmentedCell>
                                                                 <connections>
                                                                     <action selector="showSunriseSunset:" target="1aL-zR-8L4" id="ELQ-If-uaK"/>
-                                                                    <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.showSunriseSetTime" id="fCe-h2-K3A"/>
                                                                 </connections>
                                                             </segmentedControl>
                                                         </gridCell>
@@ -479,7 +478,6 @@
                                                     </segmentedCell>
                                                     <connections>
                                                         <action selector="displayDateInMenubarAction:" target="1aL-zR-8L4" id="zqf-YW-639"/>
-                                                        <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.showDate" id="NI6-wf-sMv"/>
                                                     </connections>
                                                 </segmentedControl>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="175" translatesAutoresizingMaskIntoConstraints="NO" id="pZd-Wg-YPL">
@@ -501,7 +499,6 @@
                                                     </segmentedCell>
                                                     <connections>
                                                         <action selector="displayPlaceInMenubarAction:" target="1aL-zR-8L4" id="xma-Kh-0OZ"/>
-                                                        <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.showPlaceName" id="a2r-XT-uf5"/>
                                                     </connections>
                                                 </segmentedControl>
                                                 <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AxB-VD-lXm">
@@ -512,13 +509,9 @@
                                                             <segment label="Yes" width="38"/>
                                                             <segment label="No" width="38" selected="YES" tag="1"/>
                                                         </segments>
-                                                        <connections>
-                                                            <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.showDay" id="BNl-5Q-2AM"/>
-                                                        </connections>
                                                     </segmentedCell>
                                                     <connections>
                                                         <action selector="displayDayInMenubarAction:" target="1aL-zR-8L4" id="bXE-0W-gfm"/>
-                                                        <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.showDay" id="94x-Xq-60W"/>
                                                     </connections>
                                                 </segmentedControl>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="175" translatesAutoresizingMaskIntoConstraints="NO" id="bhJ-MT-NBP">
@@ -548,7 +541,6 @@
                                                     </segmentedCell>
                                                     <connections>
                                                         <action selector="menubarModeChanged:" target="1aL-zR-8L4" id="cKL-6S-VDw"/>
-                                                        <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.com.abhishek.menubarCompactMode" id="zuN-fl-ZH2"/>
                                                     </connections>
                                                 </segmentedControl>
                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Q3M-Kz-XV3">
@@ -601,7 +593,6 @@
                                                     </segmentedCell>
                                                     <connections>
                                                         <action selector="changeAppDisplayOptions:" target="1aL-zR-8L4" id="ipf-3c-Bsn"/>
-                                                        <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.com.abhishek.appDisplayOptions" id="4Ix-iO-C4I"/>
                                                     </connections>
                                                 </segmentedControl>
                                                 <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="floatTop-ctrl-001">
@@ -665,7 +656,6 @@
                                                     <accessibility identifier="FutureSlider"/>
                                                     <connections>
                                                         <action selector="showFutureSlider:" target="1aL-zR-8L4" id="c1a-KS-oo3"/>
-                                                        <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.displayFutureSlider" id="ha9-nW-Rv2"/>
                                                     </connections>
                                                 </segmentedControl>
                                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="8Nx-Xq-XDU">
@@ -766,6 +756,8 @@
                     <connections>
                         <outlet property="appDisplayControl" destination="DjV-qq-hr9" id="Q4N-i2-oWr"/>
                         <outlet property="appDisplayLabel" destination="HNj-dh-8gr" id="A6U-gp-sje"/>
+                        <outlet property="sunriseControl" destination="9WW-jp-NeO" id="bs97-srs-out"/>
+                        <outlet property="futureSliderControl" destination="pk6-co-N73" id="bs97-fut-out"/>
                         <outlet property="floatOnTopControl" destination="floatTop-ctrl-001" id="floatTop-out-ctrl"/>
                         <outlet property="floatOnTopLabel" destination="floatTop-lbl-001" id="floatTop-out-lbl"/>
                         <outlet property="appearanceTab" destination="SGu-yd-JQh" id="CJn-3E-Ujd"/>

--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -131,7 +131,6 @@
                                                                 </popUpButtonCell>
                                                                 <connections>
                                                                     <action selector="timeFormatSelectionChanged:" target="1aL-zR-8L4" id="WMA-an-RrO"/>
-                                                                    <binding destination="Gpv-Gr-MxZ" name="selectedIndex" keyPath="values.is24HourFormatSelected" id="dda-hb-Th8"/>
                                                                 </connections>
                                                             </popUpButton>
                                                         </gridCell>


### PR DESCRIPTION
Closes #97.

## Summary
- Eliminates the legacy "0 = Yes, 1 = No" UserDefaults convention inherited from upstream Clocker. Bools are now stored and exported as bools; multi-option settings (theme, time format, etc.) are stored as enum raw values and exported as named case strings.
- Resolves the original user complaint behind the issue: settings export now reads `"showSunriseSunset": true` for an enabled toggle instead of `"showSunriseSetTime": 0`.
- Fixes a latent bug uncovered while mapping the work — Menubar Mode and Show Meridian In segmented controls were bound to dead `com.abhishek.*` UserDefaults keys; their selections never persisted across launches.
- Schema migration runs once on first launch of this build; idempotent via `boolSemanticsMigrationV1` flag.

## What changed (5 atomic commits)
1. **Typed accessors + enums** — adds `MenubarMode`, `Theme`, `RelativeDateDisplay`, `AppPresentation`, `TimeFormat` and 11 typed Bool/enum properties on `DataStore`. No behavior change.
2. **Migration layer** — runs once on launch via `AppDefaults.runBoolSemanticsMigration`. Copies legacy values to modernized keys (with inversion undone for the 5 inverted bools and `floatOnTop`), then deletes the legacy keys. New keys' defaults registered alongside.
3. **Sweep call sites** — every direct `UserDefaults.standard.set/integer/object` access on the migrated keys moves to typed accessors. KVO `displayAppAsForegroundApp: Int` becomes `floatOnTop: Bool`; `displayFutureSlider: Int` becomes `showFutureSlider: Bool`. `PanelController.log()` rewritten to emit Bool/enum values directly.
4. **Storyboard rewire** — removes 7 broken Cocoa bindings (5 inverted-bool segments + the 2 `com.abhishek.*` ones + 1 duplicate `showDay` binding). IBActions now write the typed values; `viewWillAppear` sets initial segment state from typed accessors. Adds `sunriseControl` and `futureSliderControl` outlets.
5. **SettingsManager v2 schema** — export emits `"version": 2` with named bool/enum values. Import accepts both v1 (2.19/2.20 export files, with inversion undone) and v2; unsupported versions throw.

## Latent bug fixed
The storyboard's `menubarMode` and `appDisplayControl` segmented controls were bound to `values.com.abhishek.menubarCompactMode` and `values.com.abhishek.appDisplayOptions` — keypaths no Swift code reads. The user's selection on those controls wrote to dead keys; the actual app behavior was governed only by the alert callback in `PreferencesViewController` and `AppDelegate.hideFromDock`. The two controls now bind to the correct keys via typed-setter IBActions, so toggling them in the Appearance pane actually persists.

## Test plan
- [x] All 203 unit tests pass (was 158 before — added 45 new tests across `DataStoreTypedAccessorsTests`, `BoolSemanticsMigrationTests`, `SettingsManagerVersioningTests`)
- [x] Build clean on Debug; no new lint errors
- [x] Storyboard outlets validated by `PreferencesStoryboardTests`
- [ ] Local UAT beta — see UAT section below
- [ ] CI green on PR

## UAT
**Take a settings backup first.** The migration mutates UserDefaults for `com.tpak.Meridian` on first launch. Once it runs, downgrading to 2.20.x stable will read empty legacy keys and revert to registered defaults. To safely UAT:

1. Open production Meridian → About tab → Export settings to JSON (this saves a v1 backup).
2. Build the local beta:
   ```
   osascript -e 'tell application \"Meridian\" to quit' ; sleep 2
   xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \
     CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= \
     MARKETING_VERSION=2.21.0-beta1 CURRENT_PROJECT_VERSION=2210001
   rm -rf ~/Applications/Meridian-beta.app
   cp -R \"$HOME/Library/Developer/Xcode/DerivedData/Meridian-*/Build/Products/Debug/Meridian.app\" \
     ~/Applications/Meridian-beta.app
   xattr -cr ~/Applications/Meridian-beta.app
   open ~/Applications/Meridian-beta.app
   ```
3. Verify the panel footer shows `v2.21.0-beta1`.
4. UAT checklist:
   - All Appearance pane toggles persist across app restart (sunrise, time scroller, day/date/place in menubar, float on top)
   - Menubar Mode and Show Meridian In segments persist across restart (the latent bug)
   - Export settings → check JSON has `"version": 2`, friendly bool/enum keys
   - Re-import the v1 backup from step 1 → settings restore correctly
   - Existing user data (timezones) survives migration

## Reverting
If UAT reveals a problem, install production via `brew reinstall meridian` and re-import the v1 backup. The current production code accepts v1 imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)