### PR TITLE
Fix city-list edits lost at launch and menu-bar time lag

### DIFF
--- a/Meridian/AppDelegate.swift
+++ b/Meridian/AppDelegate.swift
@@ -180,21 +180,26 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func backfillMissingCoordinates() {
         let store = DataStore.shared()
-        var timezones = store.timezones()
-        var indicesToBackfill: [(Int, TimezoneData)] = []
+        var timezonesToBackfill: [TimezoneData] = []
 
-        for (index, data) in timezones.enumerated() {
+        for data in store.timezones() {
             guard let timezone = TimezoneData.customObject(from: data) else { continue }
             if timezone.latitude == nil || timezone.longitude == nil,
                let timezoneID = timezone.timezoneID, !timezoneID.isEmpty {
-                indicesToBackfill.append((index, timezone))
+                timezonesToBackfill.append(timezone)
             }
         }
 
-        guard !indicesToBackfill.isEmpty else { return }
+        guard !timezonesToBackfill.isEmpty else { return }
 
         backfillTask = Task { @MainActor in
-            for (index, timezone) in indicesToBackfill {
+            // Geocode first, accumulating results keyed by stable identity. Each
+            // await can take seconds; writing the launch-time snapshot back after
+            // that window would silently wipe any city the user added, removed,
+            // or reordered in the meantime (CityListModel.add stores plain
+            // timezones with nil coordinates precisely for this backfill).
+            var geocoded: [String: (latitude: Double, longitude: Double)] = [:]
+            for timezone in timezonesToBackfill {
                 let components = (timezone.timezoneID ?? "").split(separator: "/")
                 guard let cityComponent = components.last else { continue }
                 let cityName = cityComponent.replacingOccurrences(of: "_", with: " ")
@@ -202,12 +207,44 @@ open class AppDelegate: NSObject, NSApplicationDelegate {
                     Logger.debug("Coordinate backfill skipped for \(cityName)")
                     continue
                 }
-                timezone.latitude = place.coordinate.latitude
-                timezone.longitude = place.coordinate.longitude
-                guard let encoded = NSKeyedArchiver.secureArchive(with: timezone) else { continue }
-                timezones[index] = encoded
+                geocoded[Self.backfillIdentity(for: timezone)] = (place.coordinate.latitude,
+                                                                  place.coordinate.longitude)
             }
-            store.setTimezones(timezones)
+
+            guard !geocoded.isEmpty else { return }
+
+            // Re-read fresh and merge with no suspension point between the read
+            // and the write — DataStore mutations are main-actor serialized, so
+            // this read-merge-write is atomic with respect to user edits.
+            let merged = Self.mergeBackfilledCoordinates(current: store.timezones(),
+                                                         geocoded: geocoded)
+            store.setTimezones(merged)
+        }
+    }
+
+    /// Stable identity used to match a geocoded result back to a row that may
+    /// have moved while the geocoder was running. placeID + timezoneID mirrors
+    /// `TimezoneData.isEqual` — plain timezones can share a placeID, so the
+    /// timezoneID disambiguates.
+    static func backfillIdentity(for timezone: TimezoneData) -> String {
+        "\(timezone.placeID ?? "")|\(timezone.timezoneID ?? "")"
+    }
+
+    /// Pure merge step for the coordinate backfill: for every current entry
+    /// that still lacks coordinates and has a geocoded match, fill them in.
+    /// Entries added, removed, or reordered since geocoding started pass
+    /// through untouched. Static (no state) so unit tests can drive it directly.
+    static func mergeBackfilledCoordinates(current: [Data],
+                                           geocoded: [String: (latitude: Double, longitude: Double)]) -> [Data] {
+        return current.map { blob in
+            guard let timezone = TimezoneData.customObject(from: blob),
+                  timezone.latitude == nil || timezone.longitude == nil,
+                  let coordinate = geocoded[backfillIdentity(for: timezone)] else {
+                return blob
+            }
+            timezone.latitude = coordinate.latitude
+            timezone.longitude = coordinate.longitude
+            return NSKeyedArchiver.secureArchive(with: timezone) ?? blob
         }
     }
 

--- a/Meridian/MeridianUnitTests/AppDelegateTests.swift
+++ b/Meridian/MeridianUnitTests/AppDelegateTests.swift
@@ -137,4 +137,52 @@ class AppDelegateTests: XCTestCase {
                        "Beta opt-in must allow the \"beta\" channel")
     }
 
+    // Coordinate backfill merge. Geocoding a city takes seconds per await, so
+    // the user can add/remove cities while the backfill task is suspended. The
+    // merge must apply geocoded coordinates onto a FRESH read of the store —
+    // matched by stable identity, not array position — so those edits survive.
+    func testMergeBackfilledCoordinatesKeepsUserEdits() throws {
+        // Launch state: two plain-timezone rows awaiting coordinates.
+        let tokyo = TimezoneData()
+        tokyo.timezoneID = "Asia/Tokyo"
+        tokyo.formattedAddress = "Tokyo"
+
+        let paris = TimezoneData()
+        paris.timezoneID = "Europe/Paris"
+        paris.formattedAddress = "Paris"
+
+        // While the geocoder ran, the user removed Paris and added Auckland
+        // (a geocoded search result that already carries real coordinates).
+        let auckland = TimezoneData()
+        auckland.timezoneID = "Pacific/Auckland"
+        auckland.formattedAddress = "Auckland"
+        auckland.latitude = -36.8485
+        auckland.longitude = 174.7633
+
+        let tokyoBlob = try XCTUnwrap(NSKeyedArchiver.secureArchive(with: tokyo))
+        let aucklandBlob = try XCTUnwrap(NSKeyedArchiver.secureArchive(with: auckland))
+
+        // Both launch-time rows finished geocoding, including the removed one.
+        let geocoded: [String: (latitude: Double, longitude: Double)] = [
+            AppDelegate.backfillIdentity(for: tokyo): (35.6762, 139.6503),
+            AppDelegate.backfillIdentity(for: paris): (48.8566, 2.3522)
+        ]
+
+        let merged = AppDelegate.mergeBackfilledCoordinates(current: [tokyoBlob, aucklandBlob],
+                                                            geocoded: geocoded)
+
+        XCTAssertEqual(merged.count, 2, "merge must preserve the current list, not the launch snapshot")
+
+        let mergedTokyo = try XCTUnwrap(TimezoneData.customObject(from: merged[0]))
+        XCTAssertEqual(mergedTokyo.timezoneID, "Asia/Tokyo")
+        XCTAssertEqual(mergedTokyo.latitude, 35.6762, "surviving row gains its geocoded coordinates")
+        XCTAssertEqual(mergedTokyo.longitude, 139.6503)
+
+        let mergedAuckland = try XCTUnwrap(TimezoneData.customObject(from: merged[1]))
+        XCTAssertEqual(mergedAuckland.timezoneID, "Pacific/Auckland", "city added during backfill must survive")
+        XCTAssertEqual(mergedAuckland.latitude, -36.8485, "existing coordinates are left untouched")
+
+        XCTAssertFalse(merged.contains { TimezoneData.customObject(from: $0)?.timezoneID == "Europe/Paris" },
+                       "city removed during backfill must not be resurrected")
+    }
 }

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -429,6 +429,39 @@ class MeridianUnitTests: XCTestCase {
         defaults.removePersistentDomain(forName: "HomeRowMigrationTest_Dedup")
     }
 
