### PR TITLE
fix: smaller popover shadow + remove top notch artifact

### DIFF
--- a/Meridian/Panel/Daybreak/DaybreakPanelController.swift
+++ b/Meridian/Panel/Daybreak/DaybreakPanelController.swift
@@ -16,7 +16,7 @@ final class DaybreakPanelController: NSWindowController, NSWindowDelegate {
     private var cancellables = Set<AnyCancellable>()
 
     // Chrome insets baked into DaybreakRootView (transparent margin around the 378px body for the
-    // shadow + notch). Used to align the body under the status item.
+    // shadow). Used to align the body under the status item.
     private let bodyInsetX: CGFloat = 40
     private let bodyTopInset: CGFloat = 14
     private let bodyWidth: CGFloat = 378

--- a/Meridian/Panel/Daybreak/DaybreakRootView.swift
+++ b/Meridian/Panel/Daybreak/DaybreakRootView.swift
@@ -2,7 +2,7 @@
 //
 // DaybreakRootView — the SwiftUI root hosted inside the menu-bar panel. Composes the hero, the city
 // cards, the scrubber, and the footer, and draws the popover chrome (378px body, 18px radius,
-// hairline border, soft shadow, top notch). Owns the inline time-edit state shared by the hero and
+// hairline border, soft shadow). Owns the inline time-edit state shared by the hero and
 // rows, and resolves light/dark from the user's Theme preference (README §1 surfaces).
 
 import SwiftUI
@@ -75,7 +75,6 @@ struct DaybreakRootView: View {
         .background(palette.surface)
         .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
         .overlay(RoundedRectangle(cornerRadius: 18, style: .continuous).stroke(palette.hairline, lineWidth: 1))
-        .overlay(alignment: .topTrailing) { notch(snapshot) }
         .shadow(color: palette.shadowColor, radius: palette.shadowRadius, y: palette.shadowY)
         .padding(.horizontal, 40)
         .padding(.top, 14)
@@ -172,14 +171,6 @@ struct DaybreakRootView: View {
         }
     }
 
-    private func notch(_ snapshot: DaybreakSnapshot) -> some View {
-        UpTriangle()
-            .fill(DaybreakSky.notchColor(for: snapshot.hero.phase))
-            .frame(width: 18, height: 9)
-            .padding(.trailing, 51)
-            .offset(y: -8)
-    }
-
     // MARK: Inline edit
 
     private func beginEdit(id: String, time: String, period: String) {
@@ -196,17 +187,5 @@ struct DaybreakRootView: View {
 
     private func cancelEdit() {
         editingID = nil
-    }
-}
-
-/// Upward-pointing triangle for the popover notch.
-private struct UpTriangle: Shape {
-    func path(in rect: CGRect) -> Path {
-        var path = Path()
-        path.move(to: CGPoint(x: rect.midX, y: rect.minY))
-        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY))
-        path.addLine(to: CGPoint(x: rect.minX, y: rect.maxY))
-        path.closeSubpath()
-        return path
     }
 }

