### PR TITLE
refactor: tech-debt cleanup from code review 4.0.0 (#160-#165)

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -240,7 +240,7 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Auto-Update Default
 
     private func enableAutoUpdateByDefault() {
-        let hasSetAutoUpdate = "HasSetAutoUpdateDefault"
+        let hasSetAutoUpdate = UserDefaultKeys.hasSetAutoUpdateDefault
         if !UserDefaults.standard.bool(forKey: hasSetAutoUpdate) {
             UserDefaults.standard.set(true, forKey: hasSetAutoUpdate)
             updaterController.updater.automaticallyChecksForUpdates = true
@@ -255,7 +255,7 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
         // automaticallyDownloadsUpdates = true but automaticallyChecksForUpdates = false.
         // Sparkle requires both to be true for scheduled background checks to run,
         // so sync them once.
-        let hasFixedAutoUpdateSync = "HasFixedAutoUpdateSync"
+        let hasFixedAutoUpdateSync = UserDefaultKeys.hasFixedAutoUpdateSync
         if !UserDefaults.standard.bool(forKey: hasFixedAutoUpdateSync) {
             UserDefaults.standard.set(true, forKey: hasFixedAutoUpdateSync)
             if updaterController.updater.automaticallyDownloadsUpdates {
@@ -277,10 +277,10 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
     /// absence marks a brand-new install. MUST run BEFORE enableAutoUpdateByDefault(), which sets
     /// that flag.
     private func enableStartAtLoginByDefault() {
-        let hasSetStartAtLogin = "HasSetStartAtLoginDefault"
+        let hasSetStartAtLogin = UserDefaultKeys.hasSetStartAtLoginDefault
         guard !UserDefaults.standard.bool(forKey: hasSetStartAtLogin) else { return }
 
-        let isFreshInstall = !UserDefaults.standard.bool(forKey: "HasSetAutoUpdateDefault")
+        let isFreshInstall = !UserDefaults.standard.bool(forKey: UserDefaultKeys.hasSetAutoUpdateDefault)
         UserDefaults.standard.set(true, forKey: hasSetStartAtLogin)
         guard isFreshInstall else {
             Logger.production("Existing install — leaving start-at-login preference untouched")

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -28,6 +28,10 @@ public enum UserDefaultKeys {
     static let betaUpdatesEnabled = "com.tpak.meridian.betaUpdatesEnabled"
     static let latitude = "latitude"
     static let longitude = "longitude"
+    // One-shot install/migration flags — raw string values preserved from the pre-typed-key era; do NOT change.
+    static let hasSetAutoUpdateDefault = "HasSetAutoUpdateDefault"
+    static let hasFixedAutoUpdateSync = "HasFixedAutoUpdateSync"
+    static let hasSetStartAtLoginDefault = "HasSetStartAtLoginDefault"
 
     // MARK: - Modernized typed-storage keys (issue #97)
     // These replace the legacy inverted-bool / int-encoded keys above.

--- a/Meridian/Panel/Daybreak/CityColorStore.swift
+++ b/Meridian/Panel/Daybreak/CityColorStore.swift
@@ -9,7 +9,7 @@ import SwiftUI
 import AppKit
 
 enum CityColorStore {
-    private static let key = "com.tpak.meridian.v4.cityColors"
+    private static let key = DaybreakDefaults.Keys.cityColors
 
     /// The design's per-city swatch palette (Settings → Cities).
     static let palette: [String] = [

--- a/Meridian/Panel/Daybreak/DaybreakDefaults.swift
+++ b/Meridian/Panel/Daybreak/DaybreakDefaults.swift
@@ -4,9 +4,9 @@
 //
 // These are intentionally kept out of the carefully-migrated core (`Strings.swift` /
 // `AppDefaults` / `DataStore`) for the duration of the redesign: each accessor reads through a
-// sensible fallback, so no default-registration or migration is required to ship Phase 1. They
-// will be folded into `DataStore`'s typed accessors (and registered in `AppDefaults`) when the
-// Settings window is rebuilt in Phase 3.
+// sensible fallback, so no default-registration or migration is required to ship Phase 1. Every
+// v4 key string is now centralized in `Keys` below (the single source of truth); folding the typed
+// accessors into `DataStore` and registering defaults in `AppDefaults` remains a later step.
 
 import Foundation
 
@@ -22,6 +22,18 @@ enum DaybreakDefaults {
         static let snapStep = "com.tpak.meridian.v4.snapStep"
         /// Pin the current-location row to the top of the list (Settings → Cities; default on).
         static let pinCurrentToTop = "com.tpak.meridian.v4.pinCurrentToTop"
+        /// Popover text-scale factor 0.85–1.3 (Settings → Appearance → Text size; default 1.0).
+        static let textScale = "com.tpak.meridian.v4.textScale"
+        /// Show the leading color dot in the menu bar (Settings → Menu Bar; default on).
+        static let menubarColorDots = "com.tpak.meridian.v4.menubarColorDots"
+        /// Legacy two-line stacked menu-bar layout, opt-in via the "Stacked" preset (#142; default off).
+        static let menubarStacked = "com.tpak.meridian.v4.menubarStacked"
+        /// Active menu-bar density preset id (Settings → Menu Bar; default "compact").
+        static let menubarPreset = "com.tpak.meridian.v4.menubarPreset"
+        /// Per-city color-dot hex map, JSON-encoded (Settings → Cities).
+        static let cityColors = "com.tpak.meridian.v4.cityColors"
+        /// Saved top-left point of the floating popover.
+        static let daybreakFloatingTopLeft = "com.tpak.meridian.v4.daybreakFloatingTopLeft"
     }
 
     private static var standard: UserDefaults { .standard }

--- a/Meridian/Panel/Daybreak/DaybreakPanelController.swift
+++ b/Meridian/Panel/Daybreak/DaybreakPanelController.swift
@@ -237,7 +237,7 @@ final class DaybreakPanelController: NSWindowController, NSWindowDelegate {
 
     // MARK: Floating position persistence
 
-    private static let floatingTopLeftKey = "com.tpak.meridian.v4.daybreakFloatingTopLeft"
+    private static let floatingTopLeftKey = DaybreakDefaults.Keys.daybreakFloatingTopLeft
 
     private var savedFloatingTopLeft: NSPoint? {
         guard let pair = UserDefaults.standard.array(forKey: Self.floatingTopLeftKey) as? [Double],

--- a/Meridian/Panel/Daybreak/DaybreakRootView.swift
+++ b/Meridian/Panel/Daybreak/DaybreakRootView.swift
@@ -21,7 +21,7 @@ struct DaybreakRootView: View {
     @State private var didCopyAll = false
     @State private var copyFeedbackTask: Task<Void, Never>?
     @State private var lastThemeRaw = DataStore.shared().theme.rawValue
-    @AppStorage("com.tpak.meridian.v4.textScale") private var textScale = 1.0
+    @AppStorage(DaybreakDefaults.Keys.textScale) private var textScale = 1.0
     @AppStorage("showFutureSlider") private var showScrubber = true
 
     private var palette: DaybreakPalette {

--- a/Meridian/Panel/PanelController.swift
+++ b/Meridian/Panel/PanelController.swift
@@ -371,9 +371,9 @@ class PanelController: ParentPanelController {
     private func startTimer() {
         Logger.debug("Start timer called")
 
-        parentTimer = Repeater(interval: .seconds(1), mode: .infinite) { _ in
+        parentTimer = Repeater(interval: .seconds(1), mode: .infinite) { [weak self] _ in
             DispatchQueue.main.async {
-                self.updateTime()
+                self?.updateTime()
             }
         }
         parentTimer?.start()

--- a/Meridian/Preferences/Appearance/AppearanceViewController.swift
+++ b/Meridian/Preferences/Appearance/AppearanceViewController.swift
@@ -311,7 +311,6 @@ class AppearanceViewController: ParentViewController {
         // after the new instance launches; the user lands back where
         // they were instead of an empty menu bar app.
         UserDefaults.standard.set(true, forKey: UserDefaultKeys.reopenAppearanceOnLaunch)
-        UserDefaults.standard.synchronize()
 
         // Spawn a new instance, then terminate this one. `open -n` makes
         // the new instance start fresh rather than activating the

--- a/Meridian/Preferences/Menu Bar/StatusContainerView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusContainerView.swift
@@ -5,18 +5,18 @@ import CoreLoggerKit
 import CoreModelKit
 
 func compactWidth(for timezone: TimezoneData, with store: DataStore) -> Int {
-    var totalWidth = 55
+    var totalWidth = MenubarLayoutConstants.baseWidth
     let timeFormat = timezone.timezoneFormat(store.timezoneFormat())
 
     if store.shouldShowDayInMenubar() {
-        totalWidth += 12
+        totalWidth += MenubarLayoutConstants.dayBuffer
     }
 
     if timeFormat == DateFormat.twelveHour
         || timeFormat == DateFormat.twelveHourWithSeconds
         || timeFormat == DateFormat.twelveHourWithZero
         || timeFormat == DateFormat.twelveHourWithSeconds {
-        totalWidth += 20
+        totalWidth += MenubarLayoutConstants.twelveHourBuffer
     } else if timeFormat == DateFormat.twentyFourHour
         || timeFormat == DateFormat.twentyFourHourWithSeconds {
         totalWidth += 0
@@ -24,11 +24,11 @@ func compactWidth(for timezone: TimezoneData, with store: DataStore) -> Int {
 
     if timezone.shouldShowSeconds(store.timezoneFormat()) {
         // Slight buffer needed when the Menubar supplementary text was Mon 9:27:58 AM
-        totalWidth += 15
+        totalWidth += MenubarLayoutConstants.secondsBuffer
     }
 
     if store.shouldShowDateInMenubar() {
-        totalWidth += 20
+        totalWidth += MenubarLayoutConstants.dateBuffer
     }
 
     return totalWidth
@@ -97,7 +97,7 @@ class StatusContainerView: NSView {
                     // truncating the measurement itself.
                     let lineSize = compactModeTimeFont.size(for: operationObject.compactMenuOneLine(),
                                                             width: 1000, attributes: timeBasedAttributes)
-                    let dotPad: CGFloat = menubarColorDotsEnabled ? 14 : 0
+                    let dotPad: CGFloat = menubarColorDotsEnabled ? MenubarLayoutConstants.colorDotPadding : 0
                     return result + lineSize.width + dotPad + bufferWidth
                 }
                 let precalculatedWidth = Double(compactWidth(for: timezoneObject, with: store))
@@ -161,7 +161,7 @@ class StatusContainerView: NSView {
         if kMenubarV4SingleLine {
             let lineSize = compactModeTimeFont.size(for: operation.compactMenuOneLine(),
                                                     width: 1000, attributes: timeBasedAttributes)
-            let dotPad: CGFloat = menubarColorDotsEnabled ? 14 : 0
+            let dotPad: CGFloat = menubarColorDotsEnabled ? MenubarLayoutConstants.colorDotPadding : 0
             result = Int(lineSize.width + dotPad + bufferWidth)
         } else {
             let bestSize = compactModeTimeFont.size(for: operation.compactMenuSubtitle(),

--- a/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
@@ -10,11 +10,15 @@ internal enum MenubarState {
     case icon
 }
 
-private enum BufferWidthConstants {
+/// Shared menu-bar width geometry, referenced by both `bufferCalculatedWidth()` here and
+/// `compactWidth(for:with:)` in StatusContainerView so the two stay in sync.
+enum MenubarLayoutConstants {
     static let baseWidth = 55
     static let dayBuffer = 12
     static let twelveHourBuffer = 20
+    static let secondsBuffer = 15
     static let dateBuffer = 20
+    static let colorDotPadding: CGFloat = 14
 }
 
 private enum MenubarTimerConstants {
@@ -451,18 +455,18 @@ class StatusItemHandler: NSObject {
     }
 
     private func bufferCalculatedWidth() -> Int {
-        var totalWidth = BufferWidthConstants.baseWidth
+        var totalWidth = MenubarLayoutConstants.baseWidth
 
         if store.shouldShowDayInMenubar() {
-            totalWidth += BufferWidthConstants.dayBuffer
+            totalWidth += MenubarLayoutConstants.dayBuffer
         }
 
         if store.isBufferRequiredForTwelveHourFormats() {
-            totalWidth += BufferWidthConstants.twelveHourBuffer
+            totalWidth += MenubarLayoutConstants.twelveHourBuffer
         }
 
         if store.shouldShowDateInMenubar() {
-            totalWidth += BufferWidthConstants.dateBuffer
+            totalWidth += MenubarLayoutConstants.dateBuffer
         }
 
         return totalWidth

--- a/Meridian/Preferences/Menu Bar/StatusItemView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemView.swift
@@ -36,12 +36,12 @@ var kMenubarV4SingleLine: Bool { !menubarStackedLayoutEnabled }
 /// `UserDefaults.didChangeNotification`, which `StatusItemHandler` already observes to rebuild the
 /// menu-bar container with fresh `StatusItemView`s in the new layout.
 var menubarStackedLayoutEnabled: Bool {
-    UserDefaults.standard.object(forKey: "com.tpak.meridian.v4.menubarStacked") as? Bool ?? false
+    UserDefaults.standard.object(forKey: DaybreakDefaults.Keys.menubarStacked) as? Bool ?? false
 }
 
 /// Whether the leading color dot is shown (Settings → Menu Bar → Color dots; default on).
 var menubarColorDotsEnabled: Bool {
-    UserDefaults.standard.object(forKey: "com.tpak.meridian.v4.menubarColorDots") as? Bool ?? true
+    UserDefaults.standard.object(forKey: DaybreakDefaults.Keys.menubarColorDots) as? Bool ?? true
 }
 
 extension NSView {
@@ -60,9 +60,7 @@ class StatusItemView: NSView {
 
     private let locationView = NSTextField(labelWithString: "Hello")
     private let timeView = NSTextField(labelWithString: "Mon 19:14 PM")
-    private var operationsObject: TimezoneDataOperations {
-        return TimezoneDataOperations(with: dataObject, store: DataStore.shared())
-    }
+    private var operationsObject: TimezoneDataOperations!
     private lazy var paragraphStyle: NSMutableParagraphStyle = {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
@@ -111,6 +109,8 @@ class StatusItemView: NSView {
 
     var dataObject: TimezoneData! {
         didSet {
+            // Rebuild the operations object once per data change instead of on every render access.
+            operationsObject = TimezoneDataOperations(with: dataObject, store: DataStore.shared())
             initialSetup()
         }
     }

--- a/Meridian/Preferences/V4Settings/AppearancePane.swift
+++ b/Meridian/Preferences/V4Settings/AppearancePane.swift
@@ -15,7 +15,7 @@ struct AppearancePane: View {
     @AppStorage("timeFormat") private var timeFormat: TimeFormat = .twelveHour
     @AppStorage("relativeDate") private var dayDisplay: RelativeDateDisplay = .relative
     @AppStorage("showSunriseSunset") private var showSunriseSunset = false // matches AppDefaults
-    @AppStorage("com.tpak.meridian.v4.textScale") private var textScale = 1.0
+    @AppStorage(DaybreakDefaults.Keys.textScale) private var textScale = 1.0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/Meridian/Preferences/V4Settings/CitiesPane.swift
+++ b/Meridian/Preferences/V4Settings/CitiesPane.swift
@@ -16,7 +16,7 @@ struct CitiesPane: View {
     @ObservedObject var model: CityListModel
     let accent: Color
 
-    @AppStorage("com.tpak.meridian.v4.pinCurrentToTop") private var pinCurrentToTop = true
+    @AppStorage(DaybreakDefaults.Keys.pinCurrentToTop) private var pinCurrentToTop = true
     static let locationControlWidth: CGFloat = 200
 
     @State private var query = ""

--- a/Meridian/Preferences/V4Settings/MenuBarPane.swift
+++ b/Meridian/Preferences/V4Settings/MenuBarPane.swift
@@ -100,16 +100,16 @@ struct MenuBarPane: View {
     @AppStorage("showDayInMenubar") private var showDay = false
     @AppStorage("showDateInMenubar") private var showDate = false
     @AppStorage("timeFormat") private var timeFormat: TimeFormat = .twelveHour
-    @AppStorage("com.tpak.meridian.v4.menubarColorDots") private var menubarColorDots = true
+    @AppStorage(DaybreakDefaults.Keys.menubarColorDots) private var menubarColorDots = true
     // Legacy two-line stacked layout, opt-in via the "Stacked" preset (issue #142). Default off.
-    @AppStorage("com.tpak.meridian.v4.menubarStacked") private var menubarStacked = false
+    @AppStorage(DaybreakDefaults.Keys.menubarStacked) private var menubarStacked = false
 
     // Presentation + float
     @AppStorage("com.tpak.meridian.appDisplayOptions") private var appPresentation: AppPresentation = .menubarOnly
     @AppStorage("floatOnTop") private var floatOnTop = false
 
     // Active preset tracking
-    @AppStorage("com.tpak.meridian.v4.menubarPreset") private var activePresetID = "compact"
+    @AppStorage(DaybreakDefaults.Keys.menubarPreset) private var activePresetID = "compact"
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {

--- a/Meridian/Preferences/V4Settings/TimeTravelPane.swift
+++ b/Meridian/Preferences/V4Settings/TimeTravelPane.swift
@@ -9,8 +9,8 @@ struct TimeTravelPane: View {
     let accent: Color
 
     @AppStorage("sliderDayRange") private var forwardDays = 6
-    @AppStorage("com.tpak.meridian.v4.travelPastDays") private var backDays = 2
-    @AppStorage("com.tpak.meridian.v4.snapStep") private var snapStep = 15
+    @AppStorage(DaybreakDefaults.Keys.travelPastDays) private var backDays = 2
+    @AppStorage(DaybreakDefaults.Keys.snapStep) private var snapStep = 15
     @AppStorage("showFutureSlider") private var showFutureSlider = true
 
     var body: some View {


### PR DESCRIPTION
## What

Pays down the **technical-debt** findings from the 4.0.0 code review (tracked in #166). Kept on its own branch so it can be tested independently of the already-merged dead-code/security cleanup (#169).

| Finding | Change |
|---|---|
| **F23** (#160, medium) | Centralize **every** `com.tpak.meridian.v4.*` key in `DaybreakDefaults.Keys` (single source of truth) and replace all 12 hardcoded literals across 8 files with the constants. Removes the silent typo-desync hazard between the Settings UI and the renderers. **Key strings are byte-for-byte unchanged**, so persisted user prefs are preserved. |
| **F24** (#161) | `[weak self]` in `PanelController`'s per-second `Repeater` closure (breaks the retain cycle; matches the rest of the codebase). |
| **F25** (#162) | Drop the deprecated `UserDefaults.standard.synchronize()` call. |
| **F27** (#163) | Cache `TimezoneDataOperations` on `StatusItemView` (rebuilt in the existing `dataObject didSet`) instead of allocating one per render on the menu-bar tick. |
| **F28** (#164) | Hoist the duplicated menu-bar width literals (`55/12/20/15`) into a shared `MenubarLayoutConstants` enum referenced by both `StatusItemHandler.bufferCalculatedWidth()` and `StatusContainerView.compactWidth()`, plus the color-dot padding. |
| **F29** (#165) | Move `AppDelegate`'s one-shot migration flags to typed `UserDefaultKeys` (string values preserved so the one-shot migrations don't re-fire for existing users). |

## Validation
- `xcodebuild build` — **BUILD SUCCEEDED**
- `MeridianUnitTests` — **280 tests, 0 failures**
- SwiftLint — **0 errors** (79 pre-existing warnings, unchanged)
- Verified no `com.tpak.meridian.v4` string literals remain outside `DaybreakDefaults.Keys`, and no `BufferWidthConstants` references remain.

## Scope note
Per the F23 issue, full `AppDefaults` default-registration for the v4 keys is **intentionally still deferred** — `DaybreakDefaults` provides sensible read fallbacks, and registration was a separately-tracked "Phase 3" step. This PR delivers the single-source-of-truth consolidation (the part that removes the real desync risk).

Closes #160
Closes #161
Closes #162
Closes #163
Closes #164
Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