+    func testHomeRowMigrationKeepsFirstFlaggedRowWhenNoMatch() throws {
+        let defaults = UserDefaults(suiteName: "HomeRowMigrationTest_NoMatch")!
+        defaults.removePersistentDomain(forName: "HomeRowMigrationTest_NoMatch")
+
+        // Both rows flagged, NEITHER matches the machine's current timezone
+        // (candidates are filtered so the test stays hermetic wherever it runs).
+        // Documented contract: keep the first flagged row rather than clearing
+        // the flag on every row and leaving no current-location marker at all.
+        let systemTimezoneID = TimeZone.autoupdatingCurrent.identifier
+        let staleZones = ["Asia/Tokyo", "Europe/Paris", "Australia/Melbourne"]
+            .filter { $0 != systemTimezoneID }
+
+        let first = TimezoneData()
+        first.timezoneID = staleZones[0]
+        first.isSystemTimezone = true
+
+        let second = TimezoneData()
+        second.timezoneID = staleZones[1]
+        second.isSystemTimezone = true
+
+        let firstBlob = try XCTUnwrap(NSKeyedArchiver.secureArchive(with: first))
+        let secondBlob = try XCTUnwrap(NSKeyedArchiver.secureArchive(with: second))
+
+        let healed = AppDefaults.runHomeRowMigrationV1(on: [firstBlob, secondBlob], defaults: defaults)
+        let healedFirst = try XCTUnwrap(TimezoneData.customObject(from: healed[0]))
+        let healedSecond = try XCTUnwrap(TimezoneData.customObject(from: healed[1]))
+
+        XCTAssertTrue(healedFirst.isSystemTimezone, "first flagged row keeps the flag when nothing matches")
+        XCTAssertFalse(healedSecond.isSystemTimezone, "every other flagged row is cleared")
+
+        defaults.removePersistentDomain(forName: "HomeRowMigrationTest_NoMatch")
+    }
+
     func testSeedsCurrentTimezoneAsCurrentLocationWhenEmpty() {
         let suite = "SeedTest_Empty"
         let defaults = UserDefaults(suiteName: suite)!
@@ -957,6 +990,21 @@ class BoolSemanticsMigrationTests: XCTestCase {
 
         XCTAssertNil(defaults.object(forKey: UserDefaultKeys.sunriseSunsetTime))
         XCTAssertNil(defaults.object(forKey: UserDefaultKeys.showDayInMenu))
+    }
+
+    func testInvertedBool_garbageLegacyValueLeavesModernKeyAtDefault() {
+        // An unexpected legacy value type used to fall back to 1 (= hidden),
+        // silently disabling a feature the user may have had on. It must
+        // instead write nothing so the registered default applies.
+        defaults.set("not a number", forKey: UserDefaultKeys.displayFutureSliderKey)
+
+        AppDefaults.runBoolSemanticsMigration(on: defaults)
+
+        let p = persistent()
+        XCTAssertNil(p[UserDefaultKeys.showFutureSlider],
+                     "uninterpretable legacy value must not write the modern key")
+        XCTAssertNil(defaults.object(forKey: UserDefaultKeys.displayFutureSliderKey),
+                     "the garbage legacy key is still cleaned up")
     }
 
     // MARK: non-inverted bool

--- a/Meridian/Overall App/AppDefaults.swift
+++ b/Meridian/Overall App/AppDefaults.swift
@@ -204,9 +204,10 @@ class AppDefaults {
         }
 
         // Decide which single row (if any) should keep the flag. Prefer a
-        // flagged row that matches the current system tz; otherwise prefer
-        // the first flagged row whose stored timezoneID matches; otherwise
-        // an unflagged row whose timezoneID matches the system tz.
+        // flagged row that matches the current system tz; otherwise an
+        // unflagged row whose timezoneID matches the system tz; otherwise
+        // fall back to the first flagged row (contract item 2) so the flag
+        // is never cleared everywhere when nothing matches.
         var keepIndex: Int? = flaggedIndices.first { idx in
             decoded[idx].model?.timezoneID == currentSystemTimezone
         }
@@ -215,6 +216,10 @@ class AppDefaults {
             keepIndex = decoded.first { entry in
                 entry.model?.timezoneID == currentSystemTimezone && entry.model?.isSystemTimezone == false
             }?.idx
+        }
+
+        if keepIndex == nil {
+            keepIndex = flaggedIndices.first
         }
 
         // Walk all rows and rewrite as needed.
@@ -240,7 +245,13 @@ class AppDefaults {
         // this key explicitly. In that case we leave both keys untouched and
         // let the new key's registered default take over below.
         guard let object = defaults.object(forKey: legacy) else { return }
-        let legacyInt = (object as? NSNumber)?.intValue ?? (object as? Int) ?? 1
+        // An uninterpretable legacy value (unexpected type) tells us nothing
+        // about the user's choice — drop it and leave the modern key at its
+        // registered default rather than silently disabling the feature.
+        guard let legacyInt = (object as? NSNumber)?.intValue else {
+            defaults.removeObject(forKey: legacy)
+            return
+        }
         defaults.set(legacyInt == 0, forKey: target)
         defaults.removeObject(forKey: legacy)
     }

--- a/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
@@ -85,8 +85,6 @@ class StatusItemHandler: NSObject {
 
     private var calendar = Calendar.autoupdatingCurrent
 
-    private lazy var units: Set<Calendar.Component> = Set([.era, .year, .month, .day, .hour, .minute])
-
     private var cancellables = Set<AnyCancellable>()
 
     private let store: DataStore
@@ -241,11 +239,6 @@ class StatusItemHandler: NSObject {
     }
 
     private func setupNotificationObservers() {
-        NotificationCenter.default.publisher(for: NSWorkspace.didWakeNotification)
-            .receive(on: RunLoop.main)
-            .sink { [weak self] _ in self?.updateMenubar() }
-            .store(in: &cancellables)
-
         DistributedNotificationCenter.default.publisher(for: .interfaceStyleDidChange)
             .receive(on: RunLoop.main)
             .sink { [weak self] _ in self?.respondToInterfaceStyleChange() }
@@ -369,7 +362,13 @@ class StatusItemHandler: NSObject {
         let shouldDisplaySeconds = shouldDisplaySecondsInMenubar()
         let menubarFavourites = store.menubarTimezones()
 
-        if !units.contains(.second), shouldDisplaySeconds {
+        // Derive the component set fresh on every calculation. An instance-level
+        // set that only ever gains .second keeps carrying the current seconds
+        // after the user switches to a no-seconds format, landing the "next
+        // minute" fire date at :SS instead of :00 — the menubar time then lags
+        // by up to a minute until relaunch.
+        var units: Set<Calendar.Component> = [.era, .year, .month, .day, .hour, .minute]
+        if shouldDisplaySeconds {
             units.insert(.second)
         }
 
@@ -380,6 +379,9 @@ class StatusItemHandler: NSObject {
             components.second = seconds + 1
         } else if let minutes = components.minute {
             components.minute = minutes + 1
+            // Fire exactly on the minute boundary regardless of whether .second
+            // made it into the component set above.
+            components.second = 0
         } else {
             Logger.production("Unable to create date components for menubar timer")
             return nil

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
 #
-# validate_feature.sh — TDD checks for issue #142: "bring back stacked time in
-# compact menu bar" as an opt-in 6th menu-bar preset ("Stacked").
+# validate_feature.sh — TDD checks for the backfill data-loss audit fixes:
+#   1. AppDelegate.backfillMissingCoordinates merges by stable identity into a
+#      FRESH store read instead of writing back the launch-time snapshot.
+#   2. StatusItemHandler derives the .second calendar component per call (the
+#      old instance-level set only ever gained .second, never lost it).
+#   3. The dead NotificationCenter.default didWake observer is deleted
+#      (NSWorkspace posts on NSWorkspace.shared.notificationCenter).
+#   4. runHomeRowMigrationV1 keeps the FIRST flagged row when no row matches
+#      the current system timezone (instead of clearing the flag everywhere).
+#   5. migrateInvertedBool writes nothing when the legacy value can't be
+#      interpreted (instead of defaulting to 1 == feature hidden).
 #
 # Run BEFORE implementing (expect failures), then again after (expect all green).
 #
-#   bash scripts/validate_feature.sh            # static checks + Debug build
+#   bash scripts/validate_feature.sh            # static checks + build + new tests
 #   bash scripts/validate_feature.sh --no-build # static checks only (fast)
 #
 set -uo pipefail
@@ -14,12 +23,11 @@ cd "$(dirname "$0")/.." || exit 2
 
 PASS=0
 FAIL=0
-SIV="Meridian/Preferences/Menu Bar/StatusItemView.swift"
-SCV="Meridian/Preferences/Menu Bar/StatusContainerView.swift"
-PANE="Meridian/Preferences/V4Settings/MenuBarPane.swift"
-GP="Meridian/Preferences/V4Settings/GeneralPane.swift"
 APPD="Meridian/AppDelegate.swift"
-KEY="com.tpak.meridian.v4.menubarStacked"
+SIH="Meridian/Preferences/Menu Bar/StatusItemHandler.swift"
+DEFAULTS="Meridian/Overall App/AppDefaults.swift"
+UNIT="Meridian/MeridianUnitTests/MeridianUnitTests.swift"
+APPD_TESTS="Meridian/MeridianUnitTests/AppDelegateTests.swift"
 
 ok()  { printf "  \033[32mOK:\033[0m   %s\n" "$1"; PASS=$((PASS+1)); }
 bad() { printf "  \033[31mFAIL:\033[0m %s\n" "$1" >&2; FAIL=$((FAIL+1)); }
@@ -29,128 +37,109 @@ check() { # check "description" <grep-args...>
   if grep -q "$@"; then ok "$desc"; else bad "$desc"; fi
 }
 
-echo "Issue #142 — Stacked menu-bar preset — validation"
-echo "------------------------------------------------"
+absent() { # absent "description" <grep-args...>
+  local desc="$1"; shift
+  if grep -q "$@"; then bad "$desc"; else ok "$desc"; fi
+}
 
-# 1. The single-line switch is no longer a hard-coded constant.
-if grep -Eq '^[[:space:]]*let[[:space:]]+kMenubarV4SingleLine[[:space:]]*=[[:space:]]*true' "$SIV"; then
-  bad "kMenubarV4SingleLine is no longer a hard-coded 'let ... = true'"
-else
-  ok "kMenubarV4SingleLine is no longer a hard-coded 'let ... = true'"
-fi
+echo "Backfill data-loss + timer/migration audit fixes — validation"
+echo "--------------------------------------------------------------"
 
-# 2. It is now a computed value (var with a Bool body).
-check "kMenubarV4SingleLine is now computed (var ...: Bool {)" -Eq 'var[[:space:]]+kMenubarV4SingleLine[[:space:]]*:[[:space:]]*Bool[[:space:]]*\{' "$SIV"
+# --- Fix 1: coordinate backfill must not clobber concurrent edits ------------
 
-# 3. The render path reads the new UserDefault key.
-check "render path (StatusItemView) references the new key" -Fq "$KEY" "$SIV"
+# The merge is a pure, unit-testable function keyed by stable identity.
+check "AppDelegate has mergeBackfilledCoordinates(current:...)" \
+  -Eq 'static func mergeBackfilledCoordinates\(current:' "$APPD"
 
-# 4. A reader exists for the stacked layout flag.
-check "menubarStackedLayoutEnabled reader exists" -Eq 'menubarStackedLayoutEnabled' "$SIV"
+# The identity used for the merge is derived from the model, not the array index.
+check "AppDelegate derives a stable backfill identity from TimezoneData" \
+  -Eq 'func backfillIdentity\(for' "$APPD"
 
-# 5. Default is OFF (single-line preserved for everyone) — reader falls back to false.
-check "stacked default is false (?? false)" -Eq 'as\? Bool \?\? false' "$SIV"
+# The write path re-reads the store AFTER the awaits (fresh read feeding the merge).
+check "backfill merges into a fresh store.timezones() read" \
+  -Eq 'mergeBackfilledCoordinates\(current: store\.timezones\(\)' "$APPD"
 
-# 6. MenuBarPane exposes a 6th "Stacked" preset.
-check "MenuBarPane has a 'stacked' preset id" -Eq 'id:[[:space:]]*"stacked"' "$PANE"
-check "MenuBarPane has a 'Stacked' preset label" -Fq 'String(localized: "Stacked")' "$PANE"
+# The old positional write-back of the pre-await snapshot is gone.
+absent "no positional snapshot write-back (timezones[index] = encoded)" \
+  -Fq 'timezones[index] = encoded' "$APPD"
 
-# 7. MenuBarPane persists the new key via @AppStorage.
-check "MenuBarPane binds the new key via @AppStorage" -Fq "@AppStorage(\"$KEY\")" "$PANE"
+# Unit test: user edits during backfill survive the merge.
+check "unit test covers add+remove during backfill" \
+  -Eq 'func testMergeBackfilledCoordinates.*(KeepsUserEdits|PreservesConcurrentEdits)' "$APPD_TESTS"
 
-# 8. Selecting a preset applies the stacked flag.
-check "applyPreset writes the stacked flag" -Eq 'menubarStacked[[:space:]]*=[[:space:]]*preset\.stacked' "$PANE"
+# --- Fix 2: .second component derived fresh per calculation ------------------
 
-# 9. The preset model carries a 'stacked' field.
-check "MenuBarPreset model has a 'stacked' field" -Eq 'let[[:space:]]+stacked:[[:space:]]*Bool' "$PANE"
+# The sticky instance-level set is gone (a plain local 'var units' is fine)…
+absent "no instance-level 'units' property on StatusItemHandler" \
+  -Eq 'private (lazy )?var units' "$SIH"
 
-# 10. Preview can render a two-line (stacked) chip.
-check "preview supports a two-line/stacked chip (bottomLabel)" -Eq 'bottomLabel' "$PANE"
+# …and the once-only sticky insert guard with it.
+absent "no sticky '!units.contains(.second)' insert guard" \
+  -Fq '!units.contains(.second)' "$SIH"
 
-# 11. UAT r5: stacked menu-bar item height tracks the live bar thickness (a fixed/oversized height
-#     overflows the 22pt bar and crams the time onto the bottom edge).
-check "menubarItemHeight tracks bar thickness" -Eq 'var menubarItemHeight: CGFloat \{ NSStatusBar\.system\.thickness \}' "$SCV"
+# The component set is rebuilt locally on every calculation.
+check "component set derived fresh per call" \
+  -Eq 'var units: Set<Calendar\.Component> = \[\.era' "$SIH"
 
-# 12. UAT fix: preset cards reserve two sample lines so the Stacked card doesn't grow its row.
-check "preset card reserves two sample lines" -Fq 'reservesSpace: true' "$PANE"
+# The minute-boundary branch pins seconds to zero.
+check "minute-branch fire date has second == 0" \
+  -Fq 'components.second = 0' "$SIH"
 
-# 13. UAT r2: stacked menu-bar name line uses semibold (matches the cleaner preview), not bold.
-check "menu-bar name font is semibold" -Eq 'systemFont\(ofSize: 10, weight: .semibold\)' "$SIV"
-if grep -q 'boldSystemFont(ofSize: 10)' "$SIV"; then bad "menu-bar name still uses boldSystemFont"; else ok "menu-bar name no longer boldSystemFont"; fi
+# --- Fix 3: dead default-center didWake observer deleted ---------------------
 
-# 14. UAT r2: preset card sample is right-justified.
-check "preset card sample is right-justified" -Fq 'multilineTextAlignment(.trailing)' "$PANE"
+absent "no NotificationCenter.default subscription to NSWorkspace.didWakeNotification" \
+  -Fq 'NotificationCenter.default.publisher(for: NSWorkspace.didWakeNotification)' "$SIH"
 
-# 15. UAT r2: 'Check Now' lives on its own row (empty-label FormRow under the segment).
-check "Check Now is on its own FormRow" -Eq 'FormRow\(label: ""\)' "$GP"
+# The correct workspace-center subscriptions must remain intact.
+check "workspace-center didWake subscription still present" \
+  -Fq 'NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.didWakeNotification)' "$SIH"
+check "workspace-center willSleep subscription still present" \
+  -Fq 'NSWorkspace.shared.notificationCenter.publisher(for: NSWorkspace.willSleepNotification)' "$SIH"
 
-# 16. UAT r2: fresh-install start-at-login default.
-check "enableStartAtLoginByDefault exists" -Eq 'func enableStartAtLoginByDefault' "$APPD"
-check "start-at-login wired into launch" -Eq 'enableStartAtLoginByDefault\(\)' "$APPD"
+# --- Fix 4: home-row migration keeps first flagged row as fallback -----------
 
-# 17. UAT r2: fresh-install daily update cadence.
-check "fresh-install sets daily update interval (86400)" -Eq 'updateCheckInterval = 86400' "$APPD"
+check "runHomeRowMigrationV1 falls back to the first flagged row" \
+  -Eq 'keepIndex = flaggedIndices\.first$' "$DEFAULTS"
 
-# 18. UAT r5: stacked lines have their text centres placed symmetrically about the bar middle
-#     (verified by screenshot: tight, centred pair, time off the bottom edge).
-check "stacked name text centred above the middle" -Fq 'locationView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -halfGap)' "$SIV"
-check "stacked time text centred below the middle" -Fq 'timeView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: halfGap)' "$SIV"
-if grep -q 'multiplier: 0.35\|multiplier: 0.5' "$SIV"; then bad "stacked still uses a proportional split"; else ok "stacked no longer uses a proportional split"; fi
+check "unit test covers two flagged rows with no system match" \
+  -Eq 'func testHomeRowMigration.*(NoMatch|NeitherMatches)' "$UNIT"
 
-# 19. UAT r5: General-pane command buttons use the visible ShadedButtonStyle (the system .bordered
-#     style was near-invisible on the dark canvas); no .plain command buttons remain.
-check "command buttons use ShadedButtonStyle" -Fq 'buttonStyle(ShadedButtonStyle())' "$GP"
-check "ShadedButtonStyle is defined" -Fq 'struct ShadedButtonStyle: ButtonStyle' "$GP"
-if grep -q 'buttonStyle(.plain)' "$GP"; then bad "GeneralPane still has a .plain command button"; else ok "no .plain command buttons remain in GeneralPane"; fi
+# --- Fix 5: migrateInvertedBool skips uninterpretable legacy values ----------
 
-# 20. UAT r5: stacked menu-bar item height matches the bar (no fixed 30pt that overflowed the 22pt bar).
-if grep -q 'stackedMenubarItemHeight\|multiplier: 0.5\|: 30' "$SCV"; then bad "stacked item still uses a fixed/oversized height"; else ok "stacked item height matches the bar thickness"; fi
+absent "migrateInvertedBool no longer defaults garbage to 1 (hidden)" \
+  -Fq '?? (object as? Int) ?? 1' "$DEFAULTS"
 
-# 21. UAT r6: the Daybreak panel sits below the bar (gap), not flush against it.
-DPC="Meridian/Panel/Daybreak/DaybreakPanelController.swift"
-check "panel anchors with a gap below the bar" -Fq 'buttonRect.minY + bodyTopInset - bodyGapBelowBar' "$DPC"
+check "migrateInvertedBool guards on an interpretable legacy value" \
+  -Eq 'guard let legacyInt' "$DEFAULTS"
 
-# --- New "Midnight Sundial" icons ---
-AIS="Meridian/Media.xcassets/AppIcon.appiconset"
-MBI="Meridian/Media.xcassets/MenuBarIcon.imageset"
-SIH="Meridian/Preferences/Menu Bar/StatusItemHandler.swift"
-FAD="Meridian/Overall App/Foundation + Additions.swift"
+check "unit test covers garbage legacy value leaving registered default" \
+  -Eq 'func testInvertedBool_garbageLegacyValue' "$UNIT"
 
-# 22. New AppIcon iconset present (all 10), old Clocker/meridian-* art gone.
-if [ "$(find "$AIS" -name 'icon_*.png' | wc -l | tr -d ' ')" = "10" ]; then ok "AppIcon has the 10 new icon_*.png"; else bad "AppIcon missing new icon_*.png"; fi
-if find "$AIS" -iname '*clocker*' -o -iname 'meridian-*.png' 2>/dev/null | grep -q .; then bad "old Clocker/meridian-* app-icon art still present"; else ok "old app-icon art removed"; fi
-check "AppIcon Contents.json maps the new files" -Fq 'icon_512x512@2x.png' "$AIS/Contents.json"
+# --- Build + targeted tests ---------------------------------------------------
 
-# 23. MenuBarIcon template imageset present and rendered as template.
-if [ -f "$MBI/MenuBarIcon.png" ] && [ -f "$MBI/MenuBarIcon@2x.png" ]; then ok "MenuBarIcon imageset has the template pair"; else bad "MenuBarIcon imageset PNGs missing"; fi
-check "MenuBarIcon renders as a template image" -Fq '"template-rendering-intent" : "template"' "$MBI/Contents.json"
-
-# 24. Old unused menu-bar icon asset removed.
-if [ -d "Meridian/Media.xcassets/Menubar Icons" ]; then bad "old 'Menubar Icons' (LightModeIcon) folder still present"; else ok "old 'Menubar Icons' folder removed"; fi
-
-# 25. Code loads the template glyph (not the old clock.fill SF Symbol).
-check "menubarIcon name points at MenuBarIcon" -Fq 'NSImage.Name("MenuBarIcon")' "$FAD"
-check "status item loads the template icon" -Fq 'NSImage(named: .menubarIcon)' "$SIH"
-check "status item icon is set as a template" -Eq 'image\?\.isTemplate = true' "$SIH"
-if grep -q 'clock.fill' "$SIH"; then bad "still references the clock.fill SF Symbol"; else ok "no clock.fill reference remains"; fi
-
-echo ""
-if [[ "${1:-}" == "--no-build" ]]; then
-  echo "Skipping build (--no-build)."
-else
-  echo "Building (Debug, no code signing)…"
-  BUILD_LOG=$(mktemp)
+if [[ "${1:-}" != "--no-build" ]]; then
+  echo ""
+  echo "Building Debug configuration…"
   if xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \
-       CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= \
-       >"$BUILD_LOG" 2>&1; then
-    ok "Debug build succeeded"
+      CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= > /tmp/validate_build.log 2>&1; then
+    ok "Debug build succeeds"
   else
-    bad "Debug build FAILED — see $BUILD_LOG"
-    tail -25 "$BUILD_LOG" >&2
+    bad "Debug build failed (see /tmp/validate_build.log)"
+  fi
+
+  echo "Running the new unit tests (serial)…"
+  if xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug test \
+      -only-testing:MeridianUnitTests/AppDelegateTests \
+      -only-testing:MeridianUnitTests/MeridianUnitTests \
+      -only-testing:MeridianUnitTests/BoolSemanticsMigrationTests \
+      -parallel-testing-enabled NO -disable-concurrent-destination-testing \
+      CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= > /tmp/validate_tests.log 2>&1; then
+    ok "New + surrounding unit tests pass"
+  else
+    bad "Unit tests failed (see /tmp/validate_tests.log)"
   fi
 fi
 
 echo ""
-echo "------------------------------------------------"
-echo "PASS=$PASS  FAIL=$FAIL"
-[[ "$FAIL" -eq 0 ]] && { echo "ALL GREEN"; exit 0; } || { echo "FAILURES PRESENT"; exit 1; }
+echo "Passed: $PASS  Failed: $FAIL"
+[[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
- Fix cities added or removed right after launch being silently undone by the automatic coordinate lookup
- Fix the menu-bar clock lagging up to a minute after turning off seconds display
- Fix the Home city losing its flag during settings migration when saved cities no longer match the current timezone
- Fix a settings migration that could switch off a display option the user had enabled

## Technical detail (not for release notes)

From the resilience/concurrency audit:

1. `AppDelegate.backfillMissingCoordinates()` persisted a pre-`await` snapshot of the whole city list after up-to-10s-per-city geocoding, wiping concurrent user edits. Now geocoded coordinates accumulate keyed by stable identity (`placeID|timezoneID`), and a pure `mergeBackfilledCoordinates(current:geocoded:)` merges them onto a *fresh* store read with no suspension point between read and write (main-actor atomic). Unit-tested: add + remove during backfill survive.
2. `StatusItemHandler.calculateFireDate()` builds its calendar-component set fresh per call (the old instance-level set only ever *gained* `.second`), and the minute branch pins `second = 0`, so HH:MM updates on the minute boundary after seconds display is turned off.
3. `runHomeRowMigrationV1` now falls back to keeping the first flagged row when no row matches the current system zone (per its documented contract) instead of clearing the flag everywhere.
4. `migrateInvertedBool` leaves the modern key at its registered default when the legacy value is uninterpretable, instead of defaulting to "hidden".
5. Removed a dead `NSWorkspace.didWakeNotification` subscription on `NotificationCenter.default` (never fires there; the working workspace-center subscriptions remain).

Tests: full suite 251/251 passing (serial), 3 new tests. SwiftLint clean. TDD validation script 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUpXyziq1Tss3nZBQ8u348