--- a/Meridian/Panel/Daybreak/DaybreakTokens.swift
+++ b/Meridian/Panel/Daybreak/DaybreakTokens.swift
@@ -82,7 +82,7 @@ struct DaybreakPalette {
         dayTick: rgb(255, 255, 255, 0.50),
         foot: rgb(235, 235, 245, 0.50),
         footVersion: rgb(235, 235, 245, 0.30),
-        shadowColor: rgb(0, 0, 0, 0.55), shadowRadius: 35, shadowY: 28
+        shadowColor: rgb(0, 0, 0, 0.45), shadowRadius: 18, shadowY: 8
     )
 
     static let light = DaybreakPalette(
@@ -97,7 +97,7 @@ struct DaybreakPalette {
         dayTick: rgb(0, 0, 0, 0.42),
         foot: rgb(60, 60, 67, 0.55),
         footVersion: rgb(60, 60, 67, 0.32),
-        shadowColor: rgb(0, 0, 0, 0.18), shadowRadius: 35, shadowY: 28
+        shadowColor: rgb(0, 0, 0, 0.16), shadowRadius: 18, shadowY: 8
     )
 
     static func resolve(_ scheme: ColorScheme) -> DaybreakPalette {
@@ -121,7 +121,7 @@ struct DaybreakPalette {
     var editFieldBorder: Color { isDark ? rgb(255, 255, 255, 0.30) : rgb(0, 0, 0, 0.20) }
 }
 
-/// Hero sky gradient + notch color, keyed by the current location's phase (README §C).
+/// Hero sky gradient, keyed by the current location's phase (README §C).
 enum DaybreakSky {
     /// 135° gradient ≈ top-leading → bottom-trailing.
     static func gradient(for phase: DayPhase) -> LinearGradient {
@@ -134,16 +134,6 @@ enum DaybreakSky {
         case .dawn:  return [rgb(70, 64, 111), rgb(255, 158, 109)] // #46406f → #ff9e6d
         case .day:   return [rgb(52, 80, 127), rgb(111, 147, 196)] // #34507f → #6f93c4
         case .dusk:  return [rgb(58, 47, 94), rgb(255, 122, 89)]   // #3a2f5e → #ff7a59
-        }
-    }
-
-    /// The notch (small triangle pointing at the menu-bar item) matches the gradient's top color.
-    static func notchColor(for phase: DayPhase) -> Color {
-        switch phase {
-        case .night: return rgb(16, 18, 43)
-        case .dawn:  return rgb(70, 64, 111)
-        case .day:   return rgb(52, 80, 127)
-        case .dusk:  return rgb(58, 47, 94)
         }
     }
 }

--- a/design_handoff_meridian_v4/CHANGES-FOR-DESIGN-PARTNER.md
+++ b/design_handoff_meridian_v4/CHANGES-FOR-DESIGN-PARTNER.md
@@ -36,6 +36,8 @@ These were verified against the shipping code (4.0.0-beta3x). Each may be a deli
 | **Sunrise/sunset default** | Appearance: **default on** | default **off** | Confirm default. |
 | **Theme default** | "real app follows macOS" (Auto) | default **Light** | Confirm whether default should be Auto. |
 | **Cities drag-to-reorder** | City rows have a **drag handle** to reorder | Drag-reorder is **inert**; ordering is via the **Sort** control only | Confirm: drop the handle from the design, or implement drag. |
+| **Popover drop shadow** | Popover §1: "large soft drop shadow" | Reduced to a smaller, window-like shadow (radius 35→18, y-offset 28→8) | UAT: the large shadow read heavy next to standard macOS windows (Settings / Finder). Confirm the lighter shadow, or update the spec. |
+| **Popover top notch** | Popover §1: "small notch at top pointing to the menu-bar item" | **Removed** | Read as a stray artifact (especially while floating, detached from the bar) with no clear purpose. Confirm removal, or restyle if it should stay. |
 
 ---
 


### PR DESCRIPTION
Two popover polish fixes from UAT, plus the matching design-partner notes.

- **Shadow:** the Daybreak popover drew a heavy, offset shadow (radius 35, y 28, 0.55 opacity dark) that looked oversized next to standard macOS windows. Reduced to a window-like shadow (**radius 18, y 8, 0.45/0.16 opacity**) closer to Settings/Finder.
- **Notch:** removed the small up-pointer artifact at the top of the popover (and its now-dead helpers `notch(_:)`, `UpTriangle`, `DaybreakSky.notchColor`) — it read as a stray mark, especially while floating.
- **Docs:** added both to `design_handoff_meridian_v4/CHANGES-FOR-DESIGN-PARTNER.md` as divergences from the handoff (spec called for a large shadow + a notch).

Build + 280 unit tests green; swiftlint 0 errors. Visual change — best verified in a running build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)