### PR TITLE
Name the menu-bar measured-seconds buffer (F28 straggler)

### DIFF
--- a/Meridian/Preferences/Menu Bar/StatusContainerView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusContainerView.swift
@@ -108,7 +108,7 @@ class StatusContainerView: NSView {
                                                                    width: precalculatedWidth,
                                                                    attributes: timeBasedAttributes)
                 let showSeconds = timezoneObject.shouldShowSeconds(store.timezoneFormat())
-                let secondsBuffer: CGFloat = showSeconds ? 7 : 0
+                let secondsBuffer: CGFloat = showSeconds ? MenubarLayoutConstants.measuredSecondsBuffer : 0
                 return result + max(calculatedTitleSize.width, calculatedSubtitleSize.width) + bufferWidth + secondsBuffer
             }
 

--- a/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
@@ -19,6 +19,10 @@ enum MenubarLayoutConstants {
     static let secondsBuffer = 15
     static let dateBuffer = 20
     static let colorDotPadding: CGFloat = 14
+    // Extra room added to the font-measured two-line width when seconds are
+    // shown, so the trailing ":58" isn't clipped. Distinct from secondsBuffer
+    // above, which pads the pre-calculated width budget.
+    static let measuredSecondsBuffer: CGFloat = 7
 }
 
 private enum MenubarTimerConstants {


### PR DESCRIPTION
Follow-up to #164 (menu-bar magic-number de-duplication): the `7` in `StatusContainerView`'s two-line width *measurement* closure was the one magic number that survived, because it's a local `CGFloat` distinct from the existing `Int` `MenubarLayoutConstants.secondsBuffer` (15) used in the pre-calculated width path.

Extracted it to `MenubarLayoutConstants.measuredSecondsBuffer = 7`.

- Pure readability refactor — value unchanged, **no behavior change**
- Build: SUCCEEDED
- Not user-facing; no release needed (will ride the next release)