### PR TITLE
Restore About-tab buttons broken by ScrollView wrap

### DIFF
--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -18,18 +18,6 @@ struct AboutView: View {
     fileprivate static let updateIntervalLabels = ["Daily", "Weekly", "Monthly"]
 
     var body: some View {
-        // ScrollView keeps the bottom rows (Export Log, especially) visible
-        // when Debug Logging is toggled on. The About tab lives in a
-        // fixed-size NSTabViewController window, so without scroll the
-        // newly-revealed button gets clipped past the bottom edge.
-        ScrollView {
-            aboutContent
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    @ViewBuilder
-    private var aboutContent: some View {
         VStack(spacing: 15) {
             Text(versionString)
                 .font(.custom("Avenir-Light", size: 28))
@@ -99,7 +87,7 @@ struct AboutView: View {
             DebugLoggingSection()
         }
         .padding(20)
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     @ViewBuilder

--- a/Meridian/Preferences/Preferences.storyboard
+++ b/Meridian/Preferences/Preferences.storyboard
@@ -59,7 +59,7 @@
             <objects>
                 <viewController id="oFk-9v-L8T" customClass="AboutViewController" customModule="Meridian" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="HdR-qn-zua">
-                        <rect key="frame" x="0.0" y="0.0" width="548" height="560"/>
+                        <rect key="frame" x="0.0" y="0.0" width="548" height="720"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </view>
                 </viewController>


### PR DESCRIPTION
## Summary

- Fix Export Settings, Import Settings, and Export Log buttons not responding (regression introduced in v3.0.4)

The ScrollView wrap added in v3.0.4 hit the well-known SwiftUI macOS quirk where Buttons inside a ScrollView don't fire their action — the click is consumed as a scroll-gesture start. Reverted the ScrollView and bumped the About tab's storyboard height to 720pt so the Export Log button stays visible without needing a scroll.

## Test plan
- [x] Local UAT in 3.1.0-beta1: Export Settings opens save panel
- [x] Local UAT in 3.1.0-beta1: Import Settings opens open panel
- [x] Local UAT in 3.1.0-beta1: Export Log writes file and reveals in Finder
- [x] All other About-tab content still visible (Start at Login, Auto Update, Beta Channel, Update interval, Settings Backup, Debug Logging)
- [x] General/Appearance tabs unaffected (they keep their existing storyboard heights; only About is taller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)