### PR TITLE
Detect and recover from Tahoe Control Center menubar block (#125)

### DIFF
--- a/Meridian/App/Localizable.xcstrings
+++ b/Meridian/App/Localizable.xcstrings
@@ -2360,6 +2360,174 @@
           }
         }
       }
+    },
+    "One quick setup step": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "خطوة إعداد سريعة" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Ein kurzer Einrichtungsschritt" } },
+        "en": { "stringUnit": { "state": "translated", "value": "One quick setup step" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Un paso rápido de configuración" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Une étape de configuration rapide" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "एक त्वरित सेटअप चरण" } },
+        "hr": { "stringUnit": { "state": "translated", "value": "Jedan brzi korak postavljanja" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "簡単なセットアップが必要です" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "간단한 설정 한 단계" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Jeden szybki krok konfiguracji" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Uma etapa rápida de configuração" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Один быстрый шаг настройки" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Hızlı bir kurulum adımı" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Один швидкий крок налаштування" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "一个简单的设置步骤" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "一個簡單的設定步驟" } }
+      }
+    },
+    "macOS Tahoe requires you to explicitly allow apps to put icons in the menu bar. Open System Settings → Control Center, scroll to the third-party apps section, and turn on Meridian.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "تتطلب macOS Tahoe السماح صراحةً للتطبيقات بوضع أيقونات في شريط القوائم. افتح إعدادات النظام ← مركز التحكم، ومرّر إلى قسم تطبيقات الجهات الخارجية، ثم قم بتشغيل Meridian." } },
+        "de": { "stringUnit": { "state": "translated", "value": "macOS Tahoe verlangt, dass du Apps ausdrücklich erlaubst, Symbole in der Menüleiste anzuzeigen. Öffne Systemeinstellungen → Kontrollzentrum, scrolle zum Bereich für Drittanbieter-Apps und aktiviere Meridian." } },
+        "en": { "stringUnit": { "state": "translated", "value": "macOS Tahoe requires you to explicitly allow apps to put icons in the menu bar. Open System Settings → Control Center, scroll to the third-party apps section, and turn on Meridian." } },
+        "es": { "stringUnit": { "state": "translated", "value": "macOS Tahoe requiere que permitas explícitamente a las apps colocar iconos en la barra de menús. Abre Ajustes del Sistema → Centro de control, desplázate hasta la sección de apps de terceros y activa Meridian." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "macOS Tahoe vous demande d'autoriser explicitement les apps à placer des icônes dans la barre de menus. Ouvrez Réglages Système → Centre de contrôle, faites défiler jusqu'à la section des apps tierces et activez Meridian." } },
+        "hi": { "stringUnit": { "state": "translated", "value": "macOS Tahoe को मेनू बार में आइकन जोड़ने के लिए ऐप्स को स्पष्ट रूप से अनुमति देनी होती है. सिस्टम सेटिंग्स → कंट्रोल सेंटर खोलें, थर्ड-पार्टी ऐप्स अनुभाग तक स्क्रॉल करें और Meridian को चालू करें." } },
+        "hr": { "stringUnit": { "state": "translated", "value": "macOS Tahoe zahtijeva da izričito dopustite aplikacijama postavljanje ikona u traku izbornika. Otvorite Postavke sustava → Kontrolni centar, dođite do odjeljka aplikacija trećih strana i uključite Meridian." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "macOS Tahoe では、メニューバーにアイコンを表示するアプリを明示的に許可する必要があります。「システム設定 → コントロールセンター」を開き、サードパーティ製アプリのセクションまでスクロールして Meridian をオンにしてください。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "macOS Tahoe에서는 메뉴 막대에 아이콘을 추가하는 앱을 명시적으로 허용해야 합니다. 시스템 설정 → 제어 센터를 열고 타사 앱 섹션까지 스크롤한 후 Meridian을 켜세요." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "System macOS Tahoe wymaga wyraźnego zezwolenia aplikacjom na umieszczanie ikon na pasku menu. Otwórz Ustawienia systemu → Centrum sterowania, przewiń do sekcji aplikacji innych firm i włącz Meridian." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O macOS Tahoe exige que você permita explicitamente que apps coloquem ícones na barra de menus. Abra Ajustes do Sistema → Central de Controle, role até a seção de apps de terceiros e ative o Meridian." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "macOS Tahoe требует явно разрешать приложениям отображать значки в строке меню. Откройте Системные настройки → Пункт управления, прокрутите до раздела сторонних приложений и включите Meridian." } },
+        "tr": { "stringUnit": { "state": "translated", "value": "macOS Tahoe, uygulamaların menü çubuğuna simge eklemesine açıkça izin vermenizi gerektirir. Sistem Ayarları → Denetim Merkezi'ni açın, üçüncü taraf uygulamalar bölümüne ilerleyin ve Meridian'ı açın." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "macOS Tahoe вимагає явно дозволити програмам додавати значки на смузі меню. Відкрийте Налаштування системи → Центр керування, прокрутіть до розділу сторонніх програм і ввімкніть Meridian." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "macOS Tahoe 要求你明确允许应用在菜单栏中显示图标。打开系统设置 → 控制中心,滚动到第三方应用部分,然后打开 Meridian。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "macOS Tahoe 要求你明確允許 App 在選單列中顯示圖示。打開系統設定 → 控制中心,捲動至第三方 App 區段,然後開啟 Meridian。" } }
+      }
+    },
+    "I've already done this": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "لقد فعلت ذلك بالفعل" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Habe ich bereits getan" } },
+        "en": { "stringUnit": { "state": "translated", "value": "I've already done this" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Ya lo he hecho" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Je l'ai déjà fait" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "मैंने यह पहले से किया है" } },
+        "hr": { "stringUnit": { "state": "translated", "value": "Već sam to učinio" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "設定済み" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "이미 했습니다" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Już to zrobiłem" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Já fiz isso" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Я уже это сделал" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Bunu zaten yaptım" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Я вже це зробив" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "我已经完成了" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "我已經完成了" } }
+      }
+    },
+    "Meridian isn't visible in your menu bar": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "Meridian غير ظاهر في شريط القوائم" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Meridian wird nicht in der Menüleiste angezeigt" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Meridian isn't visible in your menu bar" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Meridian no está visible en la barra de menús" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Meridian n'apparaît pas dans la barre de menus" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "Meridian आपके मेनू बार में दिखाई नहीं दे रहा है" } },
+        "hr": { "stringUnit": { "state": "translated", "value": "Meridian nije vidljiv u traci izbornika" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Meridian がメニューバーに表示されていません" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Meridian이 메뉴 막대에 표시되지 않습니다" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Meridian nie jest widoczny na pasku menu" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O Meridian não está visível na sua barra de menus" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Meridian не отображается в строке меню" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Meridian menü çubuğunuzda görünmüyor" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Meridian не відображається на смузі меню" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "Meridian 在菜单栏中不可见" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "Meridian 在選單列中不可見" } }
+      }
+    },
+    "macOS appears to be blocking Meridian's menu bar icon. Open System Settings → Control Center, scroll to the third-party apps section, and turn on Meridian.": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "يبدو أن macOS يحظر أيقونة Meridian في شريط القوائم. افتح إعدادات النظام ← مركز التحكم، ومرّر إلى قسم تطبيقات الجهات الخارجية، ثم قم بتشغيل Meridian." } },
+        "de": { "stringUnit": { "state": "translated", "value": "macOS scheint das Menüleistensymbol von Meridian zu blockieren. Öffne Systemeinstellungen → Kontrollzentrum, scrolle zum Bereich für Drittanbieter-Apps und aktiviere Meridian." } },
+        "en": { "stringUnit": { "state": "translated", "value": "macOS appears to be blocking Meridian's menu bar icon. Open System Settings → Control Center, scroll to the third-party apps section, and turn on Meridian." } },
+        "es": { "stringUnit": { "state": "translated", "value": "Parece que macOS está bloqueando el icono de Meridian en la barra de menús. Abre Ajustes del Sistema → Centro de control, desplázate hasta la sección de apps de terceros y activa Meridian." } },
+        "fr": { "stringUnit": { "state": "translated", "value": "macOS semble bloquer l'icône de Meridian dans la barre de menus. Ouvrez Réglages Système → Centre de contrôle, faites défiler jusqu'à la section des apps tierces et activez Meridian." } },
+        "hi": { "stringUnit": { "state": "translated", "value": "ऐसा लगता है कि macOS Meridian के मेनू बार आइकन को ब्लॉक कर रहा है. सिस्टम सेटिंग्स → कंट्रोल सेंटर खोलें, थर्ड-पार्टी ऐप्स अनुभाग तक स्क्रॉल करें और Meridian को चालू करें." } },
+        "hr": { "stringUnit": { "state": "translated", "value": "Čini se da macOS blokira ikonu Meridian u traci izbornika. Otvorite Postavke sustava → Kontrolni centar, dođite do odjeljka aplikacija trećih strana i uključite Meridian." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "macOS が Meridian のメニューバーアイコンをブロックしているようです。「システム設定 → コントロールセンター」を開き、サードパーティ製アプリのセクションまでスクロールして Meridian をオンにしてください。" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "macOS가 Meridian의 메뉴 막대 아이콘을 차단하고 있는 것 같습니다. 시스템 설정 → 제어 센터를 열고 타사 앱 섹션까지 스크롤한 후 Meridian을 켜세요." } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Wygląda na to, że system macOS blokuje ikonę Meridian na pasku menu. Otwórz Ustawienia systemu → Centrum sterowania, przewiń do sekcji aplikacji innych firm i włącz Meridian." } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "O macOS parece estar bloqueando o ícone do Meridian na barra de menus. Abra Ajustes do Sistema → Central de Controle, role até a seção de apps de terceiros e ative o Meridian." } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Похоже, macOS блокирует значок Meridian в строке меню. Откройте Системные настройки → Пункт управления, прокрутите до раздела сторонних приложений и включите Meridian." } },
+        "tr": { "stringUnit": { "state": "translated", "value": "macOS, Meridian'ın menü çubuğu simgesini engelliyor gibi görünüyor. Sistem Ayarları → Denetim Merkezi'ni açın, üçüncü taraf uygulamalar bölümüne ilerleyin ve Meridian'ı açın." } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Схоже, macOS блокує значок Meridian на смузі меню. Відкрийте Налаштування системи → Центр керування, прокрутіть до розділу сторонніх програм і ввімкніть Meridian." } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "macOS 似乎正在阻止 Meridian 的菜单栏图标。打开系统设置 → 控制中心,滚动到第三方应用部分,然后打开 Meridian。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "macOS 似乎正在阻止 Meridian 的選單列圖示。打開系統設定 → 控制中心,捲動至第三方 App 區段,然後開啟 Meridian。" } }
+      }
+    },
+    "Open Control Center Settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "فتح إعدادات مركز التحكم" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Kontrollzentrum-Einstellungen öffnen" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Open Control Center Settings" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Abrir ajustes del Centro de Control" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Ouvrir les réglages du Centre de contrôle" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "कंट्रोल सेंटर सेटिंग्स खोलें" } },
+        "hr": { "stringUnit": { "state": "translated", "value": "Otvori postavke kontrolnog centra" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "コントロールセンターの設定を開く" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "제어 센터 설정 열기" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Otwórz ustawienia Centrum sterowania" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Abrir ajustes da Central de Controle" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Открыть настройки Пункта управления" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Denetim Merkezi Ayarlarını Aç" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Відкрити налаштування Центру керування" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "打开控制中心设置" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "開啟控制中心設定" } }
+      }
+    },
+    "Quit Meridian": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "إنهاء Meridian" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Meridian beenden" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Quit Meridian" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Salir de Meridian" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Quitter Meridian" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "Meridian से बाहर निकलें" } },
+        "hr": { "stringUnit": { "state": "translated", "value": "Zatvori Meridian" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Meridian を終了" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "Meridian 종료" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Zakończ działanie Meridian" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Encerrar Meridian" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Выйти из Meridian" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Meridian'dan Çık" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Вийти з Meridian" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "退出 Meridian" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "結束 Meridian" } }
+      }
+    },
+    "Can't see Meridian in your menu bar?": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "لا ترى Meridian في شريط القوائم؟" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Meridian nicht in der Menüleiste zu sehen?" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Can't see Meridian in your menu bar?" } },
+        "es": { "stringUnit": { "state": "translated", "value": "¿No ves Meridian en la barra de menús?" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Vous ne voyez pas Meridian dans la barre de menus ?" } },
+        "hi": { "stringUnit": { "state": "translated", "value": "क्या Meridian आपके मेनू बार में नहीं दिख रहा?" } },
+        "hr": { "stringUnit": { "state": "translated", "value": "Ne vidite Meridian u traci izbornika?" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "メニューバーに Meridian が見えませんか?" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "메뉴 막대에 Meridian이 보이지 않나요?" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Nie widzisz Meridian na pasku menu?" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Não está vendo o Meridian na barra de menus?" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Не видно Meridian в строке меню?" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "Meridian menü çubuğunuzda görünmüyor mu?" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Не бачите Meridian на смузі меню?" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "在菜单栏中看不到 Meridian?" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "在選單列中看不到 Meridian?" } }
+      }
     }
   }
 }

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -31,6 +31,65 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
         continueUsually()
         setupMemoryPressureMonitoring()
         reopenAppearanceIfRelaunchedForTeamAccent()
