### PR TITLE
docs: user manual, 4.0.0 release notes, and code-review report

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,6 +415,13 @@ Before any release, run a full pre-release check and **show the status of each i
 3. Release notes don't break shell interpolation (no unescaped special chars in multiline strings passed to `make release`; use `bash scripts/release.sh -n "..."` directly for multiline notes)
 4. Sparkle appcast configuration is correct (`SUFeedURL`, `SUPublicEDKey` in Info.plist)
 5. After `make release` completes, run `gh run list --branch main --limit 3` and verify the version bump and appcast commits pass CI
+6. **User manual is current** — `docs/manual.md` reflects any new/changed setting, option, or feature in this release (see *User Documentation* below)
+
+## User Documentation
+
+The end-user manual lives at **`docs/manual.md`** (a single page) and is published to **GitHub Pages**. Themed release notes live at `docs/RELEASE_NOTES_<version>.md`.
+
+**Keep the manual current with every release.** Whenever a release adds, removes, or changes a user-facing setting, option, panel/menu-bar behavior, or keyboard shortcut, update `docs/manual.md` in the *same* PR — and treat a stale manual as a release blocker (Release Checklist item 6). When you document a new screen, also add a matching `<!-- screenshot: screenshots/… -->` placeholder so the image can be captured before the manual is published. Note that the shipping UI is the v4 SwiftUI Settings (`Preferences/V4Settings/*`) and Daybreak popover (`Panel/Daybreak/*`) — **not** the legacy storyboard settings behind the `useV4Settings`/`useDaybreakPanel` kill-switches — so document the v4 panes.
 
 ## Test-Driven Implementation
 

