### PR TITLE
Refresh copyright attribution to dual notice

### DIFF
--- a/Meridian/App/AccentColorSwizzler.swift
+++ b/Meridian/App/AccentColorSwizzler.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/App/LocationController.swift
+++ b/Meridian/App/LocationController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLocation

--- a/Meridian/App/Meridian-Info.plist
+++ b/Meridian/App/Meridian-Info.plist
@@ -27,7 +27,7 @@
 	<key>LSUIElement</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2026 Chris Tpak. Originally by Abhishek Banthia.</string>
+	<string>Copyright © 2026 Chris Tirpak. Originally by Abhishek Banthia.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>Meridian can be more useful when it can use your location to determine your current timezone.</string>
 	<key>NSLocationUsageDescription</key>

--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/CoreLoggerKit/Sources/CoreLoggerKit/Logger.swift
+++ b/Meridian/CoreLoggerKit/Sources/CoreLoggerKit/Logger.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import os

--- a/Meridian/CoreLoggerKit/Tests/CoreLoggerKitTests/CoreLoggerKitTests.swift
+++ b/Meridian/CoreLoggerKit/Tests/CoreLoggerKitTests/CoreLoggerKitTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 @testable import CoreLoggerKit
 import os

--- a/Meridian/CoreModelKit/Sources/CoreModelKit/SearchResults.swift
+++ b/Meridian/CoreModelKit/Sources/CoreModelKit/SearchResults.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/CoreModelKit/Sources/CoreModelKit/TimezoneData.swift
+++ b/Meridian/CoreModelKit/Sources/CoreModelKit/TimezoneData.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/CoreModelKit/Tests/CoreModelKitTests/TimezoneDataEqualityTests.swift
+++ b/Meridian/CoreModelKit/Tests/CoreModelKitTests/TimezoneDataEqualityTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreModelKit
 import Foundation

--- a/Meridian/Meridian.xcodeproj/xcshareddata/IDETemplateMacros.plist
+++ b/Meridian/Meridian.xcodeproj/xcshareddata/IDETemplateMacros.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>FILEHEADER</key>
-	<string> Copyright © 2015 Abhishek Banthia</string>
+	<string> Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak</string>
 </dict>
 </plist>

--- a/Meridian/MeridianUITests/AboutUsTests.swift
+++ b/Meridian/MeridianUITests/AboutUsTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import XCTest
 

--- a/Meridian/MeridianUITests/CopyToClipboardTests.swift
+++ b/Meridian/MeridianUITests/CopyToClipboardTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import XCTest
 

--- a/Meridian/MeridianUITests/PanelTests.swift
+++ b/Meridian/MeridianUITests/PanelTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import XCTest
 

--- a/Meridian/MeridianUITests/PreferencesTest.swift
+++ b/Meridian/MeridianUITests/PreferencesTest.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 // NOTE: These UI tests require a real macOS session with menu bar access.
 // They are not run in CI (GitHub Actions lacks NSStatusItem accessibility).

--- a/Meridian/MeridianUITests/ShortcutTests.swift
+++ b/Meridian/MeridianUITests/ShortcutTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import XCTest
 

--- a/Meridian/MeridianUnitTests/AppDelegateTests.swift
+++ b/Meridian/MeridianUnitTests/AppDelegateTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreModelKit
 import XCTest

--- a/Meridian/MeridianUnitTests/DateFormatterManagerTests.swift
+++ b/Meridian/MeridianUnitTests/DateFormatterManagerTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import XCTest
 

--- a/Meridian/MeridianUnitTests/GeocodingServiceTests.swift
+++ b/Meridian/MeridianUnitTests/GeocodingServiceTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreLocation
 import XCTest

--- a/Meridian/MeridianUnitTests/GlobalShortcutMonitorTests.swift
+++ b/Meridian/MeridianUnitTests/GlobalShortcutMonitorTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import XCTest
 @testable import Meridian

--- a/Meridian/MeridianUnitTests/LocalizationTests.swift
+++ b/Meridian/MeridianUnitTests/LocalizationTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 @testable import Meridian
 import XCTest

--- a/Meridian/MeridianUnitTests/LocationControllerTests.swift
+++ b/Meridian/MeridianUnitTests/LocationControllerTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreLocation
 import CoreModelKit

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreModelKit
 

--- a/Meridian/MeridianUnitTests/MockDataStore.swift
+++ b/Meridian/MeridianUnitTests/MockDataStore.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Foundation
 import CoreModelKit