+        showTahoeOnboardingIfNeeded()
+        observeAppActivationForVisibilityRecheck()
+    }
+
+    // MARK: - Tahoe Menubar Onboarding (#125)
+
+    /// First time Meridian runs on a machine, surface a one-shot dialog
+    /// explaining that macOS Tahoe requires the user to explicitly enable
+    /// third-party menubar items in Control Center. The flag is persisted
+    /// so this never re-prompts. The reactive heuristic in
+    /// StatusItemHandler.verifyStatusItemVisible() handles the case where
+    /// the user dismissed onboarding without flipping the toggle.
+    private func showTahoeOnboardingIfNeeded() {
+        // Skip during XCTest runs so the modal alert never hangs the test
+        // host. Tests that need to exercise this path can drive it directly
+        // through the helper used here, not via the launch sequence.
+        guard NSClassFromString("XCTestCase") == nil else { return }
+        guard !UserDefaults.standard.bool(forKey: UserDefaultKeys.tahoeOnboardingShown) else { return }
+
+        // The dialog must come after the status item has actually been
+        // constructed (continueUsually() materialised the lazy var) so the
+        // user sees their icon — if it shows up — at the same moment.
+        DispatchQueue.main.async { [weak self] in
+            self?.presentTahoeOnboardingAlert()
+        }
+    }
+
+    private func presentTahoeOnboardingAlert() {
+        let body = "macOS Tahoe requires you to explicitly allow apps to put icons in the menu bar. "
+            + "Open System Settings → Control Center, scroll to the third-party apps section, and turn on Meridian."
+        let alert = NSAlert()
+        alert.messageText = "One quick setup step".localized()
+        alert.informativeText = body.localized()
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "Open Control Center Settings".localized())
+        alert.addButton(withTitle: "I've already done this".localized())
+
+        let response = alert.runModal()
+        UserDefaults.standard.set(true, forKey: UserDefaultKeys.tahoeOnboardingShown)
+
+        if response == .alertFirstButtonReturn {
+            ControlCenterSettings.open()
+        }
+    }
+
+    /// After the user visits Settings to flip the Control Center toggle,
+    /// they'll return focus to Meridian (usually via the menubar icon, the
+    /// dock if `appPresentation == .both`, or the global shortcut). Catch
+    /// that activation and re-run the visibility heuristic so a successful
+    /// fix is reflected without requiring a relaunch — and so a still-broken
+    /// state re-surfaces the recovery dialog on the next session.
+    private func observeAppActivationForVisibilityRecheck() {
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.statusBarHandler.scheduleVisibilityVerification()
+        }
     }
 
     /// If we were just relaunched by the user picking a new accent color

