### PR TITLE
Stop unit tests leaking a plist per run; fix Melbourne-only test failure

### DIFF
--- a/Meridian/MeridianUnitTests/MenubarBlockDetectionTests.swift
+++ b/Meridian/MeridianUnitTests/MenubarBlockDetectionTests.swift
@@ -85,8 +85,14 @@ final class MenubarBlockDetectionTests: XCTestCase {
     /// AppDefaults registration and the simple read/write semantics, which
     /// together back the "show once and only once" guarantee.
     func testTahoeOnboardingShownDefaultsToFalse() {
-        let defaults = UserDefaults(suiteName: "TahoeOnboardingDefaults-\(UUID().uuidString)")!
-        defaults.removePersistentDomain(forName: defaults.dictionaryRepresentation().keys.first ?? "")
+        // Use a fixed suite name (not a per-run UUID) so the backing plist in
+        // ~/Library/Preferences is reused and overwritten instead of accumulating a new
+        // file every run. removePersistentDomain clears a suite's contents but does not
+        // delete its plist file, so a UUID-based name leaks one stray plist per test run.
+        let suiteName = "com.tpak.meridian.tests.TahoeOnboardingDefaults"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
 
         AppDefaults.initialize(with: DataStore.shared(), defaults: defaults)
 
@@ -95,10 +101,13 @@ final class MenubarBlockDetectionTests: XCTestCase {
     }
 
     func testTahoeOnboardingShownRoundTrips() {
-        let defaults = UserDefaults(suiteName: "TahoeOnboardingRoundTrip-\(UUID().uuidString)")!
+        let suiteName = "com.tpak.meridian.tests.TahoeOnboardingRoundTrip"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
         defaults.set(true, forKey: UserDefaultKeys.tahoeOnboardingShown)
         XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.tahoeOnboardingShown))
-        defaults.removeObject(forKey: UserDefaultKeys.tahoeOnboardingShown)
     }
 
     // MARK: - Control Center deep link

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -339,23 +339,31 @@ class MeridianUnitTests: XCTestCase {
     }
 
     func testHomeRowMigrationClearsStaleFlag() throws {
-        // Two rows persisted: a stale-flagged Melbourne row (user added it
-        // while travelling) and an unflagged Denver row (the user's real
-        // current home). After migration, exactly the Denver row should
-        // carry the flag.
+        // Two rows persisted: a stale-flagged row (user added it while
+        // travelling) and an unflagged row for the machine's actual current
+        // timezone (the user's real home). After migration, exactly the
+        // current-timezone row should carry the flag.
+        //
+        // The stale zone is chosen to differ from the machine's current zone so
+        // the test stays hermetic even when run on a machine physically located
+        // in the otherwise-hardcoded stale zone (e.g. a developer in Melbourne).
+        // Otherwise both rows share a timezoneID and the flag can't move.
         let defaults = UserDefaults(suiteName: "HomeRowMigrationTest_Stale")!
         defaults.removePersistentDomain(forName: "HomeRowMigrationTest_Stale")
 
+        let systemTimezoneID = TimeZone.autoupdatingCurrent.identifier
+        let staleTimezoneID = systemTimezoneID == "Australia/Melbourne" ? "America/Denver" : "Australia/Melbourne"
+
         let stale = TimezoneData()
-        stale.timezoneID = "Australia/Melbourne"
-        stale.formattedAddress = "Melbourne"
-        stale.setLabel("Melbourne")
+        stale.timezoneID = staleTimezoneID
+        stale.formattedAddress = "Travelling"
+        stale.setLabel("Stale Row")
         stale.isSystemTimezone = true
 
         let actualHome = TimezoneData()
-        actualHome.timezoneID = TimeZone.autoupdatingCurrent.identifier
+        actualHome.timezoneID = systemTimezoneID
         actualHome.formattedAddress = "Home"
-        actualHome.setLabel("Denver")
+        actualHome.setLabel("Home Row")
         actualHome.isSystemTimezone = false
 
         let staleBlob = try XCTUnwrap(NSKeyedArchiver.secureArchive(with: stale))
@@ -366,9 +374,9 @@ class MeridianUnitTests: XCTestCase {
         let healedStale = try XCTUnwrap(TimezoneData.customObject(from: healed[0]))
         let healedHome = try XCTUnwrap(TimezoneData.customObject(from: healed[1]))
 
-        XCTAssertFalse(healedStale.isSystemTimezone, "stale Melbourne row should be unflagged")
-        XCTAssertEqual(healedStale.customLabel, "Melbourne", "user's label must survive migration")
-        XCTAssertTrue(healedHome.isSystemTimezone, "matching Denver row should pick up the flag")
+        XCTAssertFalse(healedStale.isSystemTimezone, "stale row should be unflagged")
+        XCTAssertEqual(healedStale.customLabel, "Stale Row", "user's label must survive migration")
+        XCTAssertTrue(healedHome.isSystemTimezone, "matching home row should pick up the flag")
 
         defaults.removePersistentDomain(forName: "HomeRowMigrationTest_Stale")
     }
@@ -632,8 +640,12 @@ class DataStoreTypedAccessorsTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        suiteName = "com.tpak.meridian.tests.\(UUID().uuidString)"
+        // Fixed suite name so the backing plist is reused, not accumulated. A per-run
+        // UUID name leaks one stray plist per test (removePersistentDomain clears the
+        // suite's contents but does not delete its file). Clear at start for isolation.
+        suiteName = "com.tpak.meridian.tests.DataStoreTypedAccessors"
         defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
         store = DataStore(with: defaults)
     }
 
