### PR TITLE
Add trademark disclaimer popover to accent color picker

### DIFF
--- a/Meridian/App/Localizable.xcstrings
+++ b/Meridian/App/Localizable.xcstrings
@@ -2423,6 +2423,39 @@
           }
         }
       }
+    },
+    "About these colors": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About these colors"
+          }
+        }
+      }
+    },
+    "About accent colors": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "About accent colors"
+          }
+        }
+      }
+    },
+    "Meridian is an independent project, built by an F1 fan, not affiliated with, sponsored by, or endorsed by Formula 1 or any of the teams listed. Team names are trademarks of their respective owners, used here only to identify the livery colors they inspire. Colors are fan approximations, not official team colors.": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meridian is an independent project, built by an F1 fan, not affiliated with, sponsored by, or endorsed by Formula 1 or any of the teams listed. Team names are trademarks of their respective owners, used here only to identify the livery colors they inspire. Colors are fan approximations, not official team colors."
+          }
+        }
+      }
     }
   }
 }

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -557,7 +557,12 @@ final class AccentColorInfoViewController: NSViewController {
     private static let edgePadding: CGFloat = 16
 
     static let titleText = "About these colors"
-    static let bodyText = "Meridian is an independent project, built by an F1 fan, not affiliated with, sponsored by, or endorsed by Formula 1 or any of the teams listed. Team names are trademarks of their respective owners, used here only to identify the livery colors they inspire. Colors are fan approximations, not official team colors."
+    // Concatenated at runtime; the joined string is the key looked up in
+    // Localizable.xcstrings so it must match the catalog entry exactly.
+    static let bodyText = "Meridian is an independent project, built by an F1 fan, "
+        + "not affiliated with, sponsored by, or endorsed by Formula 1 or any of the teams listed. "
+        + "Team names are trademarks of their respective owners, used here only to identify the "
+        + "livery colors they inspire. Colors are fan approximations, not official team colors."
 
     override func loadView() {
         let title = NSTextField(labelWithString: Self.titleText.localized())

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -23,6 +23,7 @@ class AppearanceViewController: ParentViewController {
     @IBOutlet var timeFormat: NSPopUpButton!
     @IBOutlet var theme: NSPopUpButton!
     @IBOutlet var teamAccentPopup: NSPopUpButton!
+    @IBOutlet var accentColorInfoButton: NSButton!
     @IBOutlet var informationLabel: NSTextField!
     @IBOutlet var sliderDayRangePopup: NSPopUpButton!
     @IBOutlet var visualEffectView: NSVisualEffectView!
@@ -42,6 +43,15 @@ class AppearanceViewController: ParentViewController {
     private static let sliderDayValues = [1, 2, 3, 4, 5, 6, 7, 14, 30, 90]
 
     private var previewTimezones: [TimezoneData] = []
+
+    /// Lazy popover for the trademark / fan-attribution disclaimer shown when
+    /// the user clicks the (i) button next to the team accent picker.
+    private lazy var accentInfoPopover: NSPopover = {
+        let popover = NSPopover()
+        popover.behavior = .transient
+        popover.contentViewController = AccentColorInfoViewController()
+        return popover
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -102,6 +112,16 @@ class AppearanceViewController: ParentViewController {
         popup.target = self
         popup.action = #selector(teamAccentChanged(_:))
         popup.setAccessibilityIdentifier("TeamAccentPopover")
+
+        if let info = accentColorInfoButton {
+            info.image = NSImage(systemSymbolName: "info.circle",
+                                 accessibilityDescription: "About accent colors".localized())
+            info.contentTintColor = NSColor.secondaryLabelColor
+            info.toolTip = "About these colors".localized()
+            info.setAccessibilityLabel("About accent colors".localized())
+            info.target = self
+            info.action = #selector(showAccentColorInfo(_:))
+        }
     }
 
     private func setupTimeFormatPopup() {
@@ -263,6 +283,14 @@ class AppearanceViewController: ParentViewController {
         // app pokes them (verified across betas 2-7). Offer the user
         // the only mechanism that works: a quit+relaunch.
         promptForRestart(applying: team)
+    }
+
+    @IBAction func showAccentColorInfo(_ sender: NSButton) {
+        if accentInfoPopover.isShown {
+            accentInfoPopover.performClose(sender)
+            return
+        }
+        accentInfoPopover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .maxY)
     }
 
     private func promptForRestart(applying team: TeamAccent) {
@@ -517,5 +545,51 @@ extension AppearanceViewController: NSTableViewDataSource, NSTableViewDelegate {
         }
 
         return 0
+    }
+}
+
+/// Disclaimer popover shown next to the team accent picker. The text
+/// acknowledges that the colors are fan approximations, names the teams
+/// as trademark holders of their respective owners, and disclaims any
+/// affiliation with Formula 1 — supporting a nominative-fair-use posture.
+final class AccentColorInfoViewController: NSViewController {
+    private static let popoverWidth: CGFloat = 340
+    private static let edgePadding: CGFloat = 16
+
+    static let titleText = "About these colors"
+    static let bodyText = "Meridian is an independent project, built by an F1 fan, not affiliated with, sponsored by, or endorsed by Formula 1 or any of the teams listed. Team names are trademarks of their respective owners, used here only to identify the livery colors they inspire. Colors are fan approximations, not official team colors."
+
+    override func loadView() {
+        let title = NSTextField(labelWithString: Self.titleText.localized())
+        title.font = NSFont.systemFont(ofSize: NSFont.systemFontSize, weight: .semibold)
+        title.textColor = NSColor.labelColor
+        title.translatesAutoresizingMaskIntoConstraints = false
+
+        let body = NSTextField(wrappingLabelWithString: Self.bodyText.localized())
+        body.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
+        body.textColor = NSColor.secondaryLabelColor
+        body.preferredMaxLayoutWidth = Self.popoverWidth - (Self.edgePadding * 2)
+        body.translatesAutoresizingMaskIntoConstraints = false
+
+        let stack = NSStackView(views: [title, body])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        stack.edgeInsets = NSEdgeInsets(top: Self.edgePadding,
+                                        left: Self.edgePadding,
+                                        bottom: Self.edgePadding,
+                                        right: Self.edgePadding)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let container = NSView()
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            container.widthAnchor.constraint(equalToConstant: Self.popoverWidth),
+            stack.topAnchor.constraint(equalTo: container.topAnchor),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor)
+        ])
+        view = container
     }
 }

--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -178,31 +178,58 @@
                                                             </textField>
                                                         </gridCell>
                                                         <gridCell row="Acc-1r-Row" column="YBI-pK-gPQ" id="Acc-Ce-Pop">
-                                                            <popUpButton key="contentView" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Acc-Pb-Pop">
-                                                                <rect key="frame" x="228" y="162" width="160" height="25"/>
-                                                                <popUpButtonCell key="cell" type="push" title="Aston Martin" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="Acm-iA-Asn" id="Acc-Pc-Pop">
-                                                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                                    <font key="font" size="13" name="Avenir-Book"/>
-                                                                    <menu key="menu" id="Acc-Mn-Pop">
-                                                                        <items>
-                                                                            <menuItem title="Alpine" id="Acm-iA-Alp"/>
-                                                                            <menuItem title="Aston Martin" state="on" id="Acm-iA-Asn"/>
-                                                                            <menuItem title="Audi" id="Acm-iA-Aud"/>
-                                                                            <menuItem title="Cadillac" id="Acm-iA-Cad"/>
-                                                                            <menuItem title="Ferrari" id="Acm-iA-Fer"/>
-                                                                            <menuItem title="Haas" id="Acm-iA-Has"/>
-                                                                            <menuItem title="McLaren" id="Acm-iA-Mcl"/>
-                                                                            <menuItem title="Mercedes" id="Acm-iA-Mer"/>
-                                                                            <menuItem title="Racing Bulls" id="Acm-iA-Rbu"/>
-                                                                            <menuItem title="Red Bull Racing" id="Acm-iA-Red"/>
-                                                                            <menuItem title="Williams" id="Acm-iA-Wil"/>
-                                                                        </items>
-                                                                    </menu>
-                                                                </popUpButtonCell>
-                                                                <connections>
-                                                                    <action selector="teamAccentChanged:" target="1aL-zR-8L4" id="Acc-Ac-Pop"/>
-                                                                </connections>
-                                                            </popUpButton>
+                                                            <stackView key="contentView" distribution="fill" orientation="horizontal" alignment="centerY" spacing="6" horizontalStackHuggingPriority="249" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Acc-Sv-Pop">
+                                                                <rect key="frame" x="228" y="162" width="190" height="25"/>
+                                                                <subviews>
+                                                                    <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Acc-Pb-Pop">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="160" height="25"/>
+                                                                        <popUpButtonCell key="cell" type="push" title="Aston Martin" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="Acm-iA-Asn" id="Acc-Pc-Pop">
+                                                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                                            <font key="font" size="13" name="Avenir-Book"/>
+                                                                            <menu key="menu" id="Acc-Mn-Pop">
+                                                                                <items>
+                                                                                    <menuItem title="Alpine" id="Acm-iA-Alp"/>
+                                                                                    <menuItem title="Aston Martin" state="on" id="Acm-iA-Asn"/>
+                                                                                    <menuItem title="Audi" id="Acm-iA-Aud"/>
+                                                                                    <menuItem title="Cadillac" id="Acm-iA-Cad"/>
+                                                                                    <menuItem title="Ferrari" id="Acm-iA-Fer"/>
+                                                                                    <menuItem title="Haas" id="Acm-iA-Has"/>
+                                                                                    <menuItem title="McLaren" id="Acm-iA-Mcl"/>
+                                                                                    <menuItem title="Mercedes" id="Acm-iA-Mer"/>
+                                                                                    <menuItem title="Racing Bulls" id="Acm-iA-Rbu"/>
+                                                                                    <menuItem title="Red Bull Racing" id="Acm-iA-Red"/>
+                                                                                    <menuItem title="Williams" id="Acm-iA-Wil"/>
+                                                                                </items>
+                                                                            </menu>
+                                                                        </popUpButtonCell>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" constant="160" id="Acc-Cw-Pop"/>
+                                                                        </constraints>
+                                                                        <connections>
+                                                                            <action selector="teamAccentChanged:" target="1aL-zR-8L4" id="Acc-Ac-Pop"/>
+                                                                        </connections>
+                                                                    </popUpButton>
+                                                                    <button toolTip="About these colors" bordered="NO" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Acc-Bt-Inf">
+                                                                        <rect key="frame" x="166" y="2" width="22" height="22"/>
+                                                                        <buttonCell key="cell" type="bevel" bezelStyle="rounded" imagePosition="only" alignment="center" imageScaling="proportionallyDown" inset="2" id="Acc-Bc-Inf">
+                                                                            <behavior key="behavior" pushIn="YES" lightByContents="YES"/>
+                                                                            <font key="font" metaFont="system"/>
+                                                                        </buttonCell>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="width" constant="22" id="Acc-Cw-Inf"/>
+                                                                            <constraint firstAttribute="height" constant="22" id="Acc-Ch-Inf"/>
+                                                                        </constraints>
+                                                                        <accessibility identifier="AccentColorInfo"/>
+                                                                        <connections>
+                                                                            <action selector="showAccentColorInfo:" target="1aL-zR-8L4" id="Acc-Ac-Inf"/>
+                                                                        </connections>
+                                                                    </button>
+                                                                </subviews>
+                                                                <visibilityPriorities>
+                                                                    <integer value="1000"/>
+                                                                    <integer value="1000"/>
+                                                                </visibilityPriorities>
+                                                            </stackView>
                                                         </gridCell>
                                                         <gridCell row="vjb-Ch-BZs" column="ARE-A4-4k4" id="Tkw-Kt-dMr">
                                                             <textField key="contentView" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" preferredMaxLayoutWidth="150" translatesAutoresizingMaskIntoConstraints="NO" id="gFE-hZ-J92">
@@ -819,6 +846,7 @@
                         <outlet property="sliderDayRangePopup" destination="8Nx-Xq-XDU" id="PBM-yB-Yo1"/>
                         <outlet property="teamAccentPopup" destination="Acc-Pb-Pop" id="Acc-Ol-Pop"/>
                         <outlet property="accentColorLabel" destination="Acc-Tf-Lab" id="Acc-Ol-Lab"/>
+                        <outlet property="accentColorInfoButton" destination="Acc-Bt-Inf" id="Acc-Ol-Inf"/>
 <outlet property="theme" destination="89w-KN-GJ6" id="SAL-Sh-eqp"/>
                         <outlet property="timeFormat" destination="iiG-Xu-4id" id="oM3-1Y-fAF"/>
                         <outlet property="timeFormatLabel" destination="wtO-uL-QBf" id="udS-d6-Tep"/>

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -1,90 +1,98 @@
 #!/bin/bash
-# Validates the Sparkle beta-channel feature (issue #98).
+# Validates the accent color trademark disclaimer popover (feature/accent-color-disclaimer).
 # Run from repo root. Exits non-zero if any check fails.
 #
 # Three groups of checks:
-#   1. App-side wiring (UserDefaultKeys key, AppDelegate delegate, About toggle)
-#   2. Release tooling (version regex, sparkle:channel injection, prerelease, cask skip)
-#   3. Compilation (full xcodebuild)
+#   1. Storyboard wiring (info button, action selector, outlet)
+#   2. Swift wiring (outlet, action, popover view controller, SF Symbol)
+#   3. Localization + compilation
 set -u
 cd "$(dirname "$0")/.."
 
 PASS=0
 FAIL=0
-ok()   { echo "  OK:   $1"; PASS=$((PASS+1)); }
-bad()  { echo "  FAIL: $1" >&2; FAIL=$((FAIL+1)); }
+ok()      { echo "  OK:   $1"; PASS=$((PASS+1)); }
+bad()     { echo "  FAIL: $1" >&2; FAIL=$((FAIL+1)); }
 section() { echo ""; echo "── $1"; }
 
-# ── 1. App-side wiring ────────────────────────────────────────────────
+# ── 1. Storyboard ─────────────────────────────────────────────────────
 
-section "App: UserDefaultKeys"
-STRINGS_FILE="Meridian/Overall App/Strings.swift"
-grep -q 'static let betaUpdatesEnabled' "$STRINGS_FILE" \
-    && ok "betaUpdatesEnabled key declared in Strings.swift" \
-    || bad "betaUpdatesEnabled key missing in Strings.swift"
+section "Storyboard: info button + outlet + action"
+SB="Meridian/Preferences/Preferences.storyboard"
 
-section "App: AppDelegate Sparkle channel delegate"
-APPDELEGATE="Meridian/AppDelegate.swift"
-grep -qE 'func allowedChannels\(for[^)]*\) -> Set<String>' "$APPDELEGATE" \
-    && ok "allowedChannels(for:) implemented in AppDelegate" \
-    || bad "allowedChannels(for:) not implemented in AppDelegate"
+grep -q 'id="Acc-Bt-Inf"' "$SB" \
+    && ok "info button (Acc-Bt-Inf) present" \
+    || bad "info button (Acc-Bt-Inf) missing from storyboard"
 
-grep -q 'UserDefaultKeys.betaUpdatesEnabled' "$APPDELEGATE" \
-    && ok "AppDelegate reads UserDefaultKeys.betaUpdatesEnabled" \
-    || bad "AppDelegate does not reference UserDefaultKeys.betaUpdatesEnabled"
+grep -q 'selector="showAccentColorInfo:"' "$SB" \
+    && ok "showAccentColorInfo: action wired" \
+    || bad "showAccentColorInfo: action not wired"
 
-grep -qE '"beta"' "$APPDELEGATE" \
-    && ok "AppDelegate references the \"beta\" channel literal" \
-    || bad "AppDelegate is missing the \"beta\" channel literal"
+grep -q 'property="accentColorInfoButton"' "$SB" \
+    && ok "accentColorInfoButton outlet wired" \
+    || bad "accentColorInfoButton outlet missing"
 
-# Existing Sparkle hooks must be preserved (regression guard).
-grep -q "willInstallUpdateOnQuit" "$APPDELEGATE" \
-    && ok "existing willInstallUpdateOnQuit hook still present" \
-    || bad "willInstallUpdateOnQuit hook was removed"
+# Popup must still be present and wired (regression guard for the
+# stackView restructure of the gridCell).
+grep -q 'property="teamAccentPopup"' "$SB" \
+    && ok "teamAccentPopup outlet preserved" \
+    || bad "teamAccentPopup outlet was removed"
 
-section "App: About tab beta toggle"
-ABOUT_VIEW="Meridian/Preferences/About/AboutView.swift"
-grep -q 'UserDefaultKeys.betaUpdatesEnabled' "$ABOUT_VIEW" \
-    && ok "AboutView binds to betaUpdatesEnabled" \
-    || bad "AboutView does not bind to betaUpdatesEnabled"
+grep -q 'selector="teamAccentChanged:"' "$SB" \
+    && ok "teamAccentChanged: action preserved" \
+    || bad "teamAccentChanged: action was removed"
 
-grep -qE 'BetaChannelToggle|Receive beta releases|Include beta releases' "$ABOUT_VIEW" \
-    && ok "AboutView declares a beta-channel toggle" \
-    || bad "AboutView has no visible beta toggle (looked for BetaChannelToggle / 'Receive beta releases' / 'Include beta releases')"
+# ── 2. Swift ──────────────────────────────────────────────────────────
 
-# ── 2. Release tooling ───────────────────────────────────────────────
+section "Swift: outlet, action, view controller, SF Symbol"
+APPEAR="Meridian/Preferences/Appearance/AppearanceViewController.swift"
 
-section "Release script: version handling"
-RELEASE="scripts/release.sh"
+grep -q '@IBOutlet var accentColorInfoButton: NSButton!' "$APPEAR" \
+    && ok "@IBOutlet accentColorInfoButton declared" \
+    || bad "@IBOutlet accentColorInfoButton missing"
 
-# Regex must permit X.Y.Z-betaN (look for -beta inside the bash =~ pattern).
-grep -qE 'VERSION.*=~.*-beta' "$RELEASE" \
-    && ok "release.sh version regex permits a -betaN suffix" \
-    || bad "release.sh version regex still rejects -betaN suffixes"
+grep -q '@IBAction func showAccentColorInfo' "$APPEAR" \
+    && ok "@IBAction showAccentColorInfo declared" \
+    || bad "@IBAction showAccentColorInfo missing"
 
-grep -qE 'IS_BETA|is_beta|BETA_RELEASE' "$RELEASE" \
-    && ok "release.sh detects a beta version string" \
-    || bad "release.sh has no beta detection"
+grep -q 'class AccentColorInfoViewController' "$APPEAR" \
+    && ok "AccentColorInfoViewController declared" \
+    || bad "AccentColorInfoViewController missing"
 
-section "Release script: appcast channel + prerelease"
-grep -q 'sparkle:channel' "$RELEASE" \
-    && ok "release.sh emits <sparkle:channel> for beta items" \
-    || bad "release.sh does not emit <sparkle:channel>"
+grep -q 'systemSymbolName: "info.circle"' "$APPEAR" \
+    && ok "info.circle SF Symbol assigned to button" \
+    || bad "info.circle SF Symbol not assigned"
 
-grep -q -- '--prerelease' "$RELEASE" \
-    && ok "release.sh passes --prerelease to gh for betas" \
-    || bad "release.sh never passes --prerelease"
+grep -q 'NSPopover' "$APPEAR" \
+    && ok "NSPopover used for the disclaimer" \
+    || bad "NSPopover not used"
 
-section "Release script: skip Homebrew cask for betas"
-# Look for a guard around the Homebrew section that references beta.
-if awk '/Update Homebrew cask/,/Homebrew cask updated/' "$RELEASE" \
-    | grep -qE 'IS_BETA|is_beta|BETA_RELEASE|Skipping cask.*beta|skipping.*cask'; then
-    ok "release.sh skips Homebrew cask update for betas"
-else
-    bad "release.sh always updates Homebrew cask (must skip for betas)"
-fi
+# ── 3. Localization ──────────────────────────────────────────────────
 
-# ── 3. Compilation ───────────────────────────────────────────────────
+section "Localization: disclaimer strings present in xcstrings"
+XCS="Meridian/App/Localizable.xcstrings"
+
+grep -q '"About these colors"' "$XCS" \
+    && ok "title string present" \
+    || bad "title string missing"
+
+grep -q '"About accent colors"' "$XCS" \
+    && ok "accessibility label string present" \
+    || bad "accessibility label string missing"
+
+grep -q "Meridian is an independent project, built by an F1 fan" "$XCS" \
+    && ok "body disclaimer present" \
+    || bad "body disclaimer missing"
+
+grep -q "Team names are trademarks of their respective owners" "$XCS" \
+    && ok "trademark attribution present" \
+    || bad "trademark attribution missing"
+
+grep -q "Colors are fan approximations" "$XCS" \
+    && ok "fan-approximation acknowledgement present" \
+    || bad "fan-approximation acknowledgement missing"
+
+# ── 4. Build ─────────────────────────────────────────────────────────
 
 section "Build: xcodebuild Debug (no code signing)"
 if xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \


### PR DESCRIPTION
## Summary

- Adds a small (i) info button next to the F1 team accent picker in Settings → Appearance.
- Tapping it shows a popover acknowledging Meridian as an independent project, that team names are trademarks of their respective owners, and that the colors are fan approximations rather than official livery colors.
- Supports a nominative-fair-use posture for the team-name labels in the picker.

## What changed

- `Meridian/Preferences/Preferences.storyboard` — wraps the existing accent popup in a horizontal stack view and adds a borderless info button beside it (SF Symbol `info.circle`).
- `Meridian/Preferences/Appearance/AppearanceViewController.swift` — outlet, IBAction, lazy `NSPopover`, and a private `AccentColorInfoViewController` that lays out the title + body labels.
- `Meridian/App/Localizable.xcstrings` — three new English source strings (title, accessibility label, body). Other locales will populate as `state: "new"` on next translation pass.
- `scripts/validate_feature.sh` — refreshed for this feature; all 16 checks pass.

## Test plan
- [x] xcodebuild Debug clean build succeeds
- [x] (i) button renders next to Accent Color popup; click shows popover
- [x] Popover dismisses on outside click (transient behavior)
- [x] Disclaimer text wraps cleanly at popover width
- [x] Picker still works (selection persists, restart prompt still appears)

🤖 Generated with [Claude Code](https://claude.com/claude-code)