--- a/Meridian/MeridianUnitTests/MockURLProtocol.swift
+++ b/Meridian/MeridianUnitTests/MockURLProtocol.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Foundation
 

--- a/Meridian/MeridianUnitTests/NetworkManagerAsyncTests.swift
+++ b/Meridian/MeridianUnitTests/NetworkManagerAsyncTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import XCTest
 @testable import Meridian

--- a/Meridian/MeridianUnitTests/NetworkManagerTests.swift
+++ b/Meridian/MeridianUnitTests/NetworkManagerTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 @testable import Meridian
 import XCTest

--- a/Meridian/MeridianUnitTests/SearchDataSourceTests.swift
+++ b/Meridian/MeridianUnitTests/SearchDataSourceTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreModelKit
 import XCTest

--- a/Meridian/MeridianUnitTests/TestFixtures.swift
+++ b/Meridian/MeridianUnitTests/TestFixtures.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreModelKit
 import Foundation

--- a/Meridian/MeridianUnitTests/TimeScrollerViewModelTests.swift
+++ b/Meridian/MeridianUnitTests/TimeScrollerViewModelTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import XCTest
 @testable import Meridian

--- a/Meridian/MeridianUnitTests/TimezoneDataOperationsTests.swift
+++ b/Meridian/MeridianUnitTests/TimezoneDataOperationsTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreModelKit
 import XCTest

--- a/Meridian/MeridianUnitTests/TimezoneSortingManagerTests.swift
+++ b/Meridian/MeridianUnitTests/TimezoneSortingManagerTests.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import XCTest
 import CoreModelKit

--- a/Meridian/Overall App/AppDefaults.swift
+++ b/Meridian/Overall App/AppDefaults.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Overall App/AppKit + Additions.swift
+++ b/Meridian/Overall App/AppKit + Additions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Overall App/DataStore.swift
+++ b/Meridian/Overall App/DataStore.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Overall App/DateFormatterManager.swift
+++ b/Meridian/Overall App/DateFormatterManager.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Overall App/Foundation + Additions.swift
+++ b/Meridian/Overall App/Foundation + Additions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Overall App/GeocodingService.swift
+++ b/Meridian/Overall App/GeocodingService.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreLocation
 import Foundation

--- a/Meridian/Overall App/GlobalShortcutMonitor.swift
+++ b/Meridian/Overall App/GlobalShortcutMonitor.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Overall App/NetworkManager.swift
+++ b/Meridian/Overall App/NetworkManager.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLocation

--- a/Meridian/Overall App/String + Additions.swift
+++ b/Meridian/Overall App/String + Additions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Overall App/Timer.swift
+++ b/Meridian/Overall App/Timer.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Foundation
 

--- a/Meridian/Overall App/TimezoneSearchService.swift
+++ b/Meridian/Overall App/TimezoneSearchService.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Overall App/UserDefaults + KVOExtensions.swift
+++ b/Meridian/Overall App/UserDefaults + KVOExtensions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Panel/Data Layer/TimeScrollerViewModel.swift
+++ b/Meridian/Panel/Data Layer/TimeScrollerViewModel.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Foundation
 

--- a/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
+++ b/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLocation

--- a/Meridian/Panel/Modern Slider/ModernSliderViews.swift
+++ b/Meridian/Panel/Modern Slider/ModernSliderViews.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Panel/PanelContextMenu.swift
+++ b/Meridian/Panel/PanelContextMenu.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Panel/PanelController.swift
+++ b/Meridian/Panel/PanelController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Panel/ParentPanelController+Actions.swift
+++ b/Meridian/Panel/ParentPanelController+Actions.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Panel/ParentPanelController+Layout.swift
+++ b/Meridian/Panel/ParentPanelController+Layout.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreModelKit

--- a/Meridian/Panel/ParentPanelController+ModernSlider.swift
+++ b/Meridian/Panel/ParentPanelController+ModernSlider.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import AppKit
 import Combine

--- a/Meridian/Panel/ParentPanelController.swift
+++ b/Meridian/Panel/ParentPanelController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLocation

--- a/Meridian/Panel/UI/AddTableViewCell.swift
+++ b/Meridian/Panel/UI/AddTableViewCell.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Panel/UI/BackgroundPanelView.swift
+++ b/Meridian/Panel/UI/BackgroundPanelView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Panel/UI/CustomPanel.swift
+++ b/Meridian/Panel/UI/CustomPanel.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Panel/UI/CustomSliderCell.swift
+++ b/Meridian/Panel/UI/CustomSliderCell.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Panel/UI/NoTimezoneView.swift
+++ b/Meridian/Panel/UI/NoTimezoneView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import QuartzCore