@@ -824,8 +836,12 @@ class BoolSemanticsMigrationTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        suiteName = "com.tpak.meridian.migration.\(UUID().uuidString)"
+        // Fixed suite name so the backing plist is reused, not accumulated. A per-run
+        // UUID name leaks one stray plist per test (removePersistentDomain clears the
+        // suite's contents but does not delete its file). Clear at start for isolation.
+        suiteName = "com.tpak.meridian.migration.BoolSemantics"
         defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
     }
 
     override func tearDown() {
@@ -1272,8 +1288,12 @@ class TeamAccentTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        suiteName = "com.tpak.meridian.tests.\(UUID().uuidString)"
+        // Fixed suite name so the backing plist is reused, not accumulated. A per-run
+        // UUID name leaks one stray plist per test (removePersistentDomain clears the
+        // suite's contents but does not delete its file). Clear at start for isolation.
+        suiteName = "com.tpak.meridian.tests.TeamAccent"
         defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
         store = DataStore(with: defaults)
     }
 

--- a/Meridian/MeridianUnitTests/TestFixtures.swift
+++ b/Meridian/MeridianUnitTests/TestFixtures.swift
@@ -208,10 +208,13 @@ enum TestTimezones {
 
 // MARK: - DataStore Factory
 
-/// Creates a test DataStore with isolated UserDefaults
-/// - Parameter suiteName: Optional suite name for UserDefaults. If nil, generates a unique name.
+/// Creates a test DataStore with isolated UserDefaults.
+/// - Parameter suiteName: Suite name for UserDefaults. Defaults to a fixed name so the backing
+///   plist is reused rather than accumulating a new file per call (a per-run UUID name leaks a
+///   stray plist each time). Pass a distinct name for an isolated suite; callers should
+///   removePersistentDomain on the returned UserDefaults when finished.
 /// - Returns: Tuple of (DataStore, UserDefaults) for cleanup
-func makeTestDataStore(suiteName: String = "TestSuite-\(UUID().uuidString)") -> (DataStore, UserDefaults) {
+func makeTestDataStore(suiteName: String = "com.tpak.meridian.tests.Fixture") -> (DataStore, UserDefaults) {
     let defaults = UserDefaults(suiteName: suiteName)!
     let store = DataStore(with: defaults)
     return (store, defaults)


### PR DESCRIPTION
## Why

While running the unit suite locally, **hundreds of stray `.plist` files** accumulate in `~/Library/Preferences`. Tracking that down surfaced two distinct test-suite hygiene problems.

## 1. Leaking UserDefaults suites

Several tests created suites named with a per-run UUID, e.g. `UserDefaults(suiteName: "...-\(UUID().uuidString)")`. `removePersistentDomain(forName:)` clears a suite's *contents* but does **not** delete its backing `.plist` file — so every run minted a brand-new filename that was never removed. A full suite run leaked roughly one plist per test; over months of local runs that's the "hundreds."

Fixed by switching to **fixed suite names** (reused/overwritten, not accumulated), matching the pattern the `HomeRowMigrationTest_*` suites already use:

- `MenubarBlockDetectionTests` — the two Tahoe onboarding tests. One "cleaned up" a domain named after `dictionaryRepresentation().keys.first` (an arbitrary key like `AppleLanguages`, never the suite); the other never removed the domain at all.
- `MeridianUnitTests` — `DataStoreTypedAccessorsTests`, `BoolSemanticsMigrationTests`, `TeamAccentTests` `setUp` suites (now also clear at start for per-test isolation).
- `TestFixtures.makeTestDataStore` default suite name — an unused footgun with the same UUID pattern.

**Before:** ~one new UUID-named plist per test, per run → unbounded growth.
**After:** a fixed set of ~9 reused plists for the whole suite; rerun a thousand times, still 9. Zero UUID-named stragglers.

## 2. Non-hermetic home-row migration test

`testHomeRowMigrationClearsStaleFlag` hardcoded the stale row as `Australia/Melbourne` while building the "real home" row from `TimeZone.autoupdatingCurrent`. On a machine physically in Melbourne both rows share a `timezoneID`, so the migration keeps the stale row flagged and the assertions fail. It passed in CI (UTC) but **failed 2/224 for a developer in Melbourne**. Now the stale zone is chosen to always differ from the machine's current zone.

## Testing

`xcodebuild test -only-testing:MeridianUnitTests` → **224 / 224 pass** (was 222/224 on a Melbourne machine). Verified a full run leaves only the bounded fixed-name plists and no UUID-named files.

Test-only changes; no app code touched.