### PR TITLE
Tech debt batch 2: lazy var, magic numbers, JSONNameDecodable, access modifiers

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -44,7 +44,7 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
         UserDefaults.standard.removeObject(forKey: UserDefaultKeys.reopenAppearanceOnLaunch)
         // Brief delay so AppDelegate finishes building the panel /
         // status item before we open Settings on top.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + TimingConstants.openAppearanceAfterRelaunch) { [weak self] in
             self?.panelController.oneWindow?.openAppearancePane()
         }
     }

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -8,7 +8,7 @@ import Sparkle
 @main
 open class AppDelegate: NSObject, NSApplicationDelegate {
     internal lazy var panelController = PanelController(windowNibName: .panel)
-    private var statusBarHandler: StatusItemHandler!
+    private lazy var statusBarHandler: StatusItemHandler = StatusItemHandler(with: DataStore.shared())
     lazy var updaterController: SPUStandardUpdaterController = {
         SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: self, userDriverDelegate: nil)
     }()
@@ -204,8 +204,10 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
         // Check if another instance of the app is already running. If so, then stop this one.
         checkIfAppIsAlreadyOpen()
 
-        // Install the menubar item!
-        statusBarHandler = StatusItemHandler(with: DataStore.shared())
+        // Force the lazy var to materialize here so the menubar item appears
+        // at this specific point in the launch sequence rather than on first
+        // access elsewhere.
+        _ = statusBarHandler
 
         UserDefaults.standard.register(defaults: ["NSApplicationCrashOnExceptions": true])
 

--- a/Meridian/Overall App/DataStore.swift
+++ b/Meridian/Overall App/DataStore.swift
@@ -32,6 +32,23 @@ protocol DataStoring: AnyObject {
     func shouldShowDayInMenubar() -> Bool
 }
 
+// Conforming `CaseIterable` enums get a stable string identifier (`jsonName`,
+// defaulting to the Swift case name) for SettingsManager export/import, plus
+// a failable `init?(jsonName:)` for the inverse lookup. Override `jsonName`
+// when the enum's stable identifier needs to differ from the case name.
+protocol JSONNameDecodable: CaseIterable {
+    var jsonName: String { get }
+}
+
+extension JSONNameDecodable {
+    var jsonName: String { String(describing: self) }
+
+    init?(jsonName: String) {
+        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
+        self = match
+    }
+}
+
 class DataStore: NSObject, DataStoring {
     private static var sharedStore = DataStore(with: UserDefaults.standard)
     private var userDefaults: UserDefaults!
@@ -247,13 +264,14 @@ enum TeamAccent: String, Codable, CaseIterable {
         return NSColor(srgbRed: red, green: green, blue: blue, alpha: 0.85)
     }
 
+    // Override the JSONNameDecodable default (`String(describing: self)`) to
+    // explicitly use rawValue. Functionally equivalent today since cases have
+    // no explicit raw values, but the override locks in stability if a case
+    // ever needs an explicit raw value that diverges from the case name.
     var jsonName: String { rawValue }
-
-    init?(jsonName: String) {
-        guard let match = Self.allCases.first(where: { $0.rawValue == jsonName }) else { return nil }
-        self = match
-    }
 }
