### PR TITLE
Clean up README badges and LICENSE attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
 Copyright (c) 2015-2022 Abhishek Banthia
-Copyright (c) 2026 Chris Tpak
+Copyright (c) 2026 Chris Tirpak
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
   <a href="https://github.com/tpak/Meridian/actions/workflows/ci.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/tpak/Meridian/actions/workflows/codeql.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL"></a>
   <a href="https://github.com/tpak/Meridian/blob/main/.swiftlint.yml"><img src="https://img.shields.io/badge/SwiftLint-configured-brightgreen" alt="SwiftLint"></a>
-  <a href="https://github.com/tpak/Meridian/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
   <a href="https://github.com/tpak/Meridian/releases/latest"><img src="https://img.shields.io/github/v/release/tpak/Meridian?display_name=tag&sort=semver" alt="Latest release"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,11 @@
 <h1 align="center">Meridian</h1>
 
 <p align="center">
-  <a href="https://github.com/tpak/Meridian/actions/workflows/ci.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://github.com/tpak/Meridian/actions/workflows/codeql.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/codeql.yml/badge.svg" alt="CodeQL"></a>
+  <a href="https://github.com/tpak/Meridian/actions/workflows/ci.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://github.com/tpak/Meridian/actions/workflows/codeql.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL"></a>
   <a href="https://github.com/tpak/Meridian/blob/main/.swiftlint.yml"><img src="https://img.shields.io/badge/SwiftLint-configured-brightgreen" alt="SwiftLint"></a>
-  <a href="https://github.com/tpak/Meridian/blob/main/LICENSE"><img src="https://img.shields.io/github/license/tpak/Meridian" alt="License"></a>
+  <a href="https://github.com/tpak/Meridian/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+  <a href="https://github.com/tpak/Meridian/releases/latest"><img src="https://img.shields.io/github/v/release/tpak/Meridian?display_name=tag&sort=semver" alt="Latest release"></a>
 </p>
 
 A macOS menu bar world clock. Track time across zones for your team, friends, and family.


### PR DESCRIPTION
## Summary
- Remove the GitHub license-detection badge. It rendered as "invalid" intermittently due to shields.io / GitHub API flakiness, even though GitHub's own detector correctly identifies the license as MIT. GitHub's repo sidebar and the README's License section already point readers to the LICENSE file, so the badge was redundant.
- Pin CI and CodeQL badges to `?branch=main` so the README always reflects main's status, not the most recent run on any branch.
- Add a latest-release badge so visitors can see the current shipped version at a glance.
- LICENSE: use preferred name form ("Chris Tirpak") in the copyright line and strip a trailing space. Upstream Banthia copyright preserved as MIT requires.

## Test plan
- [ ] After merge, confirm all four badges render on the GitHub repo home page (CI, CodeQL, SwiftLint, Latest release).
- [ ] CI and CodeQL badges reflect main's latest run.
- [ ] Latest-release badge shows the current tag (e.g. v3.1.1).
- [ ] LICENSE renders the second copyright line as `Copyright (c) 2026 Chris Tirpak` with no trailing whitespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)