### PR TITLE
docs: changes-for-design-partner list

### DIFF
--- a/design_handoff_meridian_v4/CHANGES-FOR-DESIGN-PARTNER.md
+++ b/design_handoff_meridian_v4/CHANGES-FOR-DESIGN-PARTNER.md
@@ -1,0 +1,42 @@
+# Changes to share with the design partner
+
+A running list of where the shipped v4 app **adds to** or **diverges from** the handoff spec (`README.md` + the `*.dc.html` prototypes). The HTML is the canonical design; this doc is the back-channel for "here's what we built/changed — confirm it, or update the design." Keep it current as we ship.
+
+> Status legend: **Added** = new since the handoff · **Diverges** = ships differently than the spec; please confirm intended or update the HTML.
+
+---
+
+## Added since the handoff
+
+### Global keyboard shortcut recorder — Settings → General  *(Added, PR #174 / issue #168)*
+The v4 redesign moved Settings to SwiftUI and, in doing so, dropped the **global hotkey** that toggles the Daybreak popover (it only existed in the old storyboard Settings). We've **restored it** as a new **"Global shortcut"** row in the **General** pane (under the Debug-logging toggle), matching the `FormRow` layout: a 150px label + a recorder control + the note "Open Meridian from anywhere."
+- **It's not in the handoff** — the spec's General pane is login / updates / beta / debug / frequency / backup / about, with no shortcut control.
+- **Design ask:** the recorder currently reuses the **legacy AppKit button** (rounded bezel, "Click to Record Shortcut" / shows e.g. `⌘⌥M`), which is *not* in the v4 visual language. If you want it styled to match (e.g. a chip/segment that matches the accent + control radii), please add it to the Settings HTML and we'll re-skin.
+
+### Stacked menu-bar preset  *(Added — see [`STACKED-MENUBAR.md`](STACKED-MENUBAR.md))*
+A **6th** menu-bar preset, "Stacked" (city name over time, two lines), added beyond the spec's five density presets so more favorites fit a narrow/notched bar. Currently an interim restore of the pre-v4 two-line layout, not yet fully styled to v4.
+
+### Copy-all-cities footer action  *(Added — see [`COPY-ALL-CITIES.md`](COPY-ALL-CITIES.md))*
+A copy icon in the popover footer that copies every city's name + time to the clipboard.
+
+### Menu-bar glyph tightening  *(Added — see [`icons/MENUBAR-GLYPH-TIGHTENED.md`](icons/MENUBAR-GLYPH-TIGHTENED.md))*
+Adjustments to the menu-bar sundial glyph spacing.
+
+---
+
+## Diverges from the spec — please confirm intended or update the HTML
+
+These were verified against the shipping code (4.0.0-beta3x). Each may be a deliberate product call — flagging so design and build agree.
+
+| Area | Handoff spec says | Ships as | Note |
+|---|---|---|---|
+| **Time-travel scrubber range** | §F: drag spans the **Travel forward/back day window** (forward 14 default, back 2) with day-boundary markers | Live drag scrubber is **fixed to ~2h back / 12h forward**; the Settings day sliders bound the *typed-time* jump, not the drag | Biggest behavioral gap. Interim by design (a code note says the day sliders "will be reworked to hour-scale to drive this"). Confirm the intended scrubber model. |
+| **Accent palette** | McLaren · Ferrari · Mercedes · Red Bull · Williams · Alpine · **Graphite** · **Indigo**; default **McLaren** | 11 **F1-team liveries** (Alpine, Aston Martin, Audi, Cadillac, Ferrari, Haas, McLaren, Mercedes, Racing Bulls, Red Bull, Williams); default **Aston Martin**; **no Graphite/Indigo** | Palette set + default changed. Confirm the final list and default. |
+| **Day display default** | Appearance: **default Actual** | default **Relative** | Confirm default. |
+| **Sunrise/sunset default** | Appearance: **default on** | default **off** | Confirm default. |
+| **Theme default** | "real app follows macOS" (Auto) | default **Light** | Confirm whether default should be Auto. |
+| **Cities drag-to-reorder** | City rows have a **drag handle** to reorder | Drag-reorder is **inert**; ordering is via the **Sort** control only | Confirm: drop the handle from the design, or implement drag. |
+
+---
+
+*Maintainers: when you add a feature that isn't in the handoff, or knowingly ship something different from the prototype, add a row here so the design partner can keep the HTML as the single source of truth.*


### PR DESCRIPTION
Adds **`design_handoff_meridian_v4/CHANGES-FOR-DESIGN-PARTNER.md`** — a single running list of where the shipped v4 app **adds to** or **diverges from** the handoff spec, so the design partner can keep the HTML prototypes authoritative.

Seeded with:
- **Added:** the global-shortcut recorder (#174 / #168) — including the design ask that it currently uses the legacy AppKit recorder, not the v4 control style; plus links to the existing per-topic notes (stacked menu bar, copy-all-cities, menu-bar glyph).
- **Diverges (confirm intended):** time-travel scrubber range (fixed ~2h/12h vs the spec's day-window), accent palette + default (F1-only / Aston Martin vs McLaren + Graphite/Indigo), day-display default (Relative vs Actual), sunrise/sunset default (off vs on), theme default (Light vs Auto), and Cities drag-to-reorder (inert vs a drag handle).

All deviations were verified against the shipping code. Trim/adjust any that are already settled with the partner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)