--- a/docs/CODE_REVIEW_4.0.0.md
+++ b/docs/CODE_REVIEW_4.0.0.md
@@ -1,0 +1,154 @@
+# Meridian 4.0.0 — Code Review (Dead Code, Security & Technical Debt)
+
+> **Status:** Review only. **No source code was changed.** Every item below is a *proposal*.
+> **Reviewed build:** `4.0.0-beta30` (branch `main` @ pre-GA) · **Date:** 2026-06-17
+> **Tracking:** Each confirmed finding has a GitHub issue (label `code-review-4.0.0`). This document is the index.
+
+## How this review was done
+
+A multi-agent pass fanned out three independent finders (dead-code, security, technical-debt) plus a SwiftLint/clang-analyzer tooling run, then put **every** candidate through an *adversarial verifier* whose job was to **refute** it — grepping Swift call sites, `.storyboard`/`.xib` files, `#selector`/`NSSelectorFromString` usage, KVO/UserDefaults key strings, protocol conformances (`NSSecureCoding`, Sparkle delegate, table-view data sources), `@objc` exposure, and the test targets — before anything was confirmed. This is why, e.g., the v4 feature-flag scaffolding is **not** reported as dead code (it's referenced by tests and storyboards and is an intentional rollback lever — see *Considered & dismissed*).
+
+| | Candidates | **Confirmed** | Refuted (false positive / intentional) |
+|---|---:|---:|---:|
+| Dead code | 17 | **15** | 2 |
+| Security | 4 | **1** | 3 |
+| Technical debt | 8 | **6** | 2 |
+| **Total** | **29** | **22** | **7** |
+
+**Severity of confirmed findings:** 0 critical · 0 high · **1 medium** · **21 low**.
+**SwiftLint:** 79 warnings, **0 errors** (no `force_cast`/`force_try`). **clang static analyzer:** `ANALYZE SUCCEEDED`, **0 source warnings**.
+
+This is a healthy codebase. There is **no urgent or shipping-blocking issue** here — the security finding is a low-sensitivity privacy nicety, and the rest is cleanup/consistency debt that can be paid down opportunistically. The single largest debt-reduction opportunity (retiring the v4 rollback scaffolding) is **deliberately deferred until after GA** — see the last section.
+
+---
+
+## Security (1)
+
+### F18 — User-chosen city label / address written to the always-on public log · `low`
+**`Meridian/Panel/Data Layer/TimezoneDataOperations.swift:353`** (logging primitive: `Meridian/CoreLoggerKit/Sources/CoreLoggerKit/Logger.swift:12-14`; secondary: `App/LocationController.swift:92,107`)
+
+`Logger.production(_:)` formats with `os_log("%{public}@", …)`, so anything interpolated lands in the unified system log **unredacted** and is captured into the user-shareable **Export Log** bundle. Line 353 logs `dataObject.formattedTimezoneLabel()` — which returns the user's *custom label* (e.g. "Mom's house") or a geocoded *address/city*. The codebase already routes genuinely-sensitive label logging through the private/opt-in `Logger.debug` channel (`%{private}@`); line 353 is the lone deviation. Fires only when Solar returns nil sunrise/sunset (e.g. polar latitudes) — rare but real. Leaked data is low-sensitivity (a self-chosen label or city-level address, not credentials/GPS), hence **low**.
+
+**Proposed fix** — log the non-identifying timezone identifier instead:
+```swift
+// TimezoneDataOperations.swift:353
+Logger.production("Sunrise/Sunset Error: Unable to fetch sunrise/sunset for timezone \(dataObject.timezoneID ?? "unknown")")
+```
+For `LocationController.swift:92,107`, drop `error.localizedDescription` in favor of `(error as NSError).domain`/`.code`, or route through `Logger.debug`. Optional hardening: add a `Logger.private(_:)` convenience (always-on but `%{private}@`) and reserve `Logger.production` for non-PII text.
+
+---
+
+## Technical debt (6)
+
+### F23 — v4 `com.tpak.meridian.v4.*` UserDefaults keys duplicated as raw literals, no single source of truth · **`medium`**
+**`Meridian/Preferences/Menu Bar/StatusItemView.swift:39,44`** + 8 files
+
+v4 preferences bypass the typed `UserDefaultKeys`/`AppDefaults` convention CLAUDE.md mandates, and the **same raw key string is hardcoded independently in 2–3 places** (13 literal sites across 8 files). Examples: `…v4.menubarStacked` is read raw in `StatusItemView.swift:39` *and* written via `@AppStorage("…v4.menubarStacked")` in `MenuBarPane.swift:105`; `…v4.snapStep`/`travelPastDays` live in `DaybreakDefaults.Keys` *and* are re-hardcoded in `TimeTravelPane.swift:12-13`; `…v4.textScale` is a literal in both `AppearancePane.swift:18` and `DaybreakRootView.swift:24`. `DaybreakDefaults.swift` itself documents this as temporary ("will be folded into DataStore's typed accessors … when the Settings window is rebuilt in Phase 3") — but Phase 3 shipped without the consolidation. **Latent desync hazard:** `DaybreakDefaults.snapStep`'s setter validates writes to `[5,15,30,60]`, but `TimeTravelPane.swift:13` writes the same key raw with no validation — two write paths, one key, divergent invariants. A typo in any literal silently desyncs the Settings UI from the renderer with **no compiler error**.
+
+**Proposed fix:** make `DaybreakDefaults.Keys` the single canonical home for every `…v4.*` string (add the missing ones: `textScale`, `menubarStacked`, `menubarColorDots`, `menubarPreset`, `cityColors`, `daybreakFloatingTopLeft`). Replace all `@AppStorage("…literal…")` and raw `UserDefaults.standard.object(forKey:)` sites with `@AppStorage(DaybreakDefaults.Keys.X)` / the typed accessors. Reconcile the unvalidated `snapStep` write path. Register defaults in `AppDefaults`. (`DaybreakEngineTests.swift:294` already uses `DaybreakDefaults.Keys.snapStep`, so the canonical constant is test-compatible.)
+
+### F29 — One-shot migration flags stored under raw, untyped UserDefaults keys in AppDelegate · `low`
+**`Meridian/AppDelegate.swift:243,258,280,283`**
+
+`"HasSetAutoUpdateDefault"`, `"HasFixedAutoUpdateSync"`, `"HasSetStartAtLoginDefault"` are read/written as inline string literals rather than via `UserDefaultKeys` (the Tahoe-onboarding and reopen-appearance flags *do* use typed constants, showing the inconsistency). The fresh-install detection cleverly reuses the *absence* of `"HasSetAutoUpdateDefault"` as a "brand-new install" proxy (line 283) — an implicit, load-bearing coupling between two unrelated flags (the launch-ordering dependency is even documented in a comment).
+
+**Proposed fix:** add the three constants to `UserDefaultKeys` **preserving the exact string values** (changing them would re-fire the one-shot migrations for existing users), then reference them in AppDelegate. Optionally introduce an explicit `hasCompletedFirstLaunch` flag so start-at-login detection no longer depends on the auto-update flag's side effect.
+
+### F24 — Panel update `Repeater` captures `self` strongly (retain cycle) · `low`
+**`Meridian/Panel/PanelController.swift:374-378`**
+
+`parentTimer = Repeater(…) { _ in DispatchQueue.main.async { self.updateTime() } }` captures `self` with no capture list. `Repeater` stores the observer closure strongly, and `self` owns `parentTimer`, so `PanelController → parentTimer → observers → closure → PanelController` is a cycle. **Dormant, not an active leak:** `PanelController` is a single app-lifetime instance and the timer is `nil`'d on minimize/close. It's inconsistent with the rest of the codebase, which correctly uses `[weak self]` (`StatusItemHandler.swift:343`, `DaybreakViewModel.swift:111`).
+
+**Proposed fix:**
+```swift
+parentTimer = Repeater(interval: .seconds(1), mode: .infinite) { [weak self] _ in
+    DispatchQueue.main.async { self?.updateTime() }
+}
+```
+
+### F27 — Per-access allocation of `TimezoneDataOperations` on the live menu-bar render path · `low`
+**`Meridian/Preferences/Menu Bar/StatusItemView.swift:63-65`**
+
+`operationsObject` is a *computed* property that allocates a new `TimezoneDataOperations` and re-resolves `DataStore.shared()` on **every** access — 1× per timezone per tick in single-line mode, 2× in stacked mode, on a cadence that can be per-second. The object is cheap, so the win is modest (one alloc + one singleton lookup per tick); this is cleanup, not a perf fix.
+
+**Proposed fix:** store the object and rebuild it in the existing `dataObject didSet` hook instead of recomputing per access. (The `shouldDisplay()`/UserDefaults reads inside the `compactMenu*` methods must still run every render and are unaffected.)
+
+### F28 — Duplicated menu-bar layout magic numbers · `low`
+**`Meridian/Preferences/Menu Bar/StatusContainerView.swift:8-38,100,164`**
+
+`StatusContainerView.compactWidth` uses bare literals `55/12/20/20` that duplicate the named `BufferWidthConstants` (`baseWidth/dayBuffer/twelveHourBuffer/dateBuffer`) in `StatusItemHandler.swift:13-18`; both feed parallel buffer-width math for the stacked layout. **Scope correction (from verification):** the dot-padding `14` is *not* duplicated across both files (it lives only in `StatusContainerView`), there is no shared `30` constant, and the divergence is confined to the opt-in **Stacked** preset (default off). Real but minor.
+
+**Proposed fix:** lift the shared geometry into one `enum MenubarLayoutConstants` referenced by both call sites.
+
+### F25 — Deprecated `UserDefaults.synchronize()` call · `low`
+**`Meridian/Preferences/Appearance/AppearanceViewController.swift:314`**
+
+The only `synchronize()` in the codebase, in the accent-color restart flow. Deprecated/discouraged by Apple since 10.12; UserDefaults persists automatically (backed by `cfprefsd`, visible cross-process), so it confers no correctness benefit even before spawning the fresh instance. Doubly inert since this legacy VC is behind the `useV4Settings` kill-switch.
+
+**Proposed fix:** delete the line. If/when the accent-restart flow is migrated to v4 settings, do not carry it over.
+
+---
+
+## Dead code (15)
+
+All 15 are confirmed unreferenced anywhere (Swift, IB, selectors, KVO, protocols, tests) and are safe to remove. All **`low`** — harmless cleanup with no behavioral/security/build impact (where a build-system step is needed, it's noted).
+
+| ID | Location | What | Note |
+|----|----------|------|------|
+| F1 | `Meridian/Overall App/Strings.swift:28` | `UserDefaultKeys.appleInterfaceStyleKey` (`"AppleInterfaceStyle"`) | Theme is observed via the `.interfaceStyleDidChange` notification, a *different* string. Clocker-era orphan. |
+| F2 | `Meridian/Overall App/Strings.swift:11` | `UserDefaultKeys.dragSessionKey` (`"public.text"`) | Drag-and-drop uses the separate typed `NSPasteboard.PasteboardType.dragSession`. Duplicate. |
+| F3 | `Meridian/Overall App/Strings.swift:33` | `UserDefaultKeys.nextUpdate` | Model archiving uses the *literal* `"nextUpdate"` coder key, not this constant. |
+| F4 | `Meridian/Preferences/General/TimezoneAdditionHandler.swift:272-278` | `private func showMessage()` | No call sites; offline-error UX handled inline elsewhere. |
+| F5 | `Meridian/Preferences/About/PointingHandCursorButton.swift` | `class PointingHandCursorButton` | Orphaned by the SwiftUI About migration; only reference is a test that exists to exercise it. |
+| F6 | `Meridian/CoreModelKit/Sources/CoreModelKit/SearchResults.swift` | `ResultStatus` / `SearchResult` / `Timezone` (whole file) | Google Geocoding/Timezone REST models; obsolete since the switch to `CLGeocoder`. |
+| F7 | `Meridian/Preferences/General/SearchDataSource.swift:21` | `private var dataTask: URLSessionDataTask?` | Never assigned/read; leftover from the old Google URLSession flow. |
+| F8 | `Meridian/Overall App/DateFormatterManager.swift:7,8,12` | `calendarDateFormatter`, `simpleFormatter`, `gregorianCalendar` | Three unused statics; the *used* `gregorianCalendar` lives in `TimezoneDataOperations`. |
+| F9 | `Meridian/Overall App/SettingsManager.swift:68-74` | `static func copySettingsToClipboard()` | No UI wires it; v4 settings only call `exportSettings()`/`importSettings()`. |
+| F10 | `Meridian/Preferences/Menu Bar/StatusItemHandler.swift:67,320-322` | `hasActiveIcon` + `@objc setHasActiveIcon(_:)` | Write-only property + setter with no callers/KVC consumers. |
+| F11 | `Meridian/Panel/PanelController.swift:398-400` | `func hasActivePanelGetter()` | Redundant wrapper; `hasActivePanel` is accessed directly. |
+| F12 | `Meridian/Preferences/General/PreferencesViewController.swift:348-350` | `@IBAction func sortOptions(_:)` | Not connected in `Preferences.storyboard`; `additionalSortOptions` visibility is set directly. |
+| F13 | `Meridian/Preferences/General/PreferencesViewController.swift:18` | `PreferencesConstants.hotKeyPathIdentifier` | Stale Cocoa-bindings KVC keypath; `GlobalShortcutMonitor` owns the real keys. |
+| F14 | `Meridian/Preferences/General/PreferencesViewController.swift:17` | `PreferencesConstants.offlineErrorMessage` | Production-unused; kept alive only by a tautological localization test. |
+| F15 | `Meridian/Panel/UI/Toasty.swift:97-99` | `enum ToastKeys { ActiveToast }` | Vestige of the upstream Toast-Swift associated-object key; never used. |
+
+**Two dead-code items need a build-system step (not just a line delete):**
+- **F5** — `PointingHandCursorButton.swift` is in the `.pbxproj` Sources phase and has a unit test (`MeridianUnitTests.swift` `testPointingHandButton`). Delete the file *from within Xcode* (prunes the 4 pbxproj refs) **and** remove the test, or the build/test breaks.
+- **F14** — removal must touch **three** spots or `testAllActiveKeysResolveToNonEmptyStrings` fails: the constant (`PreferencesViewController.swift:17`), the assertion (`LocalizationTests.swift:74`), the `activeKeys` entry (`LocalizationTests.swift:26`), and then the orphaned `Localizable.xcstrings` entry (line ~3319 + its 15 translations).
+
+---
+
+## Considered & dismissed (7 refuted — important context)
+
+The verifier **refused to confirm** these, and that judgment is worth recording so they aren't "re-discovered" later:
+
+- **v4 rollback scaffolding is NOT dead code (×3 candidates).** Three finders flagged the hardcoded `useDaybreakPanel = true` / `useV4Settings = true` flags and the "entire legacy panel/settings stack" as dead/deletable. **Refuted:** the legacy `PanelController`/`ParentPanelController`/`PreferencesViewController`/`AppearanceViewController`/storyboard classes have genuine references in the executed test target, in Interface Builder `customClass` bindings (`Preferences.storyboard`, `Panel.xib`, `HourMarkerViewItem.xib`), and in ungated production paths. The flags are a **deliberate, documented emergency-rollback lever** for the v4 beta. Only ~3 statically-unreachable `else`-branch lines are truly dead today. See the next section for the *post-GA* plan.
+- **Export-log "world-readable TOCTOU" — not exploitable.** The momentary `0o644` window is inert because every enclosing directory (sandbox container temp and `/var/folders/.../T`) is `0o700`-owned by the user; no other principal can traverse to the file. UUID filenames remove any predictable-path angle. The `0o600` chmod is harmless defense-in-depth, not a load-bearing control with a gap.
+- **Settings import "applies attacker JSON" — not a real flaw.** Requires deliberate user file-picker action, grants no capability the one-click toggles don't, toggles only the app's *own* login item, reaches no code-exec/arbitrary-FS sink under the sandbox, and the dangerous deserialization surface (timezone blobs) is already gated by `NSSecureCoding`. Defense-in-depth nicety at most.
+- **Force-unwrapped Control Center `URL` — not a crash/security issue.** `ControlCenterSettings.url` is a lazily-evaluated static (only on user click, never at launch), the string is a compile-time constant with no attacker input, and an existing CI test already asserts it parses.
+- **"Unbounded" static caches in `TimezoneDataOperations` — effectively bounded.** Keyed by timezone + *today's calendar day* (not the scrubbed slider date), so scrubbing/ticking cannot multiply entries; growth is a few hundred tiny tuples per long session. The genuinely hot Daybreak path uses a *different* cache that is already explicitly bounded to 512 with an `invalidate()`.
+
+---
+
+## SwiftLint summary (79 warnings, 0 errors)
+
+Non-blocking, but several overlap with the findings above. Dominant rules:
+- **`identifier_name`** — single-letter locals (`c/f/v/r/g/b/h/m`), heavily in `SettingsManager.swift` decode helpers (~31) and the Daybreak color/geometry code. Cosmetic.
+- **`type_body_length`** — `PanelController` (356), `TimezoneAdditionHandler` (347), `AppearanceViewController` (342). The first and third are legacy (kill-switched) classes; revisit during the post-GA cleanup.
+- **`cyclomatic_complexity`** ×3 + **`function_body_length`** ×1 — all in `SettingsManager.swift` decode paths (the v1/v2 back-compat import). Candidate for a focused refactor.
+- Minor singles: `trailing_comma` ×2, `function_parameter_count` (`DaybreakViewModel` 7, `TimezoneData.make` 6), `blanket_disable_command` ×2 (`DaybreakEngine`), `unneeded_override` (`TimezoneCellView:276`), `large_tuple` (`DaybreakTokens:194`).
+
+No `force_cast`/`force_try` (the two rules configured as **errors**).
+
+---
+
+## Forward-looking: the biggest debt reduction is *post-GA*, by design
+
+The single largest cleanup available is **retiring the v4 rollback scaffolding** once `4.0.0` GA has soaked and is confirmed stable:
+
+- Flip away from / remove the hardcoded `useDaybreakPanel` and `useV4Settings` flags in `AppDelegate.swift`.
+- Delete the now-superseded **legacy panel stack** (`PanelController`, `ParentPanelController`, the Modern Slider extensions, `NoTimezoneView`) and **legacy storyboard settings** (`PreferencesViewController`, `AppearanceViewController`, `Preferences.storyboard`) — and their tests (`PreferencesStoryboardTests`, the empty-state regression test).
+- This also retires several of the largest SwiftLint offenders (`PanelController`, `AppearanceViewController`) and makes F24/F25 moot.
+
+**Do not do this now.** While in beta, that code is the documented instant-rollback path and is still wired into context menus, the dock menu, the team-accent relaunch flow, and tests. It should be a **single dedicated PR after GA**, with the legacy paths removed atomically and the test target updated. Estimated ~2,000 lines. This is filed as its own tracking issue so it isn't forgotten.
+
+*— End of review. No files were modified. All proposed fixes are unapplied.*

--- a/docs/RELEASE_NOTES_4.0.0.md
+++ b/docs/RELEASE_NOTES_4.0.0.md
@@ -1,0 +1,56 @@
+# Meridian 4.0.0 — "Daybreak"
+
+Meridian 4.0 is the biggest release since 3.0 — a complete visual redesign built around a simple idea: a world clock should *feel* like the time of day, not just print it. The new **Daybreak** popover paints the sky for wherever you are right now, and every city shows whether the sun is up or down at a glance.
+
+Your cities, labels, favorites, and preferences all carry over automatically.
+
+---
+
+## A fresh look — the Daybreak redesign
+
+- **A living sky.** The popover's hero shifts through dawn, day, dusk, and night to match the real time of day at your current location, with a sun or moon disc that reflects the current phase.
+- **Sun & moon, everywhere.** Every city shows a sun or moon glyph that flips live as that city crosses its own sunrise and sunset.
+- **Redesigned city cards.** Each place shows its time, whether it's day or night there, and how far ahead or behind it is *relative to where you are right now*.
+- **A reimagined time-travel scrubber** with a tick ruler, day-boundary markers, and a centered handle carrying the current sun/moon.
+- **A brand-new native Settings window** with a clean sidebar: **Cities, Menu Bar, Appearance, Time Travel,** and **General**.
+- **A new "Midnight Sundial" app icon** and matching menu-bar icons.
+
+## New features
+
+- **Type a time to travel to it.** Double-click any time in the popover, type a new one (`3:30 PM`, `15:30`, `3pm`…), and every other clock instantly shows what it'd be there.
+- **Make each city yours.** Give any location a custom **label** and a per-city **color dot**.
+- **Home vs. current location.** Pick a **Home** city and let your **current location** follow your Mac's time zone as you travel — Meridian keeps them straight.
+- **Five menu-bar density presets** — *Compact, With day, With date, Dense 24h,* and *Mono* (no dots) — so the menu bar shows exactly what you want.
+- **New opt-in "Stacked" menu-bar layout** that stacks city name over time so more favorites fit in a narrow or notched menu bar.
+- **Accent color themes** to personalize switches, selections, and scrubber highlights.
+- **Adjustable text size** for the popover.
+- **Configurable time-travel range** and a snap step (5 / 15 / 30 / 60 min).
+- **Float the popover on top** and drag it anywhere — it remembers where you parked it.
+- **Copy all city times** to the clipboard from the footer as a clean, one-per-line list.
+
+## Improvements
+
+- **Smarter city search** that ranks results and handles UTC, spaces, and place names correctly, with full keyboard and hover navigation.
+- Newly added cities now **drop into their correctly sorted position**.
+- Your **current time zone is seeded automatically** whenever the city list is empty.
+- **Sort your cities** by time difference, name, or label, with a direction toggle.
+- The single-line menu-bar item is now **vertically centered**.
+- Your current location **stays pinned to system time**, so scrubbing never accidentally moves it.
+- **Full localization** of the new interface across all 15 supported languages.
+- Cleaner Settings with shaded command buttons and refreshed fresh-install defaults.
+
+## Fixes
+
+- Fixed city rows that could clip in the list.
+- Fixed a regression where the current time zone wasn't seeded on first run.
+- Fixed inconsistent labels in search results and partial-geocode artifacts.
+- Fixed time-travel so it snaps cleanly to the grid and aligns to day boundaries.
+- Restored the draggable floating popover and renamed the control from "Pin" to "Float."
+
+---
+
+## Upgrading
+
+Meridian updates itself — you'll be offered 4.0 automatically. Your time zones and settings are preserved across the upgrade. Want early access to future releases? Turn on **Settings → General → Receive beta releases**.
+
+<sub>Key PRs in this release: #140 (Daybreak redesign), #141 (localization), #142 & #143 (stacked menu-bar layout, settings polish, new icons).</sub>

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,3 @@
+title: Meridian
+description: A macOS menu-bar world clock — user manual & release notes
+theme: jekyll-theme-cayman

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,28 @@
+---
+title: Meridian
+---
+
+# Meridian
+
+A macOS menu-bar world clock. Keep the cities you care about a click away, see whether it's day or night in each one at a glance, and "time-travel" to find a moment that works across time zones.
+
+## Documentation
+
+- **[User Manual](manual.html)** — the complete guide to every setting and feature
+- **[What's new in 4.0.0 — "Daybreak"](RELEASE_NOTES_4.0.0.html)** — the latest release
+
+## Install
+
+```bash
+brew tap tpak/tpak
+brew install --cask meridian
+```
+
+Or download the latest build from the [Releases page](https://github.com/tpak/Meridian/releases).
+
+## Links
+
+- [Source code](https://github.com/tpak/Meridian)
+- [Report an issue](https://github.com/tpak/Meridian/issues)
+
+<sub>Meridian is open source and is a fork of <a href="https://github.com/n0shake/Clocker">Clocker</a> by Abhishek Banthia.</sub>

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,0 +1,341 @@
+---
+title: Meridian User Manual
+description: The complete guide to Meridian, the macOS menu-bar world clock.
+---
+
+# Meridian — User Manual
+
+**Meridian** is a macOS menu-bar world clock. It keeps the cities you care about a click away, shows you whether it's day or night in each one, and lets you "time-travel" to find a moment that works across time zones. This manual covers everything in version **4.0**.
+
+> New to 4.0? Meridian had a complete redesign called **Daybreak** — a sky that changes with the time of day, live sun/moon indicators, and a brand-new Settings window. If you're upgrading, your cities and preferences carry over automatically.
+
+---
+
+## Contents
+
+- [Installing Meridian](#installing-meridian)
+- [First launch](#first-launch)
+- [The Daybreak popover](#the-daybreak-popover)
+- [Adding & managing cities](#adding--managing-cities)
+- [The menu bar](#the-menu-bar)
+- [Time travel](#time-travel)
+- [Appearance](#appearance)
+- [Sunrise, sunset & day/night](#sunrise-sunset--daynight)
+- [Updates & the beta channel](#updates--the-beta-channel)
+- [Backing up & moving your settings](#backing-up--moving-your-settings)
+- [Keyboard shortcuts](#keyboard-shortcuts)
+- [Start at login](#start-at-login)
+- [Troubleshooting & FAQ](#troubleshooting--faq)
+- [Privacy](#privacy)
+- [Getting help](#getting-help)
+
+---
+
+## Installing Meridian
+
+The easiest way to install is with [Homebrew](https://brew.sh):
+
+```bash
+brew tap tpak/tpak
+brew install --cask meridian
+```
+
+Or download the latest `.zip` from the [Releases page](https://github.com/tpak/Meridian/releases), unzip it, and drag **Meridian.app** into your **Applications** folder.
+
+Meridian keeps itself up to date automatically, so you only have to install it once. See [Updates & the beta channel](#updates--the-beta-channel).
+
+<!-- screenshot: screenshots/menu-bar-item.png — Meridian's icon in the macOS menu bar -->
+
+---
+
+## First launch
+
+When you open Meridian, it appears in your **menu bar** (the strip at the top-right of your screen), not in the Dock. Look for the **Midnight Sundial** icon.
+
+- Meridian automatically adds **your current time zone** so the popover isn't empty.
+- **Click the menu-bar icon** to open the Daybreak popover; click again (or press `Esc`) to close it.
+
+### "I can't see the icon" (macOS Tahoe and later)
+
+On recent macOS versions, the system can hide menu-bar apps behind **Control Center**. The first time you launch, Meridian shows a one-time prompt explaining this — click **Open Control Center Settings** and switch Meridian **on**. If the icon ever goes missing later, open **Settings → General → "Can't see it in your menu bar?"** to jump straight back to that screen.
+
+---
+
+## The Daybreak popover
+
+Click the menu-bar icon to drop down the popover — a tidy card anchored under your menu-bar item.
+
+<!-- screenshot: screenshots/popover.png — the Daybreak popover with hero and city cards -->
+
+### The hero (your current location)
+
+The top section always shows **where you are right now**:
+
+- A large current time with AM/PM.
+- A label like **"DENVER · YOUR TIME"** (or **"… · CURRENT LOCATION"** when you're traveling away from your Home city).
+- A **living sky background** that shifts through dawn, day, dusk, and night to match the real time of day where you are, with a **sun or moon** disc in the corner.
+
+Hover over the small sub-line to flip it between the next sun event and a `UTC · weekday date` line.
+
+### City cards
+
+Below the hero, each city you track appears as a card:
+
+- On the left: a **sun/moon** disc (day or night there), the city's name, a **⌂ house badge** if it's your Home, and a small "next sun event" sub-label.
+- On the right: that city's **time** and how far **ahead or behind** it is *relative to where you are right now* (e.g. `+11:30`, `-4:30`). A day tag is added when the calendar day differs (e.g. `+11:30 · tmrw`).
+
+Every card's tint reflects whether it's day or night there, and all times update live every second.
+
+### The footer
+
+Along the bottom of the popover:
+
+- **Settings** — opens the Settings window (also `⌘,`).
+- **Copy icon** (two overlapping pages) — copies **every** city's name and time to your clipboard, one per line, current location first. The icon flashes a gold checkmark to confirm. (See [Copy all city times](#copy-all-city-times).)
+- **Float ▲ / Unfloat ▼** — keeps the popover open and floating above other windows. (See [Float on top](#float-the-popover).)
+- The current **version** (e.g. `v4.0.0`).
+
+---
+
+## Adding & managing cities
+
+Open **Settings → Cities** (`⌘,`, then choose **Cities** in the sidebar).
+
+<!-- screenshot: screenshots/settings-cities.png — the Cities settings pane -->
+
+### Add a city or time zone
+
+In the **"Add a city or timezone…"** search field, start typing a city, country, or time-zone name. Results appear below:
+
+- A **pin** icon means a geocoded city (with precise coordinates, for accurate sunrise/sunset).
+- A **globe** icon means a raw time zone.
+
+Click a result, or use the **↑ / ↓** arrow keys to highlight one and press **Return** to add it. Press **Esc** to clear the search. You can track up to **100** cities. Duplicate time zones are prevented automatically.
+
+### Each city row
+
+For every city in the list you can:
+
+- **★ Star it** — a filled star means the city appears in your **menu bar**. Only starred cities show in the menu bar.
+- **● Set a color dot** — click the colored circle to pick from the palette. This color is the dot shown beside that city in the menu bar.
+- **Rename it** — type a personal **Label** (e.g. "Home", "Mom") in the row's text field and press Return. The label replaces the city's name in the popover and menu bar.
+- **✕ Remove it** — click the ✕ on the right. (Your auto-detected current-location row can't be removed.)
+
+### Sort the list
+
+Use the **Sort** control to order your cities by **Time diff** (offset from where you are now), **Name**, or **Label**. Click the active option again to flip the direction (the caret toggles up/down). The popover follows the same order as the list.
+
+> The Cities list is sorted with the Sort control rather than dragged in this version.
+
+### Home & current location
+
+The **Locations** card at the top of the Cities pane has:
+
+- **Home** — pick the time zone you consider home. It's always marked with a **⌂ house** badge. When you travel away from Home, the hero switches to "CURRENT LOCATION" and Home appears as a normal city card.
+- **Currently in** — your auto-detected current time zone (read-only). Its row is badged **"Here"**. This follows your Mac as you travel.
+- **Pin to top** — when on (the default), your current time zone always appears first.
+
+---
+
+## The menu bar
+
+What shows in the menu bar depends on your starred cities:
+
+- **No starred cities** → just the Meridian icon.
+- **One or more starred cities** → their times, shown compactly.
+
+Configure this in **Settings → Menu Bar**. A **live preview** at the top of the pane shows your changes before you commit.
+
+<!-- screenshot: screenshots/settings-menubar.png — the Menu Bar settings pane with preset grid -->
+
+### Density presets
+
+Pick a preset card to set everything at once:
+
+| Preset | Example |
+|--------|---------|
+| **Compact** | `● IST 7:47 AM` |
+| **With day** | `● IST Mon 7:47 AM` |
+| **Dense · 24h** | `● IST 07:47` |
+| **With date** | `● IST 7:47 AM 13 Jun` |
+| **Mono · no dots** | `IST 7:47 AM` (no colored dot) |
+| **Stacked** | city name stacked over time (two lines) |
+
+The **Stacked** preset puts each city's name above its time, roughly halving the width per city — handy for a crowded or notched menu bar.
+
+### Fine-tune toggles
+
+Below the presets you can switch individual elements on or off: **Place name**, **Day of week**, **Date**, **24-hour time**, and **Color dots**. Adjusting any of these marks the active preset as "custom."
+
+### Where Meridian appears
+
+- **Show Meridian in** — choose **Menu Bar only** (no Dock icon) or **Dock & Menu Bar** (adds a Dock icon). Takes effect immediately.
+- When a Dock icon is shown, **right-click** it for quick actions: Toggle Panel, Settings, Check for Updates…, and Hide from Dock.
+
+### Float the popover
+
+The **Float on top** toggle (also available in the popover footer as **Float ▲**) keeps the popover open and above other windows. While floating, **drag it anywhere** by its background; it remembers where you left it. Click **Unfloat ▼** to re-anchor it under the menu-bar icon.
+
+---
+
+## Time travel
+
+Meridian lets you slide time forward and back to find a moment that works everywhere — all your cities update together.
+
+<!-- screenshot: screenshots/time-travel.png — the scrubber mid-travel with the readout pill -->
+
+### In the popover
+
+- **Drag the sun/moon handle** along the ruler below the city cards to glide through the next several hours (about **2 hours back to 12 hours ahead**). A pill above the track shows the offset and the resulting time (e.g. `+3:00 · 10:47 PM`). The handle's glyph flips between sun and moon as cities cross sunrise/sunset. A deliberate drag is required, so a stray click won't move it.
+- **Nudge arrows (‹ ›)** step the time by your **snap step** (5, 15, 30, or 60 minutes).
+- **Type a time to jump to it.** Double-click any time in the popover — the hero time or a city's time — and type a new one (`3:30 PM`, `15:30`, `3pm` all work). Press **Return** and every clock recomputes so that city reads the time you entered. This is how you jump **days** ahead or back.
+- **↺ Back to now** appears while you're traveling — click it to snap back to the present. Closing and reopening the popover also resets to now.
+
+### Settings → Time Travel
+
+<!-- screenshot: screenshots/settings-timetravel.png — the Time Travel settings pane -->
+
+- **Travel forward** — how many days ahead you can jump when typing a time (1–30 days; default 6).
+- **Travel back** — how many days back you can jump (0–7 days; `0` turns it off; default 2).
+- **Arrow / snap step** — the increment for the nudge arrows and grid alignment: **5 / 15 / 30 / 60 minutes** (default 15).
+- **Show Time Scroller** — show or hide the scrubber in the popover.
+
+> The drag scrubber always covers a compact, legible window (about 2 hours back to 12 hours forward) so the day-boundary markers stay readable. The **Travel forward / back** ranges set how far you can jump when you *type* a time.
+
+---
+
+## Appearance
+
+Open **Settings → Appearance**. A **PREVIEW** card at the bottom shows your changes live.
+
+<!-- screenshot: screenshots/settings-appearance.png — the Appearance settings pane -->
+
+- **Theme** — **Auto** (follow macOS), **Light**, or **Dark**. (Default: Light.)
+- **Accent color** — pick from a grid of **Formula 1 livery-inspired** palettes (Alpine, Aston Martin, Audi, Cadillac, Ferrari, Haas, McLaren, Mercedes, Racing Bulls, Red Bull Racing, Williams). The accent tints switches, selections, and scrubber highlights. (Default: Aston Martin.) *The palette names and colors are stylized tributes and are not affiliated with or endorsed by any Formula 1 team.* Changing the accent may prompt a quick restart so every control repaints.
+- **Time format** — **12-hour** or **24-hour**, applied everywhere (popover, menu bar, copied text). This is the same setting as the Menu Bar pane's 24-hour toggle.
+- **Day display** — how each city's day/date label reads: **Relative** (Today/Tomorrow/Yesterday-style), **Actual** (weekday), **Date**, or **Hide**.
+- **Sunrise / sunset** — show each city's next sun event (see below). (Default: off.)
+- **Text size** — scale the popover's text from **85% to 130%** (default 100%).
+
+---
+
+## Sunrise, sunset & day/night
+
+Meridian computes each city's **sunrise and sunset** from its real coordinates and the date, so the sun/moon discs, sky gradients, and card tints reflect actual day and night — including a short twilight window around dawn and dusk.
+
+Turn on **Settings → Appearance → Sunrise / sunset** to show each city's next event in its row (e.g. `↑ Sunrise 6:46 AM`, `↓ Sunset 8:28 PM`) and in the hero sub-line. When it's off, rows show the UTC offset instead.
+
+> Cities added by searching for a place name have precise coordinates and accurate sun times. A city added as a bare time zone uses an approximation until Meridian backfills its coordinates (usually by the next launch).
+
+---
+
+## Updates & the beta channel
+
+Meridian updates itself using [Sparkle](https://sparkle-project.org). Because it rarely needs to quit, updates install quietly in the background.
+
+In **Settings → General**:
+
+- **Auto-install updates** — when on (the default), new versions download and install automatically.
+- **Check for updates** — how often Meridian checks: **Manually**, **Daily**, or **Weekly**. The **Check Now** button checks immediately. The last-checked time is shown in the About block.
+- **Receive beta releases** — opt in to pre-release builds. *(These may have bugs.)* Turning it on triggers an immediate check. Beta testers automatically receive the final stable release when it ships, so you're never stuck on a beta.
+
+---
+
+## Backing up & moving your settings
+
+Everything you've configured — your cities, labels, colors, favorites, and preferences — can be exported to a file and restored later or on another Mac.
+
+In **Settings → General**:
+
+- **Export Settings…** — save a `.json` file (default `~/.meridian/meridian_settings.json`).
+- **Import Settings…** — load a previously exported file, replacing your current setup. Older exports from earlier Meridian versions are supported; a file from a *newer* version (or a corrupt file) is rejected with an explanation.
+
+Your **Start at login** preference is included in the export and re-applied to the real login item on import.
+
+### Debug logging
+
+If you're troubleshooting an issue (or a maintainer asks you to):
+
+1. Turn on **Settings → General → Debug logging**.
+2. Reproduce the problem.
+3. Click **Export Log** to save the log file and reveal it in Finder, then share it.
+
+The log is written to a private, user-only file. Turn debug logging back off when you're done.
+
+---
+
+## Keyboard shortcuts
+
+**While the popover is open:**
+
+| Shortcut | Action |
+|----------|--------|
+| `⌘,` | Open Settings |
+| `Esc` / `⌘W` | Close the popover |
+| `⌘C` | Copy your current location's time |
+| `⌘Q` | Quit Meridian |
+| Double-click a time | Edit it / jump to a specific time |
+
+### Copy all city times
+
+The **copy icon** in the popover footer copies every visible city to the clipboard as plain text, one `City · time` per line (current location first). It reflects any time-travel offset and your 12/24-hour setting — great for pasting "what time is the meeting everywhere" into a message.
+
+### Global hotkey
+
+Meridian supports a **system-wide hotkey** that toggles the popover from any app.
+
+> **Note for version 4.0:** the new Settings window doesn't yet include a control to *record* this shortcut. If you set one in an earlier version, it still works. A way to set it in the redesigned Settings is planned.
+
+---
+
+## Start at login
+
+Turn on **Settings → General → Start at login** to have Meridian launch automatically when you log in to macOS. It uses the modern macOS login-item service — no background helper app. (New installs enable this by default; if you previously turned it off, that choice is respected.)
+
+---
+
+## Troubleshooting & FAQ
+
+**The menu-bar icon disappeared.**
+macOS may have hidden it in Control Center. Open **Settings → General → "Can't see it in your menu bar?"** and switch Meridian on. (See [First launch](#first-launch).)
+
+**A city shows the wrong time.**
+Make sure you're not still time-traveling — click **↺ Back to now**, or close and reopen the popover. Times are derived from each zone's official rules, including daylight saving.
+
+**Sunrise/sunset isn't showing for a city.**
+Turn it on in **Settings → Appearance → Sunrise / sunset**. If a particular city still doesn't show times, it may have been added as a bare time zone without coordinates — remove it and re-add it by searching for the city name, or relaunch to let Meridian backfill coordinates.
+
+**My menu bar is too crowded with cities.**
+Star fewer cities, switch to a denser preset (**Dense · 24h** or **Mono**), or use the **Stacked** preset to fit more in a narrow/notched bar.
+
+**How do I show a Dock icon?**
+**Settings → Menu Bar → Show Meridian in → Dock & Menu Bar.**
+
+**Where are my settings stored?**
+In macOS user defaults for the app, plus any export you create at `~/.meridian/meridian_settings.json`. Use **Export/Import Settings** to back up or migrate.
+
+**How do I reset everything?**
+Remove your cities in **Settings → Cities** and reset preferences to taste. For a full reset, export your settings first (as a backup), then reinstall.
+
+---
+
+## Privacy
+
+Meridian is built to respect your privacy:
+
+- **No account, no sign-in, no analytics.** Your cities and preferences stay on your Mac.
+- **No third-party servers.** City search and coordinate look-ups use Apple's built-in geocoding on your device.
+- The only network activity is **checking for app updates** (Sparkle) against Meridian's public release feed.
+
+---
+
+## Getting help
+
+- **Found a bug or have an idea?** Open an issue: <https://github.com/tpak/Meridian/issues> (also linked from **Settings → General → Open an issue**).
+- **Source code:** <https://github.com/tpak/Meridian> (also **Settings → General → View source**).
+
+Meridian is open source, and is a fork of [Clocker](https://github.com/n0shake/Clocker) by Abhishek Banthia.
+
+---
+
+<sub>This manual documents Meridian 4.0. Screenshots are referenced as placeholders (<code>screenshots/…</code>) and will be added before publication.</sub>

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,0 +1,16 @@
+# Manual screenshots
+
+`docs/manual.md` references the images below as placeholders (`<!-- screenshot: screenshots/… -->`).
+Capture these before publishing the manual to GitHub Pages. Use a clean install with a few well-known cities (e.g. London, New York, Tokyo) and the default Aston Martin accent.
+
+| File | What to capture |
+|------|-----------------|
+| `menu-bar-item.png` | The Meridian icon (and a couple of starred cities) in the macOS menu bar. |
+| `popover.png` | The Daybreak popover: hero + 2–3 city cards + footer. |
+| `settings-cities.png` | Settings → Cities (Locations card, search, a few rows with star/color/label). |
+| `settings-menubar.png` | Settings → Menu Bar with the preset grid and live preview. |
+| `time-travel.png` | The popover mid-travel with the readout pill and "↺ Back to now". |
+| `settings-timetravel.png` | Settings → Time Travel (forward/back sliders, snap step). |
+| `settings-appearance.png` | Settings → Appearance with the accent grid and PREVIEW card. |
+
+Tips: the menu bar is 22 pt tall — capture it at 2× (Retina). Crop tightly and keep file sizes modest.


### PR DESCRIPTION
## What

Adds the first end-user documentation set for Meridian, plus a process guardrail to keep it current.

- **`docs/manual.md`** — a single-page user manual covering every shipping setting and feature, written against the **v4 UI** (Daybreak popover + the SwiftUI Settings panes), with Jekyll front-matter so it can be served by **GitHub Pages**. Screenshot placeholders (`<!-- screenshot: screenshots/… -->`) mark where images go.
- **`docs/RELEASE_NOTES_4.0.0.md`** — themed, user-facing "What's new in 4.0.0 (Daybreak)" covering everything since v3.1.3.
- **`docs/CODE_REVIEW_4.0.0.md`** — a dead-code / security / technical-debt review (report only — **no source changed**). 22 confirmed findings (0 high, 1 medium, 21 low), 7 refuted by adversarial verification. Findings tracked in issues **#144–#166**.
- **`docs/screenshots/README.md`** — the shot list for the manual.
- **`CLAUDE.md`** — Release Checklist **item 6** + a *User Documentation* section requiring `docs/manual.md` to be updated with every release.

## Notes

- No application source, storyboards, or project files were modified.
- The manual documents the v4 SwiftUI Settings (not the legacy storyboard settings behind the `useV4Settings`/`useDaybreakPanel` kill-switches), verified against `Preferences/V4Settings/*` and `Panel/Daybreak/*`.
- GitHub Pages will serve `docs/manual.md` once this merges to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
