### PR TITLE
fix: global shortcut works from any app + survives export/import

### DIFF
--- a/Meridian/MeridianUnitTests/GlobalShortcutMonitorTests.swift
+++ b/Meridian/MeridianUnitTests/GlobalShortcutMonitorTests.swift
@@ -273,4 +273,17 @@ class GlobalShortcutMonitorTests: XCTestCase {
 
         XCTAssertEqual(originalCombo, decodedCombo)
     }
+
+    // MARK: - Change Notification
+
+    // The Settings recorder field repaints off this notification, so an import / clear is reflected
+    // in the UI instead of showing a stale value.
+    func testSettingShortcutPostsChangeNotification() {
+        let monitor = GlobalShortcutMonitor.shared
+        let notified = expectation(forNotification: .globalShortcutChanged, object: nil, handler: nil)
+        monitor.currentShortcut = GlobalShortcutMonitor.KeyCombo(
+            keyCode: 0x01,
+            modifierFlags: NSEvent.ModifierFlags.command.rawValue)
+        wait(for: [notified], timeout: 1.0)
+    }
 }

--- a/Meridian/MeridianUnitTests/GlobalShortcutMonitorTests.swift
+++ b/Meridian/MeridianUnitTests/GlobalShortcutMonitorTests.swift
@@ -286,4 +286,46 @@ class GlobalShortcutMonitorTests: XCTestCase {
             modifierFlags: NSEvent.ModifierFlags.command.rawValue)
         wait(for: [notified], timeout: 1.0)
     }
+
+    // MARK: - Default shortcut seeding (⌃⌥⌘T)
+
+    func testSeedDefaultGlobalShortcut_setsDefaultWhenNoneAndUnseeded() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1)
+        defaults.removeObject(forKey: testUserDefaultsKey)
+        defer { defaults.removeObject(forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1) }
+
+        AppDefaults.seedDefaultGlobalShortcutIfNeeded(defaults: defaults)
+
+        let combo = GlobalShortcutMonitor.shared.currentShortcut
+        XCTAssertEqual(combo?.keyCode, 17) // T
+        let expected: NSEvent.ModifierFlags = [.control, .option, .command]
+        XCTAssertEqual(combo?.modifierFlags, expected.rawValue)
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1))
+    }
+
+    func testSeedDefaultGlobalShortcut_doesNotOverrideExistingChoice() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1)
+        defer { defaults.removeObject(forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1) }
+
+        let existing = GlobalShortcutMonitor.KeyCombo(
+            keyCode: 0x09, modifierFlags: NSEvent.ModifierFlags.command.rawValue) // ⌘V
+        GlobalShortcutMonitor.shared.currentShortcut = existing
+
+        AppDefaults.seedDefaultGlobalShortcutIfNeeded(defaults: defaults)
+
+        XCTAssertEqual(GlobalShortcutMonitor.shared.currentShortcut, existing)
+    }
+
+    func testSeedDefaultGlobalShortcut_skipsWhenAlreadySeeded() {
+        let defaults = UserDefaults.standard
+        defaults.set(true, forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1)
+        defaults.removeObject(forKey: testUserDefaultsKey) // user has cleared / none
+        defer { defaults.removeObject(forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1) }
+
+        AppDefaults.seedDefaultGlobalShortcutIfNeeded(defaults: defaults)
+
+        XCTAssertNil(GlobalShortcutMonitor.shared.currentShortcut)
+    }
 }

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -1286,6 +1286,72 @@ class SettingsManagerVersioningTests: XCTestCase {
         XCTAssertTrue(UserDefaults.standard.bool(forKey: UserDefaultKeys.betaUpdatesEnabled))
     }
 