--- a/Meridian/Panel/UI/PanelTableView.swift
+++ b/Meridian/Panel/UI/PanelTableView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Panel/UI/TimeMarkerViewItem.swift
+++ b/Meridian/Panel/UI/TimeMarkerViewItem.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Panel/UI/TimezoneCellView.swift
+++ b/Meridian/Panel/UI/TimezoneCellView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Panel/UI/TimezoneDataSource.swift
+++ b/Meridian/Panel/UI/TimezoneDataSource.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Panel/UI/Toasty.swift
+++ b/Meridian/Panel/UI/Toasty.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import AppKit
 import Foundation

--- a/Meridian/Preferences/About/AboutView.swift
+++ b/Meridian/Preferences/About/AboutView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import SwiftUI
 import CoreLoggerKit

--- a/Meridian/Preferences/About/AboutViewController.swift
+++ b/Meridian/Preferences/About/AboutViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import SwiftUI

--- a/Meridian/Preferences/About/PointingHandCursorButton.swift
+++ b/Meridian/Preferences/About/PointingHandCursorButton.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Preferences/General/PreferencesDataSource.swift
+++ b/Meridian/Preferences/General/PreferencesDataSource.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Preferences/General/PreferencesViewController.swift
+++ b/Meridian/Preferences/General/PreferencesViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import Combine

--- a/Meridian/Preferences/General/SearchDataSource.swift
+++ b/Meridian/Preferences/General/SearchDataSource.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreModelKit

--- a/Meridian/Preferences/General/ShortcutRecorderButton.swift
+++ b/Meridian/Preferences/General/ShortcutRecorderButton.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Preferences/General/TimezoneAdditionHandler.swift
+++ b/Meridian/Preferences/General/TimezoneAdditionHandler.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLocation

--- a/Meridian/Preferences/General/TimezoneSortingManager.swift
+++ b/Meridian/Preferences/General/TimezoneSortingManager.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreModelKit

--- a/Meridian/Preferences/Menu Bar/StatusContainerView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusContainerView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import Combine

--- a/Meridian/Preferences/Menu Bar/StatusItemView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemView.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreModelKit

--- a/Meridian/Preferences/OneWindowController.swift
+++ b/Meridian/Preferences/OneWindowController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 import CoreLoggerKit

--- a/Meridian/Preferences/ParentViewController.swift
+++ b/Meridian/Preferences/ParentViewController.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import Cocoa
 

--- a/Meridian/Preferences/StartupManager.swift
+++ b/Meridian/Preferences/StartupManager.swift
@@ -1,4 +1,4 @@
-// Copyright © 2015 Abhishek Banthia
+// Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
 import CoreLoggerKit
 import ServiceManagement


### PR DESCRIPTION
## Why

Prepping for wider distribution. The per-file headers still credited only the original author, and the Xcode template kept stamping that onto every new file. This adds the current maintainer as a **co-notice** rather than erasing the original author.

## What

**Per-file headers (77 files):**
```
// Copyright © 2015 Abhishek Banthia
→ // Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
```
Applied to all of Meridian's own source — app, `CoreModelKit`, `CoreLoggerKit`, and tests.

**Deliberately excluded:** vendored third-party code under `Dependencies/`. In particular `Dependencies/Solar.swift` still carries an `Abhishek Banthia` header — that's an upstream (Clocker-era) mislabelling of a third-party library (Solar, by Chris Howell). It's a *separate* problem; this PR doesn't add a third name on top of it. Flagging it for a future fix.

**Also:**
- `IDETemplateMacros.plist` — the `FILEHEADER` template now produces the dual notice, so new files stop inheriting an Abhishek-only copyright.
- `Meridian-Info.plist` — fixed `NSHumanReadableCopyright` typo **"Chris Tpak" → "Chris Tirpak"**.

## Licensing note

`LICENSE` is **unchanged** — still MIT with both `Copyright (c) 2015-2022 Abhishek Banthia` and `Copyright (c) 2026 Chris Tirpak`. MIT requires retaining the original notice, so that stays; this PR only updates the per-file/courtesy headers.

## Testing

`xcodebuild build` succeeds; both plists pass `plutil -lint`. Comment/string-only changes — no behavioral impact.