+
+extension TeamAccent: JSONNameDecodable {}
 
 extension Notification.Name {
     /// Posted when the user changes the team accent in Appearance settings.
@@ -376,46 +394,16 @@ enum TimeFormat: Int, Codable, CaseIterable {
     case epoch = 11
 }
 
-// Stable string name for typed preference enums. Used by SettingsManager v2
+// Stable string name for typed preference enums via the JSONNameDecodable
+// protocol (declared near the top of this file). Used by SettingsManager v2
 // JSON export ("compact" instead of 0). Names are derived from the Swift
 // case identifier — keep them stable across releases since users' export
 // files persist them.
-extension MenubarMode { var jsonName: String { String(describing: self) } }
-extension Theme { var jsonName: String { String(describing: self) } }
-extension RelativeDateDisplay { var jsonName: String { String(describing: self) } }
-extension AppPresentation { var jsonName: String { String(describing: self) } }
-extension TimeFormat { var jsonName: String { String(describing: self) } }
-
-extension MenubarMode {
-    init?(jsonName: String) {
-        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
-        self = match
-    }
-}
-extension Theme {
-    init?(jsonName: String) {
-        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
-        self = match
-    }
-}
-extension RelativeDateDisplay {
-    init?(jsonName: String) {
-        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
-        self = match
-    }
-}
-extension AppPresentation {
-    init?(jsonName: String) {
-        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
-        self = match
-    }
-}
-extension TimeFormat {
-    init?(jsonName: String) {
-        guard let match = Self.allCases.first(where: { $0.jsonName == jsonName }) else { return nil }
-        self = match
-    }
-}
+extension MenubarMode: JSONNameDecodable {}
+extension Theme: JSONNameDecodable {}
+extension RelativeDateDisplay: JSONNameDecodable {}
+extension AppPresentation: JSONNameDecodable {}
+extension TimeFormat: JSONNameDecodable {}
 
 // MARK: - Typed accessors (issue #97)
 

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -71,3 +71,28 @@ public enum UserDefaultKeys {
     // Settings to the Appearance tab, and clears the flag.
     static let reopenAppearanceOnLaunch = "com.tpak.meridian.reopenAppearanceOnLaunch"
 }
+
+// Centralized timing literals. Putting them here makes the rationale for each
+// delay easy to find (and to revisit) instead of hiding them as bare numbers
+// at call sites.
+enum TimingConstants {
+    /// Delay before terminating the current process during the team-accent
+    /// restart flow. Long enough for `open -n` to register the new launch
+    /// before the old process exits — otherwise macOS treats it as a
+    /// duplicate-launch suppression and the new instance never appears.
+    static let pauseBeforeRelaunchTermination: TimeInterval = 0.2
+
+    /// Delay before opening Settings → Appearance after the team-accent
+    /// relaunch completes. Lets AppDelegate finish constructing the panel
+    /// and status item before we open Settings on top of them.
+    static let openAppearanceAfterRelaunch: TimeInterval = 0.3
+}
+
+// Centralized layout literals shared across menubar text-rendering call sites.
+// Per-file layout values that aren't shared stay where they're used.
+enum LayoutConstants {
+    /// Line-height multiple applied to monospaced status-bar text in English
+    /// locales. Slightly compresses leading so descenders (p, q, y, g) read
+    /// well in the menubar. Non-English locales use 1.0 (no compression).
+    static let englishMenubarLineHeightMultiple: CGFloat = 0.92
+}

--- a/Meridian/Panel/PanelController.swift
+++ b/Meridian/Panel/PanelController.swift
@@ -11,6 +11,11 @@ private enum PanelLayout {
     static let versionLabelTrailingMargin: CGFloat = 34 // 22pt button + 4pt gap + 8pt margin
     static let frameYPointOffset: CGFloat = 2
     static let minimumSpaceBetweenWindowAndScreenEdge: CGFloat = 10
+    /// How far below the status item's origin we probe to identify which
+    /// screen contains the status item. Status items sit at the very top edge
+    /// in NS coordinates (y = screen.maxY), so a probe AT the origin can land
+    /// outside any screen. 100pt down lands well inside the menubar's screen.
+    static let statusItemScreenProbeOffset: CGFloat = 100
 }
 
 private enum PanelAnimation {
@@ -269,7 +274,7 @@ class PanelController: ParentPanelController {
 
         var statusItemFrame = statusWindow.convertToScreen(statusButton.frame)
         var testPoint = statusItemFrame.origin
-        testPoint.y -= 100
+        testPoint.y -= PanelLayout.statusItemScreenProbeOffset
 
         let statusItemScreen = NSScreen.screens.first(where: { $0.frame.contains(testPoint) }) ?? NSScreen.main
         guard let resolvedScreen = statusItemScreen else { return }

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -11,6 +11,12 @@ struct PanelConstants {
     static let minutesPerSliderPoint = 15
 }
 
+// Properties below are scoped to subclass-or-extension reach intentionally:
+// - cancellables / parentTimer / datasource: written by PanelController subclass
+// - futureSliderValue: read by TimezoneCellView (an unrelated UI cell that
+//   needs the current scrub offset)
+// - dataStore: kept internal so tests can swap in a mock
+// All other state on this class stays private.
 class ParentPanelController: NSWindowController {
     var cancellables = Set<AnyCancellable>()
 
@@ -44,8 +50,8 @@ class ParentPanelController: NSWindowController {
     @IBOutlet var roundedDateView: NSView!
 
     // Modern Slider
-    public var currentCenterSliderItemIndex: Int = -1
-    public var closestQuarterTimeRepresentation: Date?
+    var currentCenterSliderItemIndex: Int = -1
+    var closestQuarterTimeRepresentation: Date?
     @IBOutlet var modernSlider: NSCollectionView!
     @IBOutlet var modernSliderLabel: NSTextField!
     @IBOutlet var modernContainerView: ModernSliderContainerView!

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -305,7 +305,7 @@ class AppearanceViewController: ParentViewController {
         // Brief delay so the spawn has time to register before we
         // terminate; otherwise macOS may treat it as a duplicate-launch
         // suppression and the new instance never appears.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + TimingConstants.pauseBeforeRelaunchTermination) {
             NSApp.terminate(nil)
         }
     }

--- a/Meridian/Preferences/Menu Bar/StatusContainerView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusContainerView.swift
@@ -61,7 +61,7 @@ class StatusContainerView: NSView {
         paragraphStyle.lineBreakMode = .byTruncatingTail
         // Better readability for p,q,y,g in the status bar.
         let userPreferredLanguage = Locale.preferredLanguages.first ?? "en-US"
-        let lineHeight = userPreferredLanguage.contains("en") ? 0.92 : 1
+        let lineHeight = userPreferredLanguage.contains("en") ? LayoutConstants.englishMenubarLineHeightMultiple : 1
         paragraphStyle.lineHeightMultiple = CGFloat(lineHeight)
         return paragraphStyle
     }()

--- a/Meridian/Preferences/Menu Bar/StatusItemView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemView.swift
@@ -16,7 +16,7 @@ let defaultParagraphStyle: NSMutableParagraphStyle = {
     paragraphStyle.lineBreakMode = .byTruncatingTail
     // Better readability for p,q,y,g in the status bar.
     let userPreferredLanguage = Locale.preferredLanguages.first ?? "en-US"
-    let lineHeight = userPreferredLanguage.contains("en") ? 0.92 : 1
+    let lineHeight = userPreferredLanguage.contains("en") ? LayoutConstants.englishMenubarLineHeightMultiple : 1
     paragraphStyle.lineHeightMultiple = CGFloat(lineHeight)
     return paragraphStyle
 }()
@@ -48,7 +48,7 @@ class StatusItemView: NSView {
         paragraphStyle.lineBreakMode = .byTruncatingTail
         // Better readability for p,q,y,g in the status bar.
         let userPreferredLanguage = Locale.preferredLanguages.first ?? "en-US"
-        let lineHeight = userPreferredLanguage.contains("en") ? 0.92 : 1
+        let lineHeight = userPreferredLanguage.contains("en") ? LayoutConstants.englishMenubarLineHeightMultiple : 1
         paragraphStyle.lineHeightMultiple = CGFloat(lineHeight)
         return paragraphStyle
     }()


### PR DESCRIPTION
## Summary

Four mechanical-cleanup commits from the remaining tech-debt list. Review by commit; each is independent.

- **M1** — `private var statusBarHandler: StatusItemHandler!` (IUO) → `private lazy var statusBarHandler: StatusItemHandler = StatusItemHandler(with: DataStore.shared())`. The explicit assignment in `continueUsually()` becomes `_ = statusBarHandler` to keep the menubar item materializing at the same point in launch sequence.
- **M6** — Magic numeric literals (`0.3`, `0.2`, `0.92`, `100`) replaced with named constants. Two new enums in `Strings.swift`: `TimingConstants` (relaunch delays) and `LayoutConstants` (English menubar line-height multiple). The 100pt status-item screen probe stays local in `PanelController`'s existing `PanelLayout` enum. Each constant gets a doc comment explaining *why* the value is what it is.
- **M7** — Defines `JSONNameDecodable: CaseIterable` protocol with default `jsonName` (case name) and `init?(jsonName:)`. Six enums (`MenubarMode`, `Theme`, `RelativeDateDisplay`, `AppPresentation`, `TimeFormat`, `TeamAccent`) drop ~40 lines of copy-paste in favor of one-line conformances. `TeamAccent` keeps its `var jsonName: String { rawValue }` override (commented) for raw-value stability.
- **M11** — `currentCenterSliderItemIndex` and `closestQuarterTimeRepresentation` were `public var` but only used within the module. Drop both to internal. Other internal properties (`cancellables`, `parentTimer`, `datasource`, `futureSliderValue`, `dataStore`) genuinely need internal access — verified by grepping cross-class usage. Header comment block now spells out *why* each one is internal so a future audit doesn't try to tighten them blindly.

No behavioral changes. SettingsManager call sites (`MenubarMode(jsonName: s)`, etc.) and the `TeamAccent` unit tests are unchanged — same callable surface.

## Test plan

- [x] Builds Debug
- [ ] CI green (Build & Lint, Unit Tests)
- [ ] Spot-check on local UAT beta: launch behaves normally (menubar appears, panel opens), team-accent restart flow still works, Settings export/import round-trips correctly

## Doc update

Tech-debt doc update (marking M1, M6, M7, M11 as done) deferred to a follow-up so it doesn't conflict with PR #110 (which created the doc and added M13). Will update the doc once both this PR and #110 are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)