### PR TITLE
feat: global-shortcut recorder in v4 Settings → General (#168)

### DIFF
--- a/Meridian/Preferences/V4Settings/GeneralPane.swift
+++ b/Meridian/Preferences/V4Settings/GeneralPane.swift
@@ -21,6 +21,7 @@ struct GeneralPane: View {
                 AutoUpdateRow(accent: accent)
                 BetaRow(accent: accent)
                 DebugRow(accent: accent)
+                GlobalShortcutRow()
             }
 
             UpdateFrequencyRow(accent: accent)
@@ -172,6 +173,40 @@ private struct DebugRow: View {
     var body: some View {
         ToggleRow(label: String(localized: "Debug logging"), accent: accent, isOn: $debugLogging)
             .accessibilityIdentifier("DebugLogging")
+    }
+}
+
+// MARK: - Global shortcut
+
+// Restores the global hotkey recorder that the legacy storyboard Preferences had (#168). Reuses the
+// existing AppKit `ShortcutRecorderButton` + `GlobalShortcutMonitor`, so a shortcut saved by an older
+// version keeps working and the on-disk storage (the `globalPing` key) is unchanged.
+private struct GlobalShortcutRow: View {
+    var body: some View {
+        FormRow(label: String(localized: "Global shortcut"),
+                note: String(localized: "Open Meridian from anywhere")) {
+            ShortcutRecorderField()
+                .frame(width: 180, height: 24)
+        }
+        .accessibilityIdentifier("GlobalShortcut")
+    }
+}
+
+// Hosts the AppKit recorder inside SwiftUI. Writing the captured combo to
+// `GlobalShortcutMonitor.shared.currentShortcut` auto-encodes it and re-registers the global monitor
+// (the toggle action itself is wired once by AppDelegate at launch). `nil` clears the shortcut.
+private struct ShortcutRecorderField: NSViewRepresentable {
+    func makeNSView(context _: Context) -> ShortcutRecorderButton {
+        let button = ShortcutRecorderButton(frame: .zero)
+        button.shortcutDidChange = { [weak button] combo in
+            GlobalShortcutMonitor.shared.currentShortcut = combo
+            button?.updateDisplay()
+        }
+        return button
+    }
+
+    func updateNSView(_ nsView: ShortcutRecorderButton, context _: Context) {
+        nsView.updateDisplay()
     }
 }
 


### PR DESCRIPTION
Restores the ability to set the **global keyboard shortcut** that toggles the Daybreak popover — missing since the v4 redesign moved Settings to SwiftUI (the recorder only lived in the now-disabled legacy storyboard).

### Approach (per design decision: General pane)
- New **"Global shortcut"** row in `GeneralPane`, right after the toggle group, matching the `FormRow` style.
- Wraps the existing AppKit **`ShortcutRecorderButton`** in a small `NSViewRepresentable` and writes the captured combo to **`GlobalShortcutMonitor.shared.currentShortcut`** — which auto-encodes to the `globalPing` key and re-registers the monitor.
- **No new dependencies**, and the storage format is unchanged, so a shortcut saved by a pre-4.0 version keeps working. The toggle action is still wired once by `AppDelegate` at launch.
- Esc / Delete clears the shortcut; a modifier (⌘/⌥/⌃) is required — same as the legacy recorder.

### Validation
- `xcodebuild build` — **BUILD SUCCEEDED**
- `MeridianUnitTests` — **280 tests, 0 failures**; SwiftLint **0 errors**
- ⚠️ **Needs a functional check** (not covered by unit tests): record a combo in Settings → General, then confirm it toggles the popover from another app, and that it persists across relaunch.

### Follow-up
- Two new UI strings ("Global shortcut", "Open Meridian from anywhere") are English-only for now; they should be added to the string catalog in the localization pass.

Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)