### PR TITLE
Drop SwiftLint badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 <p align="center">
   <a href="https://github.com/tpak/Meridian/actions/workflows/ci.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
   <a href="https://github.com/tpak/Meridian/actions/workflows/codeql.yml"><img src="https://github.com/tpak/Meridian/actions/workflows/codeql.yml/badge.svg?branch=main" alt="CodeQL"></a>
-  <a href="https://github.com/tpak/Meridian/blob/main/.swiftlint.yml"><img src="https://img.shields.io/badge/SwiftLint-configured-brightgreen" alt="SwiftLint"></a>
   <a href="https://github.com/tpak/Meridian/releases/latest"><img src="https://img.shields.io/github/v/release/tpak/Meridian?display_name=tag&sort=semver" alt="Latest release"></a>
 </p>
 


### PR DESCRIPTION
## Summary
- Remove the "SwiftLint configured" badge. It was a static label linking to `.swiftlint.yml` and didn't reflect whether lint actually passes.
- SwiftLint already runs inside the `Build & Lint` job in `ci.yml`, so the CI badge encodes its pass/fail state. The SwiftLint badge added no signal the CI badge didn't already provide.

Badge row after this change: **CI · CodeQL · Latest release**.

## Test plan
- [ ] After merge, confirm the three remaining badges render correctly on the GitHub repo home page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)