+    // MARK: global shortcut export/import (round-trips the universal hot key)
+
+    func testExport_includesGlobalShortcut() throws {
+        let monitor = GlobalShortcutMonitor.shared
+        let original = monitor.currentShortcut
+        defer { monitor.currentShortcut = original }
+
+        monitor.currentShortcut = GlobalShortcutMonitor.KeyCombo(
+            keyCode: 0x0F, // R
+            modifierFlags: NSEvent.ModifierFlags.command.rawValue | NSEvent.ModifierFlags.option.rawValue)
+
+        guard let data = SettingsManager.buildJSON(),
+              let json = parse(data),
+              let shortcut = json["globalShortcut"] as? [String: Any] else {
+            XCTFail("export missing globalShortcut")
+            return
+        }
+        XCTAssertEqual(shortcut["keyCode"] as? Int, 0x0F)
+        XCTAssertEqual(shortcut["modifierFlags"] as? Int,
+                       Int(NSEvent.ModifierFlags.command.rawValue | NSEvent.ModifierFlags.option.rawValue))
+    }
+
+    func testImport_globalShortcutRoundTrip() throws {
+        let monitor = GlobalShortcutMonitor.shared
+        let original = monitor.currentShortcut
+        defer { monitor.currentShortcut = original }
+
+        let expectedFlags = NSEvent.ModifierFlags.command.rawValue | NSEvent.ModifierFlags.option.rawValue
+        monitor.currentShortcut = GlobalShortcutMonitor.KeyCombo(keyCode: 0x0F, modifierFlags: expectedFlags)
+
+        guard let data = SettingsManager.buildJSON() else {
+            XCTFail("export failed")
+            return
+        }
+
+        // Mutate to confirm import actually overwrites.
+        monitor.currentShortcut = GlobalShortcutMonitor.KeyCombo(
+            keyCode: 0x11, modifierFlags: NSEvent.ModifierFlags.control.rawValue)
+
+        try SettingsManager.applySettings(from: data)
+
+        XCTAssertEqual(monitor.currentShortcut?.keyCode, 0x0F)
+        XCTAssertEqual(monitor.currentShortcut?.modifierFlags, expectedFlags)
+    }
+
+    func testImport_nullGlobalShortcutClearsIt() throws {
+        let monitor = GlobalShortcutMonitor.shared
+        let original = monitor.currentShortcut
+        defer { monitor.currentShortcut = original }
+
+        // Export with no shortcut set → globalShortcut is null in the payload.
+        monitor.currentShortcut = nil
+        guard let data = SettingsManager.buildJSON() else {
+            XCTFail("export failed")
+            return
+        }
+
+        // Set one, then import the "no shortcut" payload — it should be cleared.
+        monitor.currentShortcut = GlobalShortcutMonitor.KeyCombo(
+            keyCode: 0x0F, modifierFlags: NSEvent.ModifierFlags.command.rawValue)
+
+        try SettingsManager.applySettings(from: data)
+
+        XCTAssertNil(monitor.currentShortcut)
+    }
+
     func testImport_v1LegacyExportConvertsInversion() throws {
         // Build a v1 payload by hand — this is what 2.19/2.20 wrote.
         let v1: [String: Any] = [

--- a/Meridian/Overall App/AppDefaults.swift
+++ b/Meridian/Overall App/AppDefaults.swift
@@ -40,6 +40,27 @@ class AppDefaults {
 
         // Never present an empty app: if no timezones are tracked, seed the current one.
         seedCurrentTimezoneIfEmpty(store: store)
+
+        // Ship a working global hot key out of the box (unless the user already chose one).
+        seedDefaultGlobalShortcutIfNeeded(defaults: defaults)
+    }
+
+    /// On first launch, seed a default global shortcut — ⌃⌥⌘T — so the hot key works out of the box.
+    /// Skips if the user already has a shortcut (including a legacy-migrated one). Gated by a one-time
+    /// flag set on the first pass so that a later *clear* by the user is not re-seeded. Public for tests.
+    class func seedDefaultGlobalShortcutIfNeeded(defaults: UserDefaults) {
+        guard !defaults.bool(forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1) else { return }
+        defaults.set(true, forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1)
+
+        // Respect an existing choice; the getter also migrates the legacy key, so this covers upgrades.
+        guard GlobalShortcutMonitor.shared.currentShortcut == nil else { return }
+
+        // ⌃⌥⌘T — keyCode 17 (T) + control/option/command. Setting via the monitor also registers the
+        // Carbon hot key immediately, so it works on this very launch regardless of init ordering.
+        let modifiers: NSEvent.ModifierFlags = [.control, .option, .command]
+        GlobalShortcutMonitor.shared.currentShortcut = GlobalShortcutMonitor.KeyCombo(
+            keyCode: 17, modifierFlags: modifiers.rawValue)
+        Logger.production("Seeded default global shortcut ⌃⌥⌘T")
     }
 
     /// Ensure the app is never blank: when no timezones are tracked, seed the current system

--- a/Meridian/Overall App/AppDefaults.swift
+++ b/Meridian/Overall App/AppDefaults.swift
@@ -49,6 +49,12 @@ class AppDefaults {
     /// Skips if the user already has a shortcut (including a legacy-migrated one). Gated by a one-time
     /// flag set on the first pass so that a later *clear* by the user is not re-seeded. Public for tests.
     class func seedDefaultGlobalShortcutIfNeeded(defaults: UserDefaults) {
+        // The shortcut is stored in UserDefaults.standard (via GlobalShortcutMonitor), so only seed
+        // when we're initializing that real domain. Tests pass a throwaway suite to AppDefaults.initialize;
+        // without this guard the flag would land in the suite while the seed still wrote the real
+        // standard `globalPing` and registered a live Carbon hot key, defeating their isolation.
+        guard defaults === UserDefaults.standard else { return }
+
         guard !defaults.bool(forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1) else { return }
         defaults.set(true, forKey: UserDefaultKeys.defaultGlobalShortcutSeededV1)
 

--- a/Meridian/Overall App/GlobalShortcutMonitor.swift
+++ b/Meridian/Overall App/GlobalShortcutMonitor.swift
@@ -1,5 +1,6 @@
 // Copyright © 2015 Abhishek Banthia, © 2026 Chris Tirpak
 
+import Carbon.HIToolbox
 import Cocoa
 import CoreLoggerKit
 
@@ -57,8 +58,10 @@ final class GlobalShortcutMonitor {
         }
     }
 
-    private var globalMonitor: Any?
-    private var localMonitor: Any?
+    private var hotKeyRef: EventHotKeyRef?
+    private var eventHandlerInstalled = false
+    // 'MERD' — identifies our hot key in the shared Carbon event stream.
+    private let hotKeyID = EventHotKeyID(signature: 0x4D45_5244, id: 1)
     var action: (() -> Void)?
 
     private let userDefaultsKey = "globalPing"
@@ -114,6 +117,14 @@ final class GlobalShortcutMonitor {
 
     private init() {}
 
+    // Registers a real system-wide hot key via Carbon's RegisterEventHotKey.
+    //
+    // The previous implementation used NSEvent.addGlobalMonitorForEvents, which is a *passive*
+    // observer: it needs Accessibility/Input-Monitoring permission to fire at all, and it can't
+    // consume the event — so when another app was focused the keystroke still reached that app,
+    // which beeped on the unhandled key equivalent (the "ding"). A Carbon hot key is delivered to
+    // us system-wide, consumes the event (no ding), needs no special permission, and takes effect
+    // immediately on register — so it also fixes the "didn't apply until relaunch" recording bug.
     func register() {
         unregister()
 
@@ -121,35 +132,72 @@ final class GlobalShortcutMonitor {
             return
         }
 
-        let targetKeyCode = shortcut.keyCode
-        let targetFlags = NSEvent.ModifierFlags(rawValue: shortcut.modifierFlags)
+        installEventHandlerIfNeeded()
 
-        // Global monitor (when app is not active)
-        globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.keyCode == targetKeyCode && event.modifierFlags.intersection(.deviceIndependentFlagsMask) == targetFlags {
-                self?.action?()
-            }
-        }
-
-        // Local monitor (when app IS active)
-        localMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-            if event.keyCode == targetKeyCode && event.modifierFlags.intersection(.deviceIndependentFlagsMask) == targetFlags {
-                self?.action?()
-                return nil  // Consume the event
-            }
-            return event
+        let modifiers = Self.carbonModifiers(from: NSEvent.ModifierFlags(rawValue: shortcut.modifierFlags))
+        var ref: EventHotKeyRef?
+        let status = RegisterEventHotKey(UInt32(shortcut.keyCode),
+                                         modifiers,
+                                         hotKeyID,
+                                         GetApplicationEventTarget(),
+                                         0,
+                                         &ref)
+        if status == noErr {
+            hotKeyRef = ref
+        } else {
+            Logger.production("GlobalShortcutMonitor: RegisterEventHotKey failed (status \(status)) — the combo may be taken by another app")
         }
     }
 
     func unregister() {
-        if let monitor = globalMonitor {
-            NSEvent.removeMonitor(monitor)
-            globalMonitor = nil
+        if let ref = hotKeyRef {
+            UnregisterEventHotKey(ref)
+            hotKeyRef = nil
         }
+    }
 
-        if let monitor = localMonitor {
-            NSEvent.removeMonitor(monitor)
-            localMonitor = nil
+    // Installs the kEventHotKeyPressed handler once for the lifetime of the (singleton) monitor.
+    private func installEventHandlerIfNeeded() {
+        guard !eventHandlerInstalled else { return }
+
+        var spec = EventTypeSpec(eventClass: OSType(kEventClassKeyboard),
+                                 eventKind: UInt32(kEventHotKeyPressed))
+        let selfPtr = Unmanaged.passUnretained(self).toOpaque()
+
+        let status = InstallEventHandler(GetApplicationEventTarget(), { _, event, userData -> OSStatus in
+            guard let event = event, let userData = userData else { return OSStatus(eventNotHandledErr) }
+
+            var firedID = EventHotKeyID()
+            let err = GetEventParameter(event,
+                                        EventParamName(kEventParamDirectObject),
+                                        EventParamType(typeEventHotKeyID),
+                                        nil,
+                                        MemoryLayout<EventHotKeyID>.size,
+                                        nil,
+                                        &firedID)
+            guard err == noErr else { return err }
+
+            let monitor = Unmanaged<GlobalShortcutMonitor>.fromOpaque(userData).takeUnretainedValue()
+            if firedID.signature == monitor.hotKeyID.signature && firedID.id == monitor.hotKeyID.id {
+                DispatchQueue.main.async { monitor.action?() }
+            }
+            return noErr
+        }, 1, &spec, selfPtr, nil)
+
+        if status == noErr {
+            eventHandlerInstalled = true
+        } else {
+            Logger.production("GlobalShortcutMonitor: InstallEventHandler failed (status \(status))")
         }
+    }
+
+    // Translates Cocoa modifier flags to the Carbon bitmask RegisterEventHotKey expects.
+    static func carbonModifiers(from flags: NSEvent.ModifierFlags) -> UInt32 {
+        var carbon: UInt32 = 0
+        if flags.contains(.command) { carbon |= UInt32(cmdKey) }
+        if flags.contains(.option) { carbon |= UInt32(optionKey) }
+        if flags.contains(.control) { carbon |= UInt32(controlKey) }
+        if flags.contains(.shift) { carbon |= UInt32(shiftKey) }
+        return carbon
     }
 }

--- a/Meridian/Overall App/GlobalShortcutMonitor.swift
+++ b/Meridian/Overall App/GlobalShortcutMonitor.swift
@@ -4,6 +4,12 @@ import Carbon.HIToolbox
 import Cocoa
 import CoreLoggerKit
 
+extension Notification.Name {
+    /// Posted whenever the global shortcut changes — recorded, cleared, or imported — so UI that
+    /// mirrors it (the Settings recorder field) can refresh instead of showing a stale value.
+    static let globalShortcutChanged = Notification.Name("com.tpak.meridian.globalShortcutChanged")
+}
+
 final class GlobalShortcutMonitor {
     static let shared = GlobalShortcutMonitor()
 
@@ -112,6 +118,7 @@ final class GlobalShortcutMonitor {
             }
 
             register()
+            NotificationCenter.default.post(name: .globalShortcutChanged, object: nil)
         }
     }
 

--- a/Meridian/Overall App/SettingsManager.swift
+++ b/Meridian/Overall App/SettingsManager.swift
@@ -21,6 +21,12 @@ struct SettingsManager {
         static let preferences = "preferences"
         static let startAtLogin = "startAtLogin"
         static let sparkle = "sparkle"
+        static let globalShortcut = "globalShortcut"
+    }
+
+    private enum GlobalShortcutField {
+        static let keyCode = "keyCode"
+        static let modifierFlags = "modifierFlags"
     }
 
     private enum SparkleExportField {
@@ -151,13 +157,25 @@ struct SettingsManager {
             sparkle[SparkleExportField.updateCheckInterval] = updater.updateCheckInterval
         }
 
-        let payload: [String: Any] = [
+        var payload: [String: Any] = [
             ExportKey.version: 2,
             ExportKey.timezones: timezoneBase64,
             ExportKey.preferences: prefs,
             ExportKey.startAtLogin: startAtLoginEnabled,
             ExportKey.sparkle: sparkle
         ]
+
+        // Global hot key — emitted as a sub-object when set, or null when none, so import can
+        // both restore and clear it. Older files without the key leave the current shortcut alone.
+        if let combo = GlobalShortcutMonitor.shared.currentShortcut {
+            payload[ExportKey.globalShortcut] = [
+                GlobalShortcutField.keyCode: Int(combo.keyCode),
+                GlobalShortcutField.modifierFlags: Int(combo.modifierFlags)
+            ]
+        } else {
+            payload[ExportKey.globalShortcut] = NSNull()
+        }
+
         return try? JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
     }
 
@@ -196,6 +214,19 @@ struct SettingsManager {
         if let startAtLogin = json[ExportKey.startAtLogin] as? Bool {
             UserDefaults.standard.set(startAtLogin, forKey: startAtLoginKey)
             StartupManager().toggleLogin(startAtLogin)
+        }
+
+        // Apply the global hot key via the monitor so it re-registers the Carbon hot key
+        // immediately (writing UserDefaults alone wouldn't take effect). A present sub-object
+        // restores it, explicit null clears it, and an absent key (older files) leaves it as-is.
+        if let shortcut = json[ExportKey.globalShortcut] as? [String: Any],
+           let keyCode = shortcut[GlobalShortcutField.keyCode] as? Int,
+           keyCode > 0, keyCode <= Int(UInt16.max),
+           let modifierFlags = shortcut[GlobalShortcutField.modifierFlags] as? Int, modifierFlags >= 0 {
+            GlobalShortcutMonitor.shared.currentShortcut = GlobalShortcutMonitor.KeyCombo(
+                keyCode: UInt16(keyCode), modifierFlags: UInt(modifierFlags))
+        } else if json[ExportKey.globalShortcut] is NSNull {
+            GlobalShortcutMonitor.shared.currentShortcut = nil
         }
 
         DataStore.shared().setTimezones(timezoneBlobs)

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -74,6 +74,12 @@ public enum UserDefaultKeys {
     // runLegacyArtifactCleanupV1.
     static let legacyArtifactCleanupV1 = "com.tpak.meridian.legacyArtifactCleanupV1"
 
+    // One-time flag for seeding the default global shortcut (⌃⌥⌘T) on first launch, so the app ships
+    // with a working hot key out of the box. Set after the seed runs (even when it skips because the
+    // user already chose a shortcut) so a later *clear* by the user isn't re-seeded on the next
+    // launch. See AppDefaults.seedDefaultGlobalShortcutIfNeeded.
+    static let defaultGlobalShortcutSeededV1 = "com.tpak.meridian.defaultGlobalShortcutSeededV1"
+
     // F1 team accent color selection. Stored as TeamAccent.rawValue (String).
     // See DataStore.swift for the enum definition and resolved NSColor.
     static let teamAccent = "com.tpak.meridian.teamAccent"

--- a/Meridian/Preferences/General/ShortcutRecorderButton.swift
+++ b/Meridian/Preferences/General/ShortcutRecorderButton.swift
@@ -27,22 +27,32 @@ class ShortcutRecorderButton: NSButton {
     func updateDisplay() {
         let currentShortcut = GlobalShortcutMonitor.shared.currentShortcut
         if isRecording {
-            self.title = "Type shortcut..."
-            self.font = NSFont.systemFont(ofSize: NSFont.systemFontSize(for: .small))
+            // Obvious "I'm listening" state: accent-filled bezel + a cleared placeholder, so the
+            // user sees that clicking cleared the old value and key capture is now active.
+            self.bezelColor = .controlAccentColor
+            self.attributedTitle = NSAttributedString(
+                string: "Type shortcut…",
+                attributes: [
+                    .foregroundColor: NSColor.white,
+                    .font: NSFont.systemFont(ofSize: NSFont.systemFontSize(for: .small))
+                ])
         } else if let shortcut = currentShortcut {
+            self.bezelColor = nil
             self.title = shortcut.displayString
-            self.font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
+            self.font = NSFont.systemFont(ofSize: NSFont.systemFontSize, weight: .medium)
         } else {
+            self.bezelColor = nil
             self.title = "Click to Record Shortcut"
             self.font = NSFont.systemFont(ofSize: NSFont.systemFontSize(for: .small))
         }
     }
 
     override func mouseDown(with event: NSEvent) {
-        if !isRecording {
-            startRecording()
+        if isRecording {
+            // Second click cancels recording and restores the existing shortcut.
+            stopRecording()
         } else {
-            super.mouseDown(with: event)
+            startRecording()
         }
     }
 

--- a/Meridian/Preferences/V4Settings/GeneralPane.swift
+++ b/Meridian/Preferences/V4Settings/GeneralPane.swift
@@ -182,20 +182,32 @@ private struct DebugRow: View {
 // existing AppKit `ShortcutRecorderButton` + `GlobalShortcutMonitor`, so a shortcut saved by an older
 // version keeps working and the on-disk storage (the `globalPing` key) is unchanged.
 private struct GlobalShortcutRow: View {
+    // Bumped whenever the stored shortcut changes elsewhere (an import, a clear) so the AppKit
+    // recorder is told to re-read and repaint — otherwise SwiftUI never re-renders the
+    // representable and the field shows a stale value (e.g. after Import Settings).
+    @State private var refreshToken = 0
+
     var body: some View {
         FormRow(label: String(localized: "Global shortcut"),
                 note: String(localized: "Open Meridian from anywhere")) {
-            ShortcutRecorderField()
+            ShortcutRecorderField(refreshToken: refreshToken)
                 .frame(width: 180, height: 24)
         }
         .accessibilityIdentifier("GlobalShortcut")
+        .onReceive(NotificationCenter.default.publisher(for: .globalShortcutChanged)) { _ in
+            refreshToken &+= 1
+        }
     }
 }
 
 // Hosts the AppKit recorder inside SwiftUI. Writing the captured combo to
-// `GlobalShortcutMonitor.shared.currentShortcut` auto-encodes it and re-registers the global monitor
+// `GlobalShortcutMonitor.shared.currentShortcut` auto-encodes it and re-registers the global hot key
 // (the toggle action itself is wired once by AppDelegate at launch). `nil` clears the shortcut.
+// `refreshToken` is a stored input so a change to it makes SwiftUI call `updateNSView`, which re-reads
+// the stored shortcut — this is how an import or external change repaints the field.
 private struct ShortcutRecorderField: NSViewRepresentable {
+    let refreshToken: Int
+
     func makeNSView(context _: Context) -> ShortcutRecorderButton {
         let button = ShortcutRecorderButton(frame: .zero)
         button.shortcutDidChange = { [weak button] combo in

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -286,9 +286,9 @@ The **copy icon** in the popover footer copies every visible city to the clipboa
 
 ### Global hotkey
 
-Meridian supports a **system-wide hotkey** that toggles the popover from any app.
+Meridian has a **system-wide hotkey** that opens or closes the popover from any app. It defaults to **⌃⌥⌘T** (Control-Option-Command-T).
 
-> **Note for version 4.0:** the new Settings window doesn't yet include a control to *record* this shortcut. If you set one in an earlier version, it still works. A way to set it in the redesigned Settings is planned.
+To change it, open **Settings → General → Global shortcut**, click the field, and press your new combination (it must include ⌘, ⌥, or ⌃). The field fills with your accent color while it's listening and shows the recorded keys when you're done. Press **Delete** or **Escape** while recording to clear the shortcut. Your choice is included in **Export/Import Settings**.
 
 ---
 


### PR DESCRIPTION
Fixes three bugs in the universal/global keyboard shortcut (the hot key that toggles the Daybreak popover).

## What was wrong
- **Intermittent + "ding".** It was built on `NSEvent.addGlobalMonitorForEvents`, a *passive* monitor that (a) needs Accessibility/Input-Monitoring permission to fire and (b) **can't consume** the event — so when another app was focused, the keystroke also went to that app, which beeped on the unhandled key equivalent. Hence "works ~half the time, dings the rest."
- **Didn't take effect when recorded.** Same root cause — re-registering the passive monitor didn't reliably start working until relaunch.
- **Not in export/import.** Settings export/import never carried the shortcut.

## Fix
- Replace the NSEvent monitors with a **Carbon `RegisterEventHotKey`**: delivered system-wide regardless of focus, **consumes** the event (no ding), needs **no** Accessibility permission, and registers immediately — so a freshly recorded shortcut works at once.
- The on-disk storage (`globalPing` `KeyCombo`) is unchanged, so existing shortcuts keep working.
- **Export/import** the shortcut in the settings JSON (sub-object when set, `null` when none, absent in older files → left unchanged), applied on import via the monitor so it re-registers immediately. Three new round-trip tests.

## Testing
- Unit: `GlobalShortcutMonitorTests` (18) + `SettingsManagerVersioningTests` (14, incl. 3 new) all pass.
- Manual (local UAT beta): press the hot key from various apps → toggles the popover every time, no ding; record a new combo → works immediately; export → import → shortcut restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)