### PR TITLE
Localize v4 interface (String(localized:) + string catalog)

### DIFF
--- a/Meridian/App/Localizable.xcstrings
+++ b/Meridian/App/Localizable.xcstrings
@@ -2,6 +2,1146 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "%@ · livery palette": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ · livery palette"
+          }
+        }
+      }
+    },
+    "%lld hour": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld hour"
+          }
+        }
+      }
+    },
+    "%lld hours": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld hours"
+          }
+        }
+      }
+    },
+    "%lld minutes": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld minutes"
+          }
+        }
+      }
+    },
+    "%lldd ago": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lldd ago"
+          }
+        }
+      }
+    },
+    "+%lldd": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "+%lldd"
+          }
+        }
+      }
+    },
+    "12-hour": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12-hour"
+          }
+        }
+      }
+    },
+    "15 min": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "15 min"
+          }
+        }
+      }
+    },
+    "24-hour": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24-hour"
+          }
+        }
+      }
+    },
+    "24-hour time": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24-hour time"
+          }
+        }
+      }
+    },
+    "30 min": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "30 min"
+          }
+        }
+      }
+    },
+    "5 min": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "5 min"
+          }
+        }
+      }
+    },
+    "60 min": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "60 min"
+          }
+        }
+      }
+    },
+    "Accent color": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Accent color"
+          }
+        }
+      }
+    },
+    "Actual": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actual"
+          }
+        }
+      }
+    },
+    "Add a city or timezone…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a city or timezone…"
+          }
+        }
+      }
+    },
+    "Add places in Settings to see them here.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add places in Settings to see them here."
+          }
+        }
+      }
+    },
+    "Always marked with the house": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always marked with the house"
+          }
+        }
+      }
+    },
+    "Appearance": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Appearance"
+          }
+        }
+      }
+    },
+    "Arrow / snap step": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arrow / snap step"
+          }
+        }
+      }
+    },
+    "Auto": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto"
+          }
+        }
+      }
+    },
+    "Auto-detected when you travel": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-detected when you travel"
+          }
+        }
+      }
+    },
+    "Auto-install updates": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto-install updates"
+          }
+        }
+      }
+    },
+    "Back %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Back %@"
+          }
+        }
+      }
+    },
+    "Can't see it in your menu bar?": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Can't see it in your menu bar?"
+          }
+        }
+      }
+    },
+    "Check for updates": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check for updates"
+          }
+        }
+      }
+    },
+    "Cities": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cities"
+          }
+        }
+      }
+    },
+    "Color dots": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Color dots"
+          }
+        }
+      }
+    },
+    "Compact": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Compact"
+          }
+        }
+      }
+    },
+    "Copy all city times": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy all city times"
+          }
+        }
+      }
+    },
+    "Current Location": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Current Location"
+          }
+        }
+      }
+    },
+    "Currently in": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Currently in"
+          }
+        }
+      }
+    },
+    "Daily": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daily"
+          }
+        }
+      }
+    },
+    "Dark": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dark"
+          }
+        }
+      }
+    },
+    "Date": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Date"
+          }
+        }
+      }
+    },
+    "Day display": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Day display"
+          }
+        }
+      }
+    },
+    "Day of week": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Day of week"
+          }
+        }
+      }
+    },
+    "Debug logging": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Debug logging"
+          }
+        }
+      }
+    },
+    "Dense · 24h": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dense · 24h"
+          }
+        }
+      }
+    },
+    "Dock & Menu Bar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dock & Menu Bar"
+          }
+        }
+      }
+    },
+    "Double-click to set this time": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Double-click to set this time"
+          }
+        }
+      }
+    },
+    "Export Log": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Log"
+          }
+        }
+      }
+    },
+    "Export Settings…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Export Settings…"
+          }
+        }
+      }
+    },
+    "Fine-tune": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fine-tune"
+          }
+        }
+      }
+    },
+    "Float on top": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Float on top"
+          }
+        }
+      }
+    },
+    "Float on top (drag to move)": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Float on top (drag to move)"
+          }
+        }
+      }
+    },
+    "Float ▲": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Float ▲"
+          }
+        }
+      }
+    },
+    "Forward %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Forward %@"
+          }
+        }
+      }
+    },
+    "General": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "General"
+          }
+        }
+      }
+    },
+    "Here": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Here"
+          }
+        }
+      }
+    },
+    "Hide": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide"
+          }
+        }
+      }
+    },
+    "Home": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
+          }
+        }
+      }
+    },
+    "How your starred cities appear up top. No app name or clock — macOS shows those.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "How your starred cities appear up top. No app name or clock — macOS shows those."
+          }
+        }
+      }
+    },
+    "Import Settings…": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Import Settings…"
+          }
+        }
+      }
+    },
+    "Keep the popover open": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keep the popover open"
+          }
+        }
+      }
+    },
+    "Label": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Label"
+          }
+        }
+      }
+    },
+    "Last checked %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last checked %@"
+          }
+        }
+      }
+    },
+    "Last checked: Never": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Last checked: Never"
+          }
+        }
+      }
+    },
+    "Light": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Light"
+          }
+        }
+      }
+    },
+    "Limits and feel of the scrubber in the popover.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Limits and feel of the scrubber in the popover."
+          }
+        }
+      }
+    },
+    "Manually": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Manually"
+          }
+        }
+      }
+    },
+    "May have bugs": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "May have bugs"
+          }
+        }
+      }
+    },
+    "Menu Bar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu Bar"
+          }
+        }
+      }
+    },
+    "Menu Bar only": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu Bar only"
+          }
+        }
+      }
+    },
+    "Mono · no dots": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mono · no dots"
+          }
+        }
+      }
+    },
+    "Name": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Name"
+          }
+        }
+      }
+    },
+    "Now": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Now"
+          }
+        }
+      }
+    },
+    "Off": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        }
+      }
+    },
+    "Open an issue": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open an issue"
+          }
+        }
+      }
+    },
+    "PREVIEW": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PREVIEW"
+          }
+        }
+      }
+    },
+    "Palette names & colors are stylized tributes for personalization only. Team names and liveries are trademarks of their respective Formula 1 teams — all rights reserved. Meridian is not affiliated with or endorsed by them.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Palette names & colors are stylized tributes for personalization only. Team names and liveries are trademarks of their respective Formula 1 teams — all rights reserved. Meridian is not affiliated with or endorsed by them."
+          }
+        }
+      }
+    },
+    "Pin to top": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pin to top"
+          }
+        }
+      }
+    },
+    "Place name": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Place name"
+          }
+        }
+      }
+    },
+    "Preset": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Preset"
+          }
+        }
+      }
+    },
+    "Receive beta releases": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Receive beta releases"
+          }
+        }
+      }
+    },
+    "Relative": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relative"
+          }
+        }
+      }
+    },
+    "Remove": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove"
+          }
+        }
+      }
+    },
+    "Set color": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set color"
+          }
+        }
+      }
+    },
+    "Settings": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
+          }
+        }
+      }
+    },
+    "Show Meridian in": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Meridian in"
+          }
+        }
+      }
+    },
+    "Show Time Scroller": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Time Scroller"
+          }
+        }
+      }
+    },
+    "Show in menu bar": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show in menu bar"
+          }
+        }
+      }
+    },
+    "Show your current timezone first in Meridian": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show your current timezone first in Meridian"
+          }
+        }
+      }
+    },
+    "Sort": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort"
+          }
+        }
+      }
+    },
+    "Sort by %@": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sort by %@"
+          }
+        }
+      }
+    },
+    "Start at login": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start at login"
+          }
+        }
+      }
+    },
+    "Stop floating on top": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop floating on top"
+          }
+        }
+      }
+    },
+    "Sunrise": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sunrise"
+          }
+        }
+      }
+    },
+    "Sunrise / sunset": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sunrise / sunset"
+          }
+        }
+      }
+    },
+    "Sunset": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sunset"
+          }
+        }
+      }
+    },
+    "Tap again to reverse": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tap again to reverse"
+          }
+        }
+      }
+    },
+    "Text size": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Text size"
+          }
+        }
+      }
+    },
+    "Theme": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Theme"
+          }
+        }
+      }
+    },
+    "Time Travel": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Time Travel"
+          }
+        }
+      }
+    },
+    "Time diff": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Time diff"
+          }
+        }
+      }
+    },
+    "Time format": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Time format"
+          }
+        }
+      }
+    },
+    "Track timezones, star the ones for your menu bar, set a color and a short label.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Track timezones, star the ones for your menu bar, set a color and a short label."
+          }
+        }
+      }
+    },
+    "Travel back": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Travel back"
+          }
+        }
+      }
+    },
+    "Travel forward": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Travel forward"
+          }
+        }
+      }
+    },
+    "Unfloat ▼": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unfloat ▼"
+          }
+        }
+      }
+    },
+    "View source": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View source"
+          }
+        }
+      }
+    },
+    "Weekly": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Weekly"
+          }
+        }
+      }
+    },
+    "With date": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "With date"
+          }
+        }
+      }
+    },
+    "With day": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "With day"
+          }
+        }
+      }
+    },
+    "Your Time": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your Time"
+          }
+        }
+      }
+    },
+    "Your time": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your time"
+          }
+        }
+      }
+    },
+    "day": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "day"
+          }
+        }
+      }
+    },
+    "days": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "days"
+          }
+        }
+      }
+    },
+    "off": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "off"
+          }
+        }
+      }
+    },
+    "on": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "on"
+          }
+        }
+      }
+    },
+    "tmrw": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tmrw"
+          }
+        }
+      }
+    },
+    "yest.": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "yest."
+          }
+        }
+      }
+    },
+    "↺ Back to now": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "↺ Back to now"
+          }
+        }
+      }
+    },
+    "⌂ Home": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "⌂ Home"
+          }
+        }
+      }
+    },
     "Preferences Tab": {
       "localizations": {
         "en": {

--- a/Meridian/Panel/Daybreak/DaybreakCityRow.swift
+++ b/Meridian/Panel/Daybreak/DaybreakCityRow.swift
@@ -36,7 +36,7 @@ struct DaybreakCityRow: View {
                             .foregroundStyle(palette.textTertiary)
                             .padding(.horizontal, 5)
                             .overlay(RoundedRectangle(cornerRadius: 5).stroke(palette.hairline, lineWidth: 1))
-                            .help("Home")
+                            .help(String(localized: "Home"))
                     }
                 }
                 Text(hovering ? city.hoverLabel : city.nextEventLabel)
@@ -95,7 +95,7 @@ struct DaybreakCityRow: View {
             }
             .contentShape(Rectangle())
             .onTapGesture(count: 2, perform: onBeginEdit)
-            .help("Double-click to set this time")
+            .help(String(localized: "Double-click to set this time"))
             .accessibilityElement(children: .combine)
             .accessibilityLabel("\(city.name). \(city.time) \(city.period). \(city.offsetLabel). \(city.nextEventLabel)")
         }

--- a/Meridian/Panel/Daybreak/DaybreakEngine.swift
+++ b/Meridian/Panel/Daybreak/DaybreakEngine.swift
@@ -104,7 +104,7 @@ enum DaybreakEngine {
     /// Offset label relative to the current location: `"+11:30"`, `"−4:30"`, or `"Your time"`
     /// for the hero (offset 0). Mirrors the prototype `offStr`.
     static func offsetLabel(offsetMinutes o: Int) -> String {
-        if o == 0 { return "Your time" }
+        if o == 0 { return String(localized: "Your time") }
         let sign = o < 0 ? minus : "+"
         let a = abs(o)
         return "\(sign)\(a / 60):\(pad(a % 60))"
@@ -118,9 +118,9 @@ enum DaybreakEngine {
         if dayDelta == 0 { return nil }
         if dayDelta < 0 {
             let k = -dayDelta
-            return k == 1 ? "yest." : "\(k)d ago"
+            return k == 1 ? String(localized: "yest.") : String(localized: "\(k)d ago")
         }
-        return dayDelta == 1 ? "tmrw" : "+\(dayDelta)d"
+        return dayDelta == 1 ? String(localized: "tmrw") : String(localized: "+\(dayDelta)d")
     }
 
     // MARK: - Scrubber readout (README §F)
@@ -128,7 +128,7 @@ enum DaybreakEngine {
     /// Human delta for the readout pill, e.g. `"Now"`, `"+12:00"`, `"−1:30"`, `"+2d"`, `"+2d 8:00"`.
     /// Mirrors the prototype `dl(d)`.
     static func deltaLabel(deltaMinutes d: Int) -> String {
-        if d == 0 { return "Now" }
+        if d == 0 { return String(localized: "Now") }
         let sign = d < 0 ? minus : "+"
         let a = abs(d)
         let days = a / 1440
@@ -148,7 +148,7 @@ enum DaybreakEngine {
     static func readout(deltaMinutes d: Int, currentLocalMinutes lm: Int, weekdayShort: String) -> String {
         let t = format12(minutes: lm)
         if d == 0 {
-            return "Now · \(t.time) \(t.period)"
+            return "\(String(localized: "Now")) · \(t.time) \(t.period)"
         }
         return "\(deltaLabel(deltaMinutes: d)) · \(weekdayShort) \(t.time) \(t.period)"
     }

--- a/Meridian/Panel/Daybreak/DaybreakHeroView.swift
+++ b/Meridian/Panel/Daybreak/DaybreakHeroView.swift
@@ -81,7 +81,7 @@ struct DaybreakHeroView: View {
             }
             .contentShape(Rectangle())
             .onTapGesture(count: 2, perform: onBeginEdit)
-            .help("Double-click to set this time")
+            .help(String(localized: "Double-click to set this time"))
             .accessibilityElement(children: .combine)
             .accessibilityLabel("\(hero.eyebrow). \(hero.time) \(hero.period). \(hero.subline)")
         }

--- a/Meridian/Panel/Daybreak/DaybreakRootView.swift
+++ b/Meridian/Panel/Daybreak/DaybreakRootView.swift
@@ -94,7 +94,7 @@ struct DaybreakRootView: View {
 
     @ViewBuilder private func cityCards(_ snapshot: DaybreakSnapshot) -> some View {
         if snapshot.cities.isEmpty {
-            Text("Add places in Settings to see them here.")
+            Text(String(localized: "Add places in Settings to see them here."))
                 .font(.system(size: 12))
                 .foregroundStyle(palette.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .center)
@@ -139,14 +139,14 @@ struct DaybreakRootView: View {
                 .frame(width: 15, height: 15)
         }
         .buttonStyle(.plain)
-        .help("Copy all city times")
-        .accessibilityLabel(Text("Copy all city times"))
+        .help(String(localized: "Copy all city times"))
+        .accessibilityLabel(Text(String(localized: "Copy all city times")))
     }
 
     private func footer(_ snapshot: DaybreakSnapshot) -> some View {
         HStack {
             Button(action: onOpenSettings) {
-                Text("Settings").font(.system(size: 12, weight: .medium)).foregroundStyle(palette.foot)
+                Text(String(localized: "Settings")).font(.system(size: 12, weight: .medium)).foregroundStyle(palette.foot)
             }
             .buttonStyle(.plain)
 
@@ -159,12 +159,12 @@ struct DaybreakRootView: View {
             Spacer()
 
             Button(action: onTogglePin) {
-                Text(isFloating ? "Unfloat ▼" : "Float ▲")
+                Text(isFloating ? String(localized: "Unfloat ▼") : String(localized: "Float ▲"))
                     .font(.system(size: 12, weight: .medium))
                     .foregroundStyle(palette.foot)
             }
             .buttonStyle(.plain)
-            .help(isFloating ? "Stop floating on top" : "Float on top (drag to move)")
+            .help(isFloating ? String(localized: "Stop floating on top") : String(localized: "Float on top (drag to move)"))
         }
         .padding(EdgeInsets(top: 10, leading: 18, bottom: 14, trailing: 18))
         .overlay(alignment: .top) {

--- a/Meridian/Panel/Daybreak/DaybreakScrubber.swift
+++ b/Meridian/Panel/Daybreak/DaybreakScrubber.swift
@@ -41,7 +41,7 @@ struct DaybreakScrubber: View {
             // top edge, so the hero never reflows. README §F.
             if data.traveling {
                 Button(action: onReset) {
-                    Text("↺ Back to now")
+                    Text(String(localized: "↺ Back to now"))
                         .font(.system(size: 11.5, weight: .medium))
                         .foregroundStyle(palette.accent)
                 }
@@ -73,12 +73,16 @@ struct DaybreakScrubber: View {
                 .overlay(Circle().stroke(palette.hairline, lineWidth: 1))
         }
         .buttonStyle(.plain)
-        .help(forward ? "Forward \(stepDescription)" : "Back \(stepDescription)")
+        .help(forward ? String(localized: "Forward \(stepDescription)") : String(localized: "Back \(stepDescription)"))
     }
 
     private var stepDescription: String {
         let step = data.stepMinutes
-        return step % 60 == 0 ? "\(step / 60) hour\(step == 60 ? "" : "s")" : "\(step) minutes"
+        if step % 60 == 0 {
+            let h = step / 60
+            return h == 1 ? String(localized: "\(h) hour") : String(localized: "\(h) hours")
+        }
+        return String(localized: "\(step) minutes")
     }
 
     private var track: some View {

--- a/Meridian/Panel/Daybreak/DaybreakViewModel.swift
+++ b/Meridian/Panel/Daybreak/DaybreakViewModel.swift
@@ -280,7 +280,7 @@ final class DaybreakViewModel: ObservableObject {
         let event = DaybreakEngine.nextSunEvent(localMinutes: localMinutes, sunrise: window.sunrise, sunset: window.sunset)
         let eventString = eventLabel(event)
         let dateString = string(fullDate, reference, timeZone)
-        let eyebrow = "\(name) · \(locationTraveling ? "Current Location" : "Your Time")"
+        let eyebrow = "\(name) · \(locationTraveling ? String(localized: "Current Location") : String(localized: "Your Time"))"
         return DaybreakHeroData(
             eyebrow: eyebrow,
             time: time, period: period,
@@ -364,7 +364,7 @@ final class DaybreakViewModel: ObservableObject {
 
     private func eventLabel(_ event: SunEvent) -> String {
         let arrow = event.kind == .sunrise ? "↑" : "↓"
-        let name = event.kind == .sunrise ? "Sunrise" : "Sunset"
+        let name = event.kind == .sunrise ? String(localized: "Sunrise") : String(localized: "Sunset")
         let (time, period) = formatTime(event.minutes)
         return period.isEmpty ? "\(arrow) \(name) \(time)" : "\(arrow) \(name) \(time) \(period)"
     }
@@ -403,7 +403,7 @@ final class DaybreakViewModel: ObservableObject {
             hero: DaybreakHeroData(eyebrow: "", time: "", period: "", subline: "", hoverSubline: "",
                                    phase: .day, localMinutes: 0),
             cities: [],
-            scrubber: DaybreakScrubberData(readout: "Now", traveling: false, handleFraction: 0.5,
+            scrubber: DaybreakScrubberData(readout: String(localized: "Now"), traveling: false, handleFraction: 0.5,
                                            handleIsNight: false, stepMinutes: 15),
             locationTraveling: false,
             versionText: versionText()

--- a/Meridian/Preferences/V4Settings/AppearancePane.swift
+++ b/Meridian/Preferences/V4Settings/AppearancePane.swift
@@ -21,26 +21,26 @@ struct AppearancePane: View {
         VStack(alignment: .leading, spacing: 0) {
             header
 
-            FormRow(label: "Theme") { themeSegment }
+            FormRow(label: String(localized: "Theme")) { themeSegment }
                 .padding(.bottom, 16)
 
             accentRow
                 .padding(.bottom, 18)
 
-            FormRow(label: "Time format") { timeFormatSegment }
+            FormRow(label: String(localized: "Time format")) { timeFormatSegment }
                 .padding(.bottom, 16)
 
-            FormRow(label: "Day display") { dayDisplaySegment }
+            FormRow(label: String(localized: "Day display")) { dayDisplaySegment }
                 .padding(.bottom, 16)
 
-            FormRow(label: "Sunrise / sunset") {
+            FormRow(label: String(localized: "Sunrise / sunset")) {
                 Toggle("", isOn: $showSunriseSunset)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
             }
             .padding(.bottom, 16)
 
-            FormRow(label: "Text size") { textSizeSlider }
+            FormRow(label: String(localized: "Text size")) { textSizeSlider }
                 .padding(.bottom, 22)
 
             previewSection
@@ -51,7 +51,7 @@ struct AppearancePane: View {
 
     private var header: some View {
         // Spec: Appearance heading has no subtitle paragraph, just the 18pt bottom margin.
-        Text("Appearance")
+        Text(String(localized: "Appearance"))
             .font(.system(size: 20, weight: .bold))
             .padding(.bottom, 18)
     }
@@ -60,7 +60,7 @@ struct AppearancePane: View {
 
     private var themeSegment: some View {
         SegmentedControl(
-            options: [(Theme.system, "Auto"), (.light, "Light"), (.dark, "Dark")],
+            options: [(Theme.system, String(localized: "Auto")), (.light, String(localized: "Light")), (.dark, String(localized: "Dark"))],
             selection: $theme,
             accent: accent
         )
@@ -68,7 +68,7 @@ struct AppearancePane: View {
 
     private var timeFormatSegment: some View {
         SegmentedControl(
-            options: [(TimeFormat.twelveHour, "12-hour"), (.twentyFourHour, "24-hour")],
+            options: [(TimeFormat.twelveHour, String(localized: "12-hour")), (.twentyFourHour, String(localized: "24-hour"))],
             selection: $timeFormat,
             accent: accent
         )
@@ -77,10 +77,10 @@ struct AppearancePane: View {
     private var dayDisplaySegment: some View {
         SegmentedControl(
             options: [
-                (RelativeDateDisplay.relative, "Relative"),
-                (.actual, "Actual"),
-                (.date, "Date"),
-                (.hidden, "Hide")
+                (RelativeDateDisplay.relative, String(localized: "Relative")),
+                (.actual, String(localized: "Actual")),
+                (.date, String(localized: "Date")),
+                (.hidden, String(localized: "Hide"))
             ],
             selection: $dayDisplay,
             accent: accent
@@ -91,7 +91,7 @@ struct AppearancePane: View {
 
     private var accentRow: some View {
         HStack(alignment: .top, spacing: 16) {
-            Text("Accent color")
+            Text(String(localized: "Accent color"))
                 .font(.system(size: 12.5))
                 .foregroundStyle(.secondary)
                 .frame(width: 150, alignment: .trailing)
@@ -99,7 +99,7 @@ struct AppearancePane: View {
 
             VStack(alignment: .leading, spacing: 8) {
                 accentSwatches
-                Text("\(teamAccent.displayName) · livery palette")
+                Text(String(localized: "\(teamAccent.displayName) · livery palette"))
                     .font(.system(size: 11.5))
                     .foregroundStyle(.tertiary)
                 liveryDisclaimer
@@ -139,10 +139,8 @@ struct AppearancePane: View {
         .padding(.top, 1)
     }
 
-    private static let disclaimerText =
-        "Palette names & colors are stylized tributes for personalization only. "
-        + "Team names and liveries are trademarks of their respective Formula 1 teams — "
-        + "all rights reserved. Meridian is not affiliated with or endorsed by them."
+    // swiftlint:disable:next line_length
+    private static let disclaimerText = String(localized: "Palette names & colors are stylized tributes for personalization only. Team names and liveries are trademarks of their respective Formula 1 teams — all rights reserved. Meridian is not affiliated with or endorsed by them.")
 
     // MARK: Text size
 
@@ -162,7 +160,7 @@ struct AppearancePane: View {
 
     private var previewSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("PREVIEW")
+            Text(String(localized: "PREVIEW"))
                 .font(.system(size: 11, weight: .bold))
                 .tracking(1.2)
                 .foregroundStyle(.tertiary)

--- a/Meridian/Preferences/V4Settings/CitiesPane.swift
+++ b/Meridian/Preferences/V4Settings/CitiesPane.swift
@@ -38,9 +38,9 @@ struct CitiesPane: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("Cities")
+            Text(String(localized: "Cities"))
                 .font(.system(size: 20, weight: .bold))
-            Text("Track timezones, star the ones for your menu bar, set a color and a short label.")
+            Text(String(localized: "Track timezones, star the ones for your menu bar, set a color and a short label."))
                 .font(.system(size: 12.5))
                 .foregroundStyle(.secondary)
         }
@@ -63,7 +63,7 @@ private extension CitiesPane {
     }
 
     var homeRow: some View {
-        FormRow(label: "Home") {
+        FormRow(label: String(localized: "Home")) {
             // Custom-styled Menu (not a native Picker, which hugs its content and won't honor a
             // fixed width) so it's the exact same box as "Currently in" and they align.
             Menu {
@@ -76,16 +76,16 @@ private extension CitiesPane {
             .menuStyle(.borderlessButton)
             .menuIndicator(.hidden)
             .fixedSize()
-            Text("Always marked with the house")
+            Text(String(localized: "Always marked with the house"))
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
         }
     }
 
     var currentRow: some View {
-        FormRow(label: "Currently in") {
+        FormRow(label: String(localized: "Currently in")) {
             locationBox(currentLocationLabel, showsChevron: false)
-            Text("Auto-detected when you travel")
+            Text(String(localized: "Auto-detected when you travel"))
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
         }
@@ -129,12 +129,12 @@ private extension CitiesPane {
     }
 
     var pinRow: some View {
-        FormRow(label: "Pin to top") {
+        FormRow(label: String(localized: "Pin to top")) {
             Toggle("", isOn: $pinCurrentToTop)
                 .labelsHidden()
                 .toggleStyle(AccentSwitchToggleStyle(accent: accent))
                 .onChange(of: pinCurrentToTop) { _, _ in model.reload() }
-            Text("Show your current timezone first in Meridian")
+            Text(String(localized: "Show your current timezone first in Meridian"))
                 .font(.system(size: 11))
                 .foregroundStyle(.tertiary)
         }
@@ -163,7 +163,7 @@ private extension CitiesPane {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 12))
                     .foregroundStyle(.tertiary)
-                TextField("Add a city or timezone…", text: $query)
+                TextField(String(localized: "Add a city or timezone…"), text: $query)
                     .textFieldStyle(.plain)
                     .font(.system(size: 13))
                     .onChange(of: query) { _, newValue in
@@ -284,7 +284,7 @@ private extension CitiesPane {
 private extension CitiesPane {
     var sortControl: some View {
         HStack(spacing: 8) {
-            Text("Sort")
+            Text(String(localized: "Sort"))
                 .font(.system(size: 11.5))
                 .foregroundStyle(.tertiary)
             // Custom segmented control (not a Picker) so tapping the already-selected segment is
@@ -323,7 +323,7 @@ private extension CitiesPane {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .help(active ? "Tap again to reverse" : "Sort by \(mode.title.lowercased())")
+        .help(active ? String(localized: "Tap again to reverse") : String(localized: "Sort by \(mode.title.lowercased())"))
     }
 }
 
@@ -432,7 +432,7 @@ private struct CityRowView: View {
                 .foregroundStyle(row.isFavourite ? accent : Color.secondary)
         }
         .buttonStyle(.plain)
-        .help("Show in menu bar")
+        .help(String(localized: "Show in menu bar"))
     }
 
     private var colorDotButton: some View {
@@ -443,7 +443,7 @@ private struct CityRowView: View {
                 .overlay(Circle().stroke(Color.primary.opacity(0.15), lineWidth: 1))
         }
         .buttonStyle(.plain)
-        .help("Set color")
+        .help(String(localized: "Set color"))
     }
 
     private var details: some View {
@@ -467,7 +467,7 @@ private struct CityRowView: View {
     }
 
     private var homeBadge: some View {
-        Text("⌂ Home")
+        Text(String(localized: "⌂ Home"))
             .font(.system(size: 10, weight: .semibold))
             .foregroundStyle(.secondary)
             .padding(.horizontal, 6)
@@ -479,7 +479,7 @@ private struct CityRowView: View {
     }
 
     private var hereBadge: some View {
-        Text("Here")
+        Text(String(localized: "Here"))
             .font(.system(size: 10, weight: .semibold))
             .foregroundStyle(.white)
             .padding(.horizontal, 6)
@@ -488,7 +488,7 @@ private struct CityRowView: View {
     }
 
     private var labelField: some View {
-        TextField("Label", text: $labelText, onCommit: { onCommitLabel(labelText) })
+        TextField(String(localized: "Label"), text: $labelText, onCommit: { onCommitLabel(labelText) })
             .textFieldStyle(.plain)
             .font(.system(size: 12.5))
             .frame(width: 92)
@@ -518,7 +518,7 @@ private struct CityRowView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .help("Remove")
+            .help(String(localized: "Remove"))
         }
     }
 

--- a/Meridian/Preferences/V4Settings/CityListModel.swift
+++ b/Meridian/Preferences/V4Settings/CityListModel.swift
@@ -31,9 +31,9 @@ final class CityListModel: ObservableObject {
         var id: String { rawValue }
         var title: String {
             switch self {
-            case .timeDiff: return "Time diff"
-            case .name: return "Name"
-            case .label: return "Label"
+            case .timeDiff: return String(localized: "Time diff")
+            case .name: return String(localized: "Name")
+            case .label: return String(localized: "Label")
             }
         }
     }

--- a/Meridian/Preferences/V4Settings/GeneralPane.swift
+++ b/Meridian/Preferences/V4Settings/GeneralPane.swift
@@ -44,7 +44,7 @@ struct GeneralPane: View {
 private struct Header: View {
     var body: some View {
         // Spec: General heading has no subtitle paragraph, just the 18pt bottom margin.
-        Text("General")
+        Text(String(localized: "General"))
             .font(.system(size: 20, weight: .bold))
             .padding(.bottom, 18)
     }
@@ -101,7 +101,7 @@ private struct StartAtLoginRow: View {
     private let startupManager = StartupManager()
 
     var body: some View {
-        ToggleRow(label: "Start at login", accent: accent, isOn: $startAtLogin)
+        ToggleRow(label: String(localized: "Start at login"), accent: accent, isOn: $startAtLogin)
             .onChange(of: startAtLogin) { _, newValue in
                 startupManager.toggleLogin(newValue)
             }
@@ -123,7 +123,7 @@ private struct AutoUpdateRow: View {
     }
 
     var body: some View {
-        ToggleRow(label: "Auto-install updates", accent: accent, isOn: $autoUpdate)
+        ToggleRow(label: String(localized: "Auto-install updates"), accent: accent, isOn: $autoUpdate)
             .accessibilityIdentifier("AutoUpdate")
             .onChange(of: autoUpdate) { _, newValue in
                 // Auto-install controls ONLY auto-download; whether Sparkle *checks* on a schedule is
@@ -156,7 +156,7 @@ private struct BetaRow: View {
     @AppStorage(UserDefaultKeys.betaUpdatesEnabled) private var receiveBetas = false
 
     var body: some View {
-        ToggleRow(label: "Receive beta releases", note: "May have bugs", accent: accent, isOn: $receiveBetas)
+        ToggleRow(label: String(localized: "Receive beta releases"), note: String(localized: "May have bugs"), accent: accent, isOn: $receiveBetas)
             .accessibilityIdentifier("ReceiveBetaReleases")
             .onChange(of: receiveBetas) { _, _ in
                 guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
@@ -170,7 +170,7 @@ private struct DebugRow: View {
     @AppStorage(UserDefaultKeys.debugLoggingEnabled) private var debugLogging = false
 
     var body: some View {
-        ToggleRow(label: "Debug logging", accent: accent, isOn: $debugLogging)
+        ToggleRow(label: String(localized: "Debug logging"), accent: accent, isOn: $debugLogging)
             .accessibilityIdentifier("DebugLogging")
     }
 }
@@ -183,7 +183,7 @@ private struct UpdateFrequencyRow: View {
     // Sparkle stores the interval in seconds. "Manually" disables scheduled
     // checks; Daily / Weekly map to the standard intervals AboutView uses.
     private static let intervals: [TimeInterval] = [0, 86400, 604800]
-    private static let labels = ["Manually", "Daily", "Weekly"]
+    private static let labels = [String(localized: "Manually"), String(localized: "Daily"), String(localized: "Weekly")]
 
     @State private var selectedIndex: Int
 
@@ -196,7 +196,7 @@ private struct UpdateFrequencyRow: View {
     }
 
     var body: some View {
-        FormRow(label: "Check for updates") {
+        FormRow(label: String(localized: "Check for updates")) {
             Picker("", selection: $selectedIndex) {
                 ForEach(0..<Self.labels.count, id: \.self) { index in
                     Text(Self.labels[index]).tag(index)
@@ -221,7 +221,7 @@ private struct UpdateFrequencyRow: View {
                 syncSelection() // reflect a settings import / external change
             }
 
-            Button("Check Now") {
+            Button(String(localized: "Check Now")) {
                 guard let appDelegate = NSApplication.shared.delegate as? AppDelegate else { return }
                 appDelegate.updaterController.checkForUpdates(nil)
             }
@@ -248,11 +248,11 @@ private struct BackupButtons: View {
 
     var body: some View {
         HStack(spacing: 10) {
-            Button("Export Settings…") { SettingsManager.exportSettings() }
+            Button(String(localized: "Export Settings…")) { SettingsManager.exportSettings() }
                 .accessibilityIdentifier("ExportSettings")
-            Button("Import Settings…") { SettingsManager.importSettings() }
+            Button(String(localized: "Import Settings…")) { SettingsManager.importSettings() }
                 .accessibilityIdentifier("ImportSettings")
-            Button("Export Log") { exportLog() }
+            Button(String(localized: "Export Log")) { exportLog() }
                 .disabled(!debugLogging)
                 .accessibilityIdentifier("ExportLog")
         }
@@ -304,18 +304,18 @@ private struct AboutBlock: View {
                 .foregroundStyle(.tertiary)
 
             HStack(spacing: 18) {
-                LinkText("Open an issue", accent: accent) {
+                LinkText(String(localized: "Open an issue"), accent: accent) {
                     open(AboutUsConstants.GitHubIssuesURL, log: "Opened GitHub Issues")
                 }
                 .accessibilityIdentifier("MeridianPrivateFeedback")
 
-                LinkText("View source", accent: accent) {
+                LinkText(String(localized: "View source"), accent: accent) {
                     open(AboutUsConstants.GitHubURL, log: "Opened GitHub")
                 }
 
                 // Tahoe (#125) recovery link — escape hatch for users who lost
                 // the menu bar icon.
-                LinkText("Can't see it in your menu bar?", accent: accent) {
+                LinkText(String(localized: "Can't see it in your menu bar?"), accent: accent) {
                     ControlCenterSettings.open()
                     Logger.debug("Opened Control Center Settings from General tab")
                 }
@@ -329,8 +329,8 @@ private struct AboutBlock: View {
     }
 
     private var lastCheckedText: String {
-        guard let date = lastCheckDate else { return "Last checked: Never" }
-        return "Last checked \(lastCheckedFormatter.string(from: date))"
+        guard let date = lastCheckDate else { return String(localized: "Last checked: Never") }
+        return String(localized: "Last checked \(lastCheckedFormatter.string(from: date))")
     }
 
     private func refreshLastChecked() {

--- a/Meridian/Preferences/V4Settings/MenuBarPane.swift
+++ b/Meridian/Preferences/V4Settings/MenuBarPane.swift
@@ -21,23 +21,23 @@ private struct MenuBarPreset: Identifiable {
 
 private let menuBarPresets: [MenuBarPreset] = [
     MenuBarPreset(
-        id: "compact", label: "Compact", sample: "IST 7:47 AM",
+        id: "compact", label: String(localized: "Compact"), sample: "IST 7:47 AM",
         place: true, day: false, date: false, twentyFourHour: false, dots: true
     ),
     MenuBarPreset(
-        id: "withday", label: "With day", sample: "IST Mon 7:47 AM",
+        id: "withday", label: String(localized: "With day"), sample: "IST Mon 7:47 AM",
         place: true, day: true, date: false, twentyFourHour: false, dots: true
     ),
     MenuBarPreset(
-        id: "dense24", label: "Dense · 24h", sample: "IST 07:47",
+        id: "dense24", label: String(localized: "Dense · 24h"), sample: "IST 07:47",
         place: true, day: false, date: false, twentyFourHour: true, dots: true
     ),
     MenuBarPreset(
-        id: "withdate", label: "With date", sample: "IST 7:47 AM 13 Jun",
+        id: "withdate", label: String(localized: "With date"), sample: "IST 7:47 AM 13 Jun",
         place: true, day: false, date: true, twentyFourHour: false, dots: true
     ),
     MenuBarPreset(
-        id: "mono", label: "Mono · no dots", sample: "IST 7:47 AM",
+        id: "mono", label: String(localized: "Mono · no dots"), sample: "IST 7:47 AM",
         place: true, day: false, date: false, twentyFourHour: false, dots: false
     )
 ]
@@ -105,9 +105,9 @@ struct MenuBarPane: View {
 
     private var header: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("Menu Bar")
+            Text(String(localized: "Menu Bar"))
                 .font(.system(size: 20, weight: .bold))
-            Text("How your starred cities appear up top. No app name or clock — macOS shows those.")
+            Text(String(localized: "How your starred cities appear up top. No app name or clock — macOS shows those."))
                 .font(.system(size: 12.5))
                 .foregroundStyle(.secondary)
         }
@@ -160,7 +160,7 @@ struct MenuBarPane: View {
 
     private var presetSection: some View {
         VStack(alignment: .leading, spacing: 11) {
-            sectionLabel("Preset")
+            sectionLabel(String(localized: "Preset"))
             LazyVGrid(
                 columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)],
                 spacing: 8
@@ -187,31 +187,31 @@ struct MenuBarPane: View {
 
     private var fineTuneSection: some View {
         VStack(alignment: .leading, spacing: 14) {
-            sectionLabel("Fine-tune")
-            formRow("Place name") {
+            sectionLabel(String(localized: "Fine-tune"))
+            formRow(String(localized: "Place name")) {
                 Toggle("", isOn: $showPlaceName)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
                     .onChange(of: showPlaceName) { _, _ in activePresetID = "custom" }
             }
-            formRow("Day of week") {
+            formRow(String(localized: "Day of week")) {
                 Toggle("", isOn: $showDay)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
                     .onChange(of: showDay) { _, _ in activePresetID = "custom" }
             }
-            formRow("Date") {
+            formRow(String(localized: "Date")) {
                 Toggle("", isOn: $showDate)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
                     .onChange(of: showDate) { _, _ in activePresetID = "custom" }
             }
-            formRow("24-hour time") {
+            formRow(String(localized: "24-hour time")) {
                 Toggle("", isOn: twentyFourBinding)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
             }
-            formRow("Color dots") {
+            formRow(String(localized: "Color dots")) {
                 Toggle("", isOn: $menubarColorDots)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
@@ -233,10 +233,10 @@ struct MenuBarPane: View {
     // MARK: - Show Meridian in
 
     private var presentationRow: some View {
-        formRow("Show Meridian in") {
+        formRow(String(localized: "Show Meridian in")) {
             Picker("", selection: $appPresentation) {
-                Text("Menu Bar only").tag(AppPresentation.menubarOnly)
-                Text("Dock & Menu Bar").tag(AppPresentation.menubarAndDock)
+                Text(String(localized: "Menu Bar only")).tag(AppPresentation.menubarOnly)
+                Text(String(localized: "Dock & Menu Bar")).tag(AppPresentation.menubarAndDock)
             }
             .pickerStyle(.segmented)
             .labelsHidden()
@@ -250,12 +250,12 @@ struct MenuBarPane: View {
     // MARK: - Float on top
 
     private var floatOnTopRow: some View {
-        formRow("Float on top") {
+        formRow(String(localized: "Float on top")) {
             HStack(spacing: 8) {
                 Toggle("", isOn: $floatOnTop)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
-                Text("Keep the popover open")
+                Text(String(localized: "Keep the popover open"))
                     .font(.system(size: 11))
                     .foregroundStyle(.tertiary)
             }

--- a/Meridian/Preferences/V4Settings/SettingsRootView.swift
+++ b/Meridian/Preferences/V4Settings/SettingsRootView.swift
@@ -13,11 +13,11 @@ enum SettingsPane: String, CaseIterable, Identifiable {
 
     var title: String {
         switch self {
-        case .cities: return "Cities"
-        case .menuBar: return "Menu Bar"
-        case .appearance: return "Appearance"
-        case .timeTravel: return "Time Travel"
-        case .general: return "General"
+        case .cities: return String(localized: "Cities")
+        case .menuBar: return String(localized: "Menu Bar")
+        case .appearance: return String(localized: "Appearance")
+        case .timeTravel: return String(localized: "Time Travel")
+        case .general: return String(localized: "General")
         }
     }
 
@@ -141,6 +141,6 @@ struct AccentSwitchToggleStyle: ToggleStyle {
         }
         .buttonStyle(.plain)
         .accessibilityAddTraits(.isButton)
-        .accessibilityValue(isOn ? Text("on") : Text("off"))
+        .accessibilityValue(isOn ? Text(String(localized: "on")) : Text(String(localized: "off")))
     }
 }

--- a/Meridian/Preferences/V4Settings/TimeTravelPane.swift
+++ b/Meridian/Preferences/V4Settings/TimeTravelPane.swift
@@ -25,10 +25,10 @@ struct TimeTravelPane: View {
 
     private var headerSection: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("Time Travel")
+            Text(String(localized: "Time Travel"))
                 .font(.system(size: 20, weight: .bold))
                 .tracking(-0.4)
-            Text("Limits and feel of the scrubber in the popover.")
+            Text(String(localized: "Limits and feel of the scrubber in the popover."))
                 .font(.system(size: 12.5))
                 .foregroundStyle(.secondary)
         }
@@ -62,11 +62,11 @@ private struct ForwardDaysRow: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
-            FormLabel("Travel forward")
+            FormLabel(String(localized: "Travel forward"))
             Slider(value: doubleBinding, in: 1...30, step: 1)
                 .tint(accent)
                 .frame(maxWidth: .infinity)
-            readout("\(forwardDays) day\(forwardDays == 1 ? "" : "s")")
+            readout("\(forwardDays) \(String(localized: forwardDays == 1 ? "day" : "days"))")
         }
     }
 }
@@ -81,11 +81,11 @@ private struct BackDaysRow: View {
         Binding(get: { Double(backDays) }, set: { backDays = Int($0) })
     }
 
-    private var label: String { backDays == 0 ? "Off" : "\(backDays) day\(backDays == 1 ? "" : "s")" }
+    private var label: String { backDays == 0 ? String(localized: "Off") : "\(backDays) \(String(localized: backDays == 1 ? "day" : "days"))" }
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
-            FormLabel("Travel back")
+            FormLabel(String(localized: "Travel back"))
             Slider(value: doubleBinding, in: 0...7, step: 1)
                 .tint(accent)
                 .frame(maxWidth: .infinity)
@@ -101,12 +101,12 @@ private struct SnapStepRow: View {
     @Binding var snapStep: Int
 
     private let options: [(value: Int, label: String)] = [
-        (5, "5 min"), (15, "15 min"), (30, "30 min"), (60, "60 min")
+        (5, String(localized: "5 min")), (15, String(localized: "15 min")), (30, String(localized: "30 min")), (60, String(localized: "60 min"))
     ]
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
-            FormLabel("Arrow / snap step")
+            FormLabel(String(localized: "Arrow / snap step"))
             segmentedControl
             Spacer()
         }
@@ -158,7 +158,7 @@ private struct ShowScrollerRow: View {
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
-            FormLabel("Show Time Scroller")
+            FormLabel(String(localized: "Show Time Scroller"))
             Toggle("", isOn: $showFutureSlider)
                 .toggleStyle(AccentSwitchToggleStyle(accent: accent))
                 .labelsHidden()


### PR DESCRIPTION
Wires the new v4 **"Daybreak"** interface for localization — the remaining GA blocker for 4.0.0.

Every user-facing string in the redesigned popover and Settings window now goes through `String(localized:)` and is registered in the app's string catalog (`Localizable.xcstrings`), so the new UI can be translated into Meridian's 15 supported languages.

## What changed
- **114 new string keys** added to the catalog (English source; translations follow via the usual community/Crowdin flow — same as any newly-added string).
- Localized the dynamic popover labels too (sunrise/sunset, "Current Location", "Now", day tags, scrubber readout, time-travel step descriptions).
- Structural/symbolic tokens (separators, UTC, offset notation, version prefix) and illustrative preview/sample data are intentionally left as plain strings.

## Verification
- English output is **unchanged** (`String(localized:)` returns the source until a translation exists).
- **281 unit tests passing**; build clean; SwiftLint clean (only pre-existing single-char-identifier warnings that already ship on `main`).

Targeting **4.0.0-beta22** on the Sparkle beta channel.