--- a/Meridian/Meridian.xcodeproj/project.pbxproj
+++ b/Meridian/Meridian.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		C2C2D3E40002000000VCTFC1 /* VerticallyCenteredTextFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2C2D3E40001000000VCTFC2 /* VerticallyCenteredTextFieldCell.swift */; };
 		B730E37E4596MOCKDATASTORE /* MockDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B730E37E4596MOCKDATASTO2 /* MockDataStore.swift */; };
 		FF11AA0100TESTFIXTURES01 /* TestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF11AA0100TESTFIXTURES02 /* TestFixtures.swift */; };
+		AC11AA0100MBDTESTS00001 /* MenubarBlockDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC11AA0100MBDTESTS00002 /* MenubarBlockDetectionTests.swift */; };
 		BB00000100LOCCTRL00TEST1 /* LocationControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00000100LOCCTRL00TEST2 /* LocationControllerTests.swift */; };
 		C20839CA21515C1E00C86589 /* MeridianUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20839C921515C1E00C86589 /* MeridianUnitTests.swift */; };
 		C22F3D802107778A0001D5E1 /* ShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C22F3D7F2107778A0001D5E1 /* ShortcutTests.swift */; };
@@ -247,6 +248,7 @@
 		C2C2D3E40001000000VCTFC2 /* VerticallyCenteredTextFieldCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticallyCenteredTextFieldCell.swift; sourceTree = "<group>"; };
 		B730E37E4596MOCKDATASTO2 /* MockDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDataStore.swift; sourceTree = "<group>"; };
 		FF11AA0100TESTFIXTURES02 /* TestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestFixtures.swift; sourceTree = "<group>"; };
+		AC11AA0100MBDTESTS00002 /* MenubarBlockDetectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenubarBlockDetectionTests.swift; sourceTree = "<group>"; };
 		BB00000100LOCCTRL00TEST2 /* LocationControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationControllerTests.swift; sourceTree = "<group>"; };
 		C20839C721515C1E00C86589 /* MeridianUnitTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MeridianUnitTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C20839C921515C1E00C86589 /* MeridianUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeridianUnitTests.swift; sourceTree = "<group>"; };
@@ -551,6 +553,7 @@
 				A1B2C3D400000004NWTEST02 /* NetworkManagerTests.swift */,
 				B730E37E4596MOCKDATASTO2 /* MockDataStore.swift */,
 				FF11AA0100TESTFIXTURES02 /* TestFixtures.swift */,
