### PR TITLE
Add one-time cleanup of legacy Clocker / previous-author defaults

### DIFF
--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -988,6 +988,64 @@ class BoolSemanticsMigrationTests: XCTestCase {
     }
 }
 
+// MARK: - LegacyArtifactCleanup tests (previous-author defaults)
+
+class LegacyArtifactCleanupTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private let suiteName = "com.tpak.meridian.tests.LegacyArtifactCleanup"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    func testRemovesPreviousAuthorAndClockerKeys() {
+        defaults.set(0, forKey: "com.abhishek.appDisplayOptions")
+        defaults.set(0, forKey: "com.abhishek.menubarCompactMode")
+        defaults.set(514, forKey: "NSStatusItem Preferred Position ClockerStatusItem")
+        defaults.set("frame", forKey: "NSWindow Frame ClockerFloatingPanel")
+        // A current Meridian key that must survive.
+        defaults.set(1, forKey: UserDefaultKeys.appDisplayOptions)
+
+        AppDefaults.runLegacyArtifactCleanupV1(on: defaults)
+
+        XCTAssertNil(defaults.object(forKey: "com.abhishek.appDisplayOptions"))
+        XCTAssertNil(defaults.object(forKey: "com.abhishek.menubarCompactMode"))
+        XCTAssertNil(defaults.object(forKey: "NSStatusItem Preferred Position ClockerStatusItem"))
+        XCTAssertNil(defaults.object(forKey: "NSWindow Frame ClockerFloatingPanel"))
+        XCTAssertEqual(defaults.integer(forKey: UserDefaultKeys.appDisplayOptions), 1,
+                       "current com.tpak.meridian.* keys must be preserved")
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.legacyArtifactCleanupV1),
+                      "migration must set its guard flag")
+    }
+
+    func testIsIdempotentAndDoesNotTouchLaterArtifacts() {
+        AppDefaults.runLegacyArtifactCleanupV1(on: defaults)
+
+        // Guard is set, so a key added afterward (e.g. from a re-imported old
+        // settings file) is left alone until a future migration version.
+        defaults.set(0, forKey: "com.abhishek.appDisplayOptions")
+        AppDefaults.runLegacyArtifactCleanupV1(on: defaults)
+
+        XCTAssertNotNil(defaults.object(forKey: "com.abhishek.appDisplayOptions"),
+                        "second run is a no-op once the guard flag is set")
+    }
+
+    func testKeyClassifier() {
+        XCTAssertTrue(AppDefaults.isLegacyArtifactKey("com.abhishek.appDisplayOptions"))
+        XCTAssertTrue(AppDefaults.isLegacyArtifactKey("NSStatusItem Preferred Position ClockerStatusItem"))
+        XCTAssertFalse(AppDefaults.isLegacyArtifactKey("com.tpak.meridian.appDisplayOptions"))
+        XCTAssertFalse(AppDefaults.isLegacyArtifactKey("NSStatusItem Preferred Position MeridianStatusItem"))
+    }
+}
+
 // MARK: - SettingsManager v1/v2 schema tests (issue #97)
 
 class SettingsManagerVersioningTests: XCTestCase {

--- a/Meridian/Overall App/AppDefaults.swift
+++ b/Meridian/Overall App/AppDefaults.swift
@@ -25,6 +25,11 @@ class AppDefaults {
         // out of the migration's read path.
         runBoolSemanticsMigration(on: defaults)
 
+        // Drop leftover keys from the original Clocker codebase / early Meridian
+        // builds. Runs before register(defaults:) for consistency with the other
+        // migrations; it only touches legacy keys, so order is not critical.
+        runLegacyArtifactCleanupV1(on: defaults)
+
         defaults.register(defaults: defaultsDictionary())
 
         // Heal any rows whose isSystemTimezone flag drifted from the actual
@@ -77,6 +82,36 @@ class AppDefaults {
         // The typed accessors layer enums over them without renaming.
 
         defaults.set(true, forKey: UserDefaultKeys.boolSemanticsMigrationV1)
+    }
+
+    /// One-time cleanup of artifacts left in the app's UserDefaults by the
+    /// original Clocker codebase and very early Meridian builds: keys under the
+    /// previous author's `com.abhishek.` namespace (e.g.
+    /// `com.abhishek.appDisplayOptions`) and legacy `Clocker` AppKit autosave
+    /// entries (e.g. `NSStatusItem Preferred Position ClockerStatusItem`).
+    /// Current code never writes these, so fresh installs are unaffected — this
+    /// only tidies machines upgrading from those builds.
+    ///
+    /// Idempotent: guarded by `UserDefaultKeys.legacyArtifactCleanupV1`. Public
+    /// for tests.
+    class func runLegacyArtifactCleanupV1(on defaults: UserDefaults) {
+        guard !defaults.bool(forKey: UserDefaultKeys.legacyArtifactCleanupV1) else {
+            return
+        }
+
+        for key in defaults.dictionaryRepresentation().keys where isLegacyArtifactKey(key) {
+            defaults.removeObject(forKey: key)
+        }
+
+        defaults.set(true, forKey: UserDefaultKeys.legacyArtifactCleanupV1)
+    }
+
+    /// True for UserDefaults keys that are leftovers from Clocker / the previous
+    /// author's namespace and are no longer written by Meridian. Meridian's own
+    /// keys live under `com.tpak.meridian.` and use the `Meridian…` autosave
+    /// names, so neither pattern collides with current state.
+    static func isLegacyArtifactKey(_ key: String) -> Bool {
+        key.hasPrefix("com.abhishek.") || key.contains("Clocker")
     }
 
     /// One-time migration that heals the "stuck home row" bug. Two failure

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -66,6 +66,13 @@ public enum UserDefaultKeys {
     // under its original city label). See runHomeRowMigrationV1.
     static let homeRowMigrationV1 = "com.tpak.meridian.homeRowMigrationV1"
 
+    // One-time cleanup flag for artifacts left in the app's UserDefaults by the
+    // original Clocker codebase and very early Meridian builds: keys under the
+    // previous author's `com.abhishek.` namespace and legacy `Clocker` AppKit
+    // autosave entries. Current code never writes these. See
+    // runLegacyArtifactCleanupV1.
+    static let legacyArtifactCleanupV1 = "com.tpak.meridian.legacyArtifactCleanupV1"
+
     // F1 team accent color selection. Stored as TeamAccent.rawValue (String).
     // See DataStore.swift for the enum definition and resolved NSColor.
     static let teamAccent = "com.tpak.meridian.teamAccent"


### PR DESCRIPTION
## Why

Early Meridian builds (and the original Clocker codebase it was forked from) wrote preference keys that current code no longer uses but never cleaned up. They linger in the UserDefaults of anyone who ran those builds — e.g. in a real defaults dump:

```
com.abhishek.appDisplayOptions
com.abhishek.menubarCompactMode
NSStatusItem Preferred Position ClockerStatusItem
```

Current code never writes these (Meridian's keys live under `com.tpak.meridian.*` and it uses `Meridian…` autosave names), so fresh installs are clean — but upgraders carry the cruft forever.

## What

A one-time, idempotent migration `runLegacyArtifactCleanupV1`, guarded by `UserDefaultKeys.legacyArtifactCleanupV1`, that removes:

- any key under the previous author's `com.abhishek.` namespace
- any legacy `Clocker` AppKit autosave entry (status-item position, window frames)

It runs alongside the existing migrations in `AppDefaults.initializeDefaults`, before `register(defaults:)`. Because it only matches the `com.abhishek.` prefix and the `Clocker` substring — neither of which appears in any live Meridian key — it cannot touch current state.

## Tests

New `LegacyArtifactCleanupTests`:
- `testRemovesPreviousAuthorAndClockerKeys` — legacy keys removed, a current `com.tpak.meridian.*` key preserved, guard flag set
- `testIsIdempotentAndDoesNotTouchLaterArtifacts` — second run is a no-op once guarded
- `testKeyClassifier` — `isLegacyArtifactKey` matches legacy, spares Meridian keys

Full unit suite: 227 tests, green in CI. (Locally on a Melbourne machine, `testHomeRowMigrationClearsStaleFlag` fails for an unrelated reason fixed in #135.)