### PR TITLE
Fix Export/Import/Export Log buttons broken by sandbox enforcement

### DIFF
--- a/Meridian/App/Meridian.entitlements
+++ b/Meridian/App/Meridian.entitlements
@@ -6,7 +6,14 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
-<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
+	<!-- Required for NSSavePanel/NSOpenPanel.runModal() to display under sandbox.
+	     Without this, macOS Tahoe silently refuses to show the panel (logs
+	     "Unable to display save panel: missing User Selected File Read/Write
+	     app sandbox entitlement" in Console). Powers Settings → About →
+	     Export Settings / Import Settings. -->
+	<key>com.apple.security.files.user-selected.read-write</key>
+	<true/>
+	<key>com.apple.security.temporary-exception.mach-lookup.global-name</key>
 	<array>
 		<string>com.tpak.Meridian-spks</string>
 		<string>com.tpak.Meridian-spki</string>

--- a/Meridian/CoreLoggerKit/Sources/CoreLoggerKit/Logger.swift
+++ b/Meridian/CoreLoggerKit/Sources/CoreLoggerKit/Logger.swift
@@ -24,8 +24,11 @@ public enum Logger {
     }
 
     /// Export recent log entries to a file for sharing. Uses OSLogStore.
+    /// .currentProcessIdentifier (not .system) so the sandboxed app can read
+    /// its own entries without the com.apple.logd.admin mach-lookup that the
+    /// .system scope requires — we never wanted other processes' logs anyway.
     public static func exportLog(to url: URL) throws {
-        let store = try OSLogStore(scope: .system)
+        let store = try OSLogStore(scope: .currentProcessIdentifier)
         let cutoff = store.position(date: Date().addingTimeInterval(-7 * 24 * 3600))
         let entries = try store.getEntries(at: cutoff, matching: NSPredicate(format: "subsystem == 'com.tpak.Meridian'"))
         let lines = entries.compactMap { entry -> String? in


### PR DESCRIPTION
## Summary

The About-tab Export Settings, Import Settings, and Export Log buttons never worked in any signed/sandboxed release build — including v3.1.0. The two prior attempts (v3.0.4 ScrollView wrap, v3.1.0 ScrollView removal + storyboard resize) chased UI causes that were never the real bug.

**Real root cause**, confirmed in Console while clicking the buttons in `/Applications/Meridian.app` v3.1.0:

```
Unable to display save panel: your app is missing the User Selected File Read/Write app sandbox entitlement.
Unable to display open panel: your app is missing the User Selected File Read app sandbox entitlement.
Sandbox: Meridian deny(1) mach-lookup com.apple.logd.admin
```

Two separate sandbox issues:

1. **`NSSavePanel` / `NSOpenPanel.runModal()`** requires `com.apple.security.files.user-selected.read-write`. Without it, AppKit's powerbox refuses the panel entirely. Added the entitlement.
2. **`Logger.exportLog`** uses `OSLogStore(scope: .system)`, which needs the `com.apple.logd.admin` mach-lookup — denied for sandboxed apps. Switched to `.currentProcessIdentifier`, which reads the calling process's own log entries (which is all we ever needed).

Check Now kept working because Sparkle manages its own windowing and never touches powerbox.

## Why this stayed undetected for so long

Debug builds with `CODE_SIGNING_REQUIRED=NO` produce unsigned binaries, on which macOS doesn't enforce the sandbox at all. The dev-loop beta workflow uses exactly that command, so every locally verified build skipped the failure mode users hit in shipped releases. Verifying this fix required a Release-config build, ad-hoc-signed with the entitlements applied, to actually exercise sandbox enforcement.

## Verification

- Built v3.1.1-beta2 (Release config) and ad-hoc signed with the new entitlements
- Sandbox active and enforced (confirmed via `codesign -d --entitlements -`)
- Logs show full successful round-trips through all four buttons; no `Unable to display save panel`, no sandbox denies for file operations
- Export writes to `~/.meridian/meridian_settings.json`, Import reads it back and applies, Export Log writes to the sandboxed temp dir (`~/Library/Containers/com.tpak.Meridian/Data/tmp/`) and `selectFile` reveals it in Finder
- 224/0 unit tests pass

## Test plan

- [ ] CI passes (Build & Lint, Unit Tests)
- [ ] After merge: `make release VERSION=3.1.1`, install via Sparkle update, verify Export Settings shows save panel
- [ ] Verify Import Settings shows open panel
- [ ] Verify Export Log writes a file and reveals it in Finder (with Debug Logging enabled)
- [ ] Verify Check Now still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)