+				AC11AA0100MBDTESTS00002 /* MenubarBlockDetectionTests.swift */,
 				3DEE1440C33BTZSORTINGTST2 /* TimezoneSortingManagerTests.swift */,
 				919639F9D2F3GLOBALSHRTCU2 /* GlobalShortcutMonitorTests.swift */,
 				4726354D81E1NWMGRASYNCT2 /* NetworkManagerAsyncTests.swift */,
@@ -813,6 +816,7 @@
 				A1B2C3D400000003NWTEST01 /* NetworkManagerTests.swift in Sources */,
 				B730E37E4596MOCKDATASTORE /* MockDataStore.swift in Sources */,
 				FF11AA0100TESTFIXTURES01 /* TestFixtures.swift in Sources */,
+				AC11AA0100MBDTESTS00001 /* MenubarBlockDetectionTests.swift in Sources */,
 				3DEE1440C33BTZSORTINGTST /* TimezoneSortingManagerTests.swift in Sources */,
 				919639F9D2F3GLOBALSHRTCUT /* GlobalShortcutMonitorTests.swift in Sources */,
 				4726354D81E1NWMGRASYNCTS /* NetworkManagerAsyncTests.swift in Sources */,

--- a/Meridian/MeridianUnitTests/MenubarBlockDetectionTests.swift
+++ b/Meridian/MeridianUnitTests/MenubarBlockDetectionTests.swift
@@ -1,0 +1,116 @@
+// Copyright © 2026 Christopher Tirpak
+
+@testable import Meridian
+import XCTest
+
+/// Tests for Tahoe (#125) menubar-block detection. These exercise the pure
+/// threshold function `MenubarBlockDetection.isStatusItemBlocked(...)` and
+/// the once-only semantics of `UserDefaultKeys.tahoeOnboardingShown` — no
+/// real NSStatusItem is required.
+final class MenubarBlockDetectionTests: XCTestCase {
+
+    // MARK: - isStatusItemBlocked
+
+    func testNilWindowWidthIsTreatedAsBlocked() {
+        XCTAssertTrue(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: nil,
+                                                                 isCompactMode: false))
+        XCTAssertTrue(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: nil,
+                                                                 isCompactMode: true))
+    }
+
+    func testZeroWidthIsBlockedInBothModes() {
+        XCTAssertTrue(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: 0,
+                                                                 isCompactMode: false))
+        XCTAssertTrue(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: 0,
+                                                                 isCompactMode: true))
+    }
+
+    func testIconModeJustBelowThresholdIsBlocked() {
+        let width = MenubarBlockDetection.iconModeMinimumWidth - 1
+        XCTAssertTrue(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: width,
+                                                                 isCompactMode: false))
+    }
+
+    func testIconModeAtThresholdIsNotBlocked() {
+        XCTAssertFalse(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: MenubarBlockDetection.iconModeMinimumWidth,
+                                                                  isCompactMode: false))
+    }
+
+    func testIconModeHealthyWidthIsNotBlocked() {
+        XCTAssertFalse(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: 60,
+                                                                  isCompactMode: false))
+    }
+
+    func testCompactModeJustBelowThresholdIsBlocked() {
+        let width = MenubarBlockDetection.compactModeMinimumWidth - 1
+        XCTAssertTrue(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: width,
+                                                                 isCompactMode: true))
+    }
+
+    func testCompactModeAtThresholdIsNotBlocked() {
+        XCTAssertFalse(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: MenubarBlockDetection.compactModeMinimumWidth,
+                                                                  isCompactMode: true))
+    }
+
+    func testCompactModeHealthyWidthIsNotBlocked() {
+        XCTAssertFalse(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: 120,
+                                                                  isCompactMode: true))
+    }
+
+    /// Compact mode threshold must be stricter than icon mode — a width that
+    /// passes icon mode might still be a blocked compact item (Control Center
+    /// allocates a tiny placeholder slot that's wider than a clock icon but
+    /// narrower than a 2-timezone text strip).
+    func testCompactThresholdIsStricterThanIconThreshold() {
+        XCTAssertGreaterThan(MenubarBlockDetection.compactModeMinimumWidth,
+                             MenubarBlockDetection.iconModeMinimumWidth)
+    }
+
+    func testWidthBetweenIconAndCompactThresholds() {
+        let between = (MenubarBlockDetection.iconModeMinimumWidth + MenubarBlockDetection.compactModeMinimumWidth) / 2
+        XCTAssertFalse(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: between,
+                                                                  isCompactMode: false),
+                       "Width above icon threshold should pass icon-mode check")
+        XCTAssertTrue(MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: between,
+                                                                 isCompactMode: true),
+                      "Same width should fail compact-mode check — compact needs more pixels")
+    }
+
+    // MARK: - Onboarding flag persistence (issue #125)
+
+    /// The first-launch onboarding alert is gated by
+    /// UserDefaultKeys.tahoeOnboardingShown. AppDefaults registers this with
+    /// a default of `false` so first launch always presents the dialog;
+    /// AppDelegate flips it to `true` once shown. This test exercises the
+    /// AppDefaults registration and the simple read/write semantics, which
+    /// together back the "show once and only once" guarantee.
+    func testTahoeOnboardingShownDefaultsToFalse() {
+        let defaults = UserDefaults(suiteName: "TahoeOnboardingDefaults-\(UUID().uuidString)")!
+        defaults.removePersistentDomain(forName: defaults.dictionaryRepresentation().keys.first ?? "")
+
+        AppDefaults.initialize(with: DataStore.shared(), defaults: defaults)
+
+        XCTAssertFalse(defaults.bool(forKey: UserDefaultKeys.tahoeOnboardingShown),
+                       "Fresh defaults must report false so first launch triggers onboarding")
+    }
+
+    func testTahoeOnboardingShownRoundTrips() {
+        let defaults = UserDefaults(suiteName: "TahoeOnboardingRoundTrip-\(UUID().uuidString)")!
+        defaults.set(true, forKey: UserDefaultKeys.tahoeOnboardingShown)
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.tahoeOnboardingShown))
+        defaults.removeObject(forKey: UserDefaultKeys.tahoeOnboardingShown)
+    }
+
+    // MARK: - Control Center deep link
+
+    func testControlCenterSettingsURLIsCorrect() {
+        XCTAssertEqual(ControlCenterSettings.urlString,
+                       "x-apple.systempreferences:com.apple.ControlCenter-Settings.extension",
+                       "Deep link must match the System Settings → Control Center extension URL — anything else opens the wrong pane")
+    }
+
+    func testControlCenterSettingsURLParsesAsValidURL() {
+        XCTAssertEqual(ControlCenterSettings.url.absoluteString,
+                       ControlCenterSettings.urlString)
+    }
+}

--- a/Meridian/Overall App/AppDefaults.swift
+++ b/Meridian/Overall App/AppDefaults.swift
@@ -109,7 +109,11 @@ class AppDefaults {
 
             // F1 team accent. Default preserves the Aston Martin look that
             // was hardcoded in the asset catalog before this feature shipped.
-            UserDefaultKeys.teamAccent: TeamAccent.default.rawValue
+            UserDefaultKeys.teamAccent: TeamAccent.default.rawValue,
+
+            // Tahoe (macOS 26+) menubar block onboarding flag. False until
+            // the first-launch dialog has been shown. See issue #125.
+            UserDefaultKeys.tahoeOnboardingShown: false
         ]
     }
 }

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -68,6 +68,12 @@ public enum UserDefaultKeys {
     // checks this on the next applicationDidFinishLaunching, opens
     // Settings to the Appearance tab, and clears the flag.
     static let reopenAppearanceOnLaunch = "com.tpak.meridian.reopenAppearanceOnLaunch"
+
+    // Tahoe (macOS 26+) silently classifies a third-party NSStatusItem as
+    // `.ephemeral` until the user enables the app in Control Center → Menu
+    // Bar Only. Set to true after the first-launch onboarding NSAlert has
+    // been shown so we don't re-prompt on every launch. See issue #125.
+    static let tahoeOnboardingShown = "com.tpak.meridian.tahoeOnboardingShown"
 }
 
 // Centralized timing literals. Putting them here makes the rationale for each

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -50,6 +50,19 @@ struct AboutView: View {
                         metadata: ["Country": Locale.autoupdatingCurrent.region?.identifier ?? ""])
             }
 
+            // Tahoe (#125) recovery link — permanent escape hatch for users
+            // who dismissed the first-launch onboarding alert and later find
+            // themselves wondering where the menu bar icon went.
+            linkButton(
+                title: "Can't see Meridian in your menu bar?".localized(),
+                underlineRange: 0..<min(36, "Can't see Meridian in your menu bar?".localized().count),
+                font: .custom("Avenir-Light", size: 13),
+                accessibilityID: "MenubarTroubleshooting"
+            ) {
+                ControlCenterSettings.open()
+                Logger.debug("Opened Control Center Settings from About tab")
+            }
+
             Toggle(String(localized: "Start at Login"), isOn: $startAtLogin)
                 .font(.custom("Avenir-Book", size: 13))
                 .toggleStyle(.checkbox)

--- a/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
@@ -5,7 +5,7 @@ import Combine
 import CoreLoggerKit
 import CoreModelKit
 
-private enum MenubarState {
+internal enum MenubarState {
     case compactText
     case icon
 }
@@ -21,6 +21,38 @@ private enum MenubarTimerConstants {
     static let debounceMilliseconds: Int = 250
     static let toleranceWithSeconds: TimeInterval = 0.5
     static let toleranceWithoutSeconds: TimeInterval = 20
+}
+
+// Pure threshold logic for "is Tahoe Control Center silently blocking us?"
+// Extracted as a non-private enum so MeridianUnitTests can exercise it
+// without spinning up a real NSStatusItem. See issue #125.
+internal enum MenubarBlockDetection {
+    // Minimum button-window width below which we conclude the status item
+    // has been classified as `.ephemeral`. Icon-only mode is narrower (~22pt
+    // on average) than compact text mode (≥ ~60pt); the thresholds sit just
+    // under each mode's expected rendered width. A blocked item's window is
+    // either nil or reports a width of zero, so any non-trivial floor catches
+    // it.
+    static let iconModeMinimumWidth: CGFloat = 20
+    static let compactModeMinimumWidth: CGFloat = 40
+
+    static func isStatusItemBlocked(buttonWindowWidth: CGFloat?, isCompactMode: Bool) -> Bool {
+        guard let width = buttonWindowWidth else { return true }
+        let threshold = isCompactMode ? compactModeMinimumWidth : iconModeMinimumWidth
+        return width < threshold
+    }
+}
+
+// URL that deep-links to System Settings → Control Center → Menu Bar Only.
+// Used by both the StatusItemHandler recovery alert and the About-tab help
+// link.
+internal enum ControlCenterSettings {
+    static let urlString = "x-apple.systempreferences:com.apple.ControlCenter-Settings.extension"
+    static let url = URL(string: urlString)!
+
+    static func open() {
+        NSWorkspace.shared.open(url)
+    }
 }
 
 class StatusItemHandler: NSObject {
@@ -46,6 +78,18 @@ class StatusItemHandler: NSObject {
     private var cancellables = Set<AnyCancellable>()
 
     private let store: DataStore
+
+    // Tahoe (#125): the recovery alert is shown at most once per process so
+    // we don't pop a dialog on every UserDefaults-change-triggered
+    // setupStatusItem() invocation. The onboarding flag in UserDefaults is a
+    // separate, persistent across-launches signal — this is in-memory only.
+    private var hasShownBlockedAlertThisSession: Bool = false
+
+    // Brief delay after setupStatusItem() before checking visibility. Control
+    // Center takes a beat to position (or reject) a freshly-registered
+    // status item; querying too early reports a zero-width window even on
+    // healthy installs.
+    private let visibilityVerificationDelay: TimeInterval = 1.5
 
     // Current State might be set twice when the user first launches an app.
     // First, when StatusItemHandler() is instantiated in AppDelegate
@@ -122,6 +166,66 @@ class StatusItemHandler: NSObject {
         statusItem.button?.target = self
         statusItem.autosaveName = NSStatusItem.AutosaveName("MeridianStatusItem")
         setSelector()
+
+        scheduleVisibilityVerification()
+    }
+
+    // MARK: - Tahoe Visibility Verification (#125)
+
+    /// Schedules an asynchronous check to detect whether macOS Tahoe's
+    /// Control Center has silently classified this status item as
+    /// `.ephemeral`. Called from setupStatusItem() (initial launch, wake,
+    /// and UserDefaults-driven refresh paths) and from AppDelegate's
+    /// didBecomeActive listener after the user returns from Settings.
+    func scheduleVisibilityVerification() {
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.verifyStatusItemVisible()
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + visibilityVerificationDelay,
+                                       execute: workItem)
+    }
+
+    private func verifyStatusItemVisible() {
+        // Tests instantiate AppDelegate which builds a StatusItemHandler;
+        // popping a modal NSAlert would hang the test runner. Skip the
+        // dialog branch entirely when running under XCTest.
+        guard NSClassFromString("XCTestCase") == nil else { return }
+
+        // Once-per-session — the underlying defaults-change observer can
+        // re-enter setupStatusItem() many times during normal use.
+        guard !hasShownBlockedAlertThisSession else { return }
+
+        let width = statusItem.button?.window?.frame.size.width
+        let isCompactMode = currentState == .compactText
+        guard MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth: width,
+                                                       isCompactMode: isCompactMode) else {
+            return
+        }
+
+        Logger.production("Status item appears blocked by Control Center (width=\(width ?? -1), compact=\(isCompactMode)) — surfacing recovery dialog")
+        hasShownBlockedAlertThisSession = true
+        showBlockedRecoveryDialog()
+    }
+
+    private func showBlockedRecoveryDialog() {
+        let body = "macOS appears to be blocking Meridian's menu bar icon. "
+            + "Open System Settings → Control Center, scroll to the third-party apps section, and turn on Meridian."
+        let alert = NSAlert()
+        alert.messageText = "Meridian isn't visible in your menu bar".localized()
+        alert.informativeText = body.localized()
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Open Control Center Settings".localized())
+        alert.addButton(withTitle: "Quit Meridian".localized())
+
+        let response = alert.runModal()
+        switch response {
+        case .alertFirstButtonReturn:
+            ControlCenterSettings.open()
+        case .alertSecondButtonReturn:
+            NSApp.terminate(nil)
+        default:
+            break
+        }
     }
 
     private func setupNotificationObservers() {

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
-# Validates the accent color trademark disclaimer popover (feature/accent-color-disclaimer).
+# Validates the Tahoe menubar-block detection & recovery feature (issue #125).
 # Run from repo root. Exits non-zero if any check fails.
 #
-# Three groups of checks:
-#   1. Storyboard wiring (info button, action selector, outlet)
-#   2. Swift wiring (outlet, action, popover view controller, SF Symbol)
-#   3. Localization + compilation
+# Layers checked:
+#   1. StatusItemHandler wiring (detection hook + pure helper + deep link)
+#   2. Strings / AppDefaults (tahoeOnboardingShown key + default)
+#   3. AppDelegate (onboarding alert + didBecomeActive re-check)
+#   4. About tab (permanent help link)
+#   5. Localization: all 8 new keys translated into 15 supported languages
+#   6. Build (Debug, no code signing)
 set -u
 cd "$(dirname "$0")/.."
 
@@ -15,84 +18,120 @@ ok()      { echo "  OK:   $1"; PASS=$((PASS+1)); }
 bad()     { echo "  FAIL: $1" >&2; FAIL=$((FAIL+1)); }
 section() { echo ""; echo "── $1"; }
 
-# ── 1. Storyboard ─────────────────────────────────────────────────────
+# ── 1. StatusItemHandler ──────────────────────────────────────────────
 
-section "Storyboard: info button + outlet + action"
-SB="Meridian/Preferences/Preferences.storyboard"
+section "StatusItemHandler: detection hook + helper + deep link"
+SIH="Meridian/Preferences/Menu Bar/StatusItemHandler.swift"
 
-grep -q 'id="Acc-Bt-Inf"' "$SB" \
-    && ok "info button (Acc-Bt-Inf) present" \
-    || bad "info button (Acc-Bt-Inf) missing from storyboard"
+grep -q "func scheduleVisibilityVerification" "$SIH" \
+    && ok "scheduleVisibilityVerification declared" \
+    || bad "scheduleVisibilityVerification missing"
 
-grep -q 'selector="showAccentColorInfo:"' "$SB" \
-    && ok "showAccentColorInfo: action wired" \
-    || bad "showAccentColorInfo: action not wired"
+grep -q "verifyStatusItemVisible" "$SIH" \
+    && ok "verifyStatusItemVisible declared" \
+    || bad "verifyStatusItemVisible missing"
 
-grep -q 'property="accentColorInfoButton"' "$SB" \
-    && ok "accentColorInfoButton outlet wired" \
-    || bad "accentColorInfoButton outlet missing"
+grep -q "showBlockedRecoveryDialog" "$SIH" \
+    && ok "showBlockedRecoveryDialog declared" \
+    || bad "showBlockedRecoveryDialog missing"
 
-# Popup must still be present and wired (regression guard for the
-# stackView restructure of the gridCell).
-grep -q 'property="teamAccentPopup"' "$SB" \
-    && ok "teamAccentPopup outlet preserved" \
-    || bad "teamAccentPopup outlet was removed"
+grep -q "enum MenubarBlockDetection" "$SIH" \
+    && ok "MenubarBlockDetection enum declared" \
+    || bad "MenubarBlockDetection enum missing"
 
-grep -q 'selector="teamAccentChanged:"' "$SB" \
-    && ok "teamAccentChanged: action preserved" \
-    || bad "teamAccentChanged: action was removed"
+grep -q "func isStatusItemBlocked" "$SIH" \
+    && ok "isStatusItemBlocked pure helper declared" \
+    || bad "isStatusItemBlocked pure helper missing"
 
-# ── 2. Swift ──────────────────────────────────────────────────────────
+grep -q "x-apple.systempreferences:com.apple.ControlCenter-Settings.extension" "$SIH" \
+    && ok "Control Center deep-link URL present" \
+    || bad "Control Center deep-link URL missing"
 
-section "Swift: outlet, action, view controller, SF Symbol"
-APPEAR="Meridian/Preferences/Appearance/AppearanceViewController.swift"
+# ── 2. Strings / AppDefaults ──────────────────────────────────────────
 
-grep -q '@IBOutlet var accentColorInfoButton: NSButton!' "$APPEAR" \
-    && ok "@IBOutlet accentColorInfoButton declared" \
-    || bad "@IBOutlet accentColorInfoButton missing"
+section "Defaults: tahoeOnboardingShown key declared + registered"
 
-grep -q '@IBAction func showAccentColorInfo' "$APPEAR" \
-    && ok "@IBAction showAccentColorInfo declared" \
-    || bad "@IBAction showAccentColorInfo missing"
+grep -q "tahoeOnboardingShown" "Meridian/Overall App/Strings.swift" \
+    && ok "tahoeOnboardingShown declared in Strings.swift" \
+    || bad "tahoeOnboardingShown not declared"
 
-grep -q 'class AccentColorInfoViewController' "$APPEAR" \
-    && ok "AccentColorInfoViewController declared" \
-    || bad "AccentColorInfoViewController missing"
+grep -q "tahoeOnboardingShown" "Meridian/Overall App/AppDefaults.swift" \
+    && ok "tahoeOnboardingShown registered in AppDefaults.swift" \
+    || bad "tahoeOnboardingShown not registered with default value"
 
-grep -q 'systemSymbolName: "info.circle"' "$APPEAR" \
-    && ok "info.circle SF Symbol assigned to button" \
-    || bad "info.circle SF Symbol not assigned"
+# ── 3. AppDelegate ────────────────────────────────────────────────────
 
-grep -q 'NSPopover' "$APPEAR" \
-    && ok "NSPopover used for the disclaimer" \
-    || bad "NSPopover not used"
+section "AppDelegate: onboarding hook + activation re-check"
 
-# ── 3. Localization ──────────────────────────────────────────────────
+grep -q "showTahoeOnboardingIfNeeded" "Meridian/AppDelegate.swift" \
+    && ok "showTahoeOnboardingIfNeeded called in applicationDidFinishLaunching" \
+    || bad "showTahoeOnboardingIfNeeded missing"
 
-section "Localization: disclaimer strings present in xcstrings"
-XCS="Meridian/App/Localizable.xcstrings"
+grep -q "presentTahoeOnboardingAlert" "Meridian/AppDelegate.swift" \
+    && ok "presentTahoeOnboardingAlert declared" \
+    || bad "presentTahoeOnboardingAlert missing"
 
-grep -q '"About these colors"' "$XCS" \
-    && ok "title string present" \
-    || bad "title string missing"
+grep -q "didBecomeActiveNotification" "Meridian/AppDelegate.swift" \
+    && ok "didBecomeActiveNotification observer wired for re-check" \
+    || bad "didBecomeActiveNotification observer missing"
 
-grep -q '"About accent colors"' "$XCS" \
-    && ok "accessibility label string present" \
-    || bad "accessibility label string missing"
+# ── 4. About tab ──────────────────────────────────────────────────────
 
-grep -q "Meridian is an independent project, built by an F1 fan" "$XCS" \
-    && ok "body disclaimer present" \
-    || bad "body disclaimer missing"
+section "About tab: permanent menubar troubleshooting link"
 
-grep -q "Team names are trademarks of their respective owners" "$XCS" \
-    && ok "trademark attribution present" \
-    || bad "trademark attribution missing"
+grep -q "Can't see Meridian in your menu bar" "Meridian/Preferences/About/AboutView.swift" \
+    && ok "help link present in AboutView" \
+    || bad "help link missing from AboutView"
 
-grep -q "Colors are fan approximations" "$XCS" \
-    && ok "fan-approximation acknowledgement present" \
-    || bad "fan-approximation acknowledgement missing"
+grep -q "ControlCenterSettings.open" "Meridian/Preferences/About/AboutView.swift" \
+    && ok "help link invokes ControlCenterSettings.open" \
+    || bad "help link does not open Control Center settings"
 
-# ── 4. Build ─────────────────────────────────────────────────────────
+# ── 5. Localization ───────────────────────────────────────────────────
+
+section "Localization: 8 new keys × 16 locales"
+if python3 - <<'PY'
+import json, sys
+required_langs = ["ar","de","en","es","fr","hi","hr","ja","ko","pl","pt-BR","ru","tr","uk","zh-Hans","zh-Hant"]
+new_keys = [
+    "One quick setup step",
+    "macOS Tahoe requires you to explicitly allow apps to put icons in the menu bar. Open System Settings → Control Center, scroll to the third-party apps section, and turn on Meridian.",
+    "I've already done this",
+    "Meridian isn't visible in your menu bar",
+    "macOS appears to be blocking Meridian's menu bar icon. Open System Settings → Control Center, scroll to the third-party apps section, and turn on Meridian.",
+    "Open Control Center Settings",
+    "Quit Meridian",
+    "Can't see Meridian in your menu bar?",
+]
+with open("Meridian/App/Localizable.xcstrings") as f:
+    data = json.load(f)
+strings = data.get("strings", {})
+missing = []
+for key in new_keys:
+    entry = strings.get(key)
+    if entry is None:
+        missing.append((key, "KEY MISSING"))
+        continue
+    locs = entry.get("localizations", {})
+    for lang in required_langs:
+        unit = locs.get(lang, {}).get("stringUnit", {})
+        value = unit.get("value", "")
+        if not value:
+            missing.append((key, f"missing {lang}"))
+if missing:
+    print(f"  FAIL: {len(missing)} localization gap(s):", file=sys.stderr)
+    for k, why in missing[:10]:
+        print(f"    - {k[:60]}… -> {why}", file=sys.stderr)
+    sys.exit(1)
+print(f"  OK:   all 8 new keys translated to {len(required_langs)} locales each")
+PY
+then
+    PASS=$((PASS+1))
+else
+    FAIL=$((FAIL+1))
+fi
+
+# ── 6. Build ──────────────────────────────────────────────────────────
 
 section "Build: xcodebuild Debug (no code signing)"
 if xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \


### PR DESCRIPTION
## Summary

Fixes #125 — macOS Tahoe silently classifies third-party `NSStatusItem`s as `.ephemeral` until the user enables the app in Control Center → Menu Bar Only. From the user's side, Meridian "doesn't work" on a fresh Tahoe install. This adds a two-layer recovery path.

## Changes

- **Layer 1 — First-launch onboarding** (`AppDelegate.swift`): One-shot `NSAlert` explaining the requirement, with [Open Control Center Settings] / [I've already done this]. Gated by a persistent `tahoeOnboardingShown` UserDefault so it never re-prompts.
- **Layer 2 — Heuristic detection** (`StatusItemHandler.swift`): After `setupStatusItem()` (initial launch, wake-from-sleep) and after `NSApplication.didBecomeActiveNotification`, check `statusItem.button?.window?.frame.size.width` against thresholds (icon mode ≥ 20pt, compact mode ≥ 40pt). On a likely-blocked state surface a recovery `NSAlert` with [Open Control Center Settings] / [Quit Meridian]. Fires at most once per process to avoid pop-up spam from the debounced UserDefaults observer.
- **Permanent help link** (`AboutView.swift`): "Can't see Meridian in your menu bar?" link in the About tab that opens the same Control Center deep-link, for users who dismissed onboarding and later wonder where the icon went.
- **Threshold logic extracted to a pure helper** (`MenubarBlockDetection.isStatusItemBlocked(buttonWindowWidth:isCompactMode:)`) so it's unit-testable without spinning up a real `NSStatusItem`. 14 new tests cover threshold edges, onboarding flag default, and the Control Center URL.
- **Localization** — 8 new strings translated across all 15 supported languages (ar, de, es, fr, hi, hr, ja, ko, pl, pt-BR, ru, tr, uk, zh-Hans, zh-Hant).
- **`scripts/validate_feature.sh`** rewrite — 15 checks across wiring, defaults registration, localization parity, and a Debug build.

## Programmatic toggle investigation

The issue asked whether anything (defaults writes, ScriptingBridge, a new entitlement) could enable a third-party menubar item programmatically. Findings:

- Control Center stores third-party item visibility as `NSStatusItem Visible Item-N` under `com.apple.controlcenter`'s defaults, but:
  - The `Item-N` slot index is opaque to the app — no documented bundle-ID-to-slot mapping.
  - A sandboxed app can't write to `com.apple.controlcenter`'s persistent domain.
- No documented ScriptingBridge surface or Tahoe entitlement exposes the toggle.

Shipping the dialog-only path. If Apple opens this up in a future Tahoe point release, the alert can grow an "Enable for me" button without breaking existing flows.

## Test plan

- [x] `scripts/validate_feature.sh` — 15/15 checks pass (StatusItemHandler wiring, defaults, AppDelegate, About link, localization, Debug build)
- [x] All unit tests pass: `xcodebuild test -only-testing:MeridianUnitTests` — **219/219** green (14 new + 205 existing)
- [x] SwiftLint clean on new/changed files
- [ ] Manual on Tahoe: `defaults delete com.tpak.Meridian com.tpak.meridian.tahoeOnboardingShown`, ensure Meridian is OFF in Control Center, launch → onboarding alert; without enabling, return → recovery alert; enable in Control Center → no further alerts; relaunch → silent

🤖 Generated with [Claude Code](https://claude.com/claude-code)