### PR TITLE
Improve update delivery reliability

### DIFF
--- a/.github/workflows/appcast-validate.yml
+++ b/.github/workflows/appcast-validate.yml
@@ -1,0 +1,50 @@
+name: Appcast Validate
+
+# The main CI workflow ignores appcast.xml (full app builds on every appcast
+# push would be wasteful), so release.sh's direct-to-main appcast pushes ran
+# no CI at all. This lightweight check fills that gap: it validates that the
+# feed is well-formed XML and that every enclosure carries the attributes
+# Sparkle needs to verify and install an update.
+
+on:
+  push:
+    paths:
+      - 'appcast.xml'
+  pull_request:
+    paths:
+      - 'appcast.xml'
+
+jobs:
+  validate:
+    name: Validate appcast.xml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install xmllint
+        run: |
+          if ! command -v xmllint >/dev/null 2>&1; then
+            sudo apt-get update -q
+            sudo apt-get install -y -q libxml2-utils
+          fi
+
+      - name: Validate XML well-formedness
+        run: xmllint --noout appcast.xml
+
+      - name: Check enclosures have signatures and lengths
+        run: |
+          # Every <enclosure> must carry a non-empty sparkle:edSignature and a
+          # non-empty length, or Sparkle clients can't verify the download.
+          # local-name() sidesteps xmllint's lack of namespace registration
+          # for the sparkle: attribute prefix.
+          total="$(xmllint --xpath 'count(//enclosure)' appcast.xml)"
+          valid="$(xmllint --xpath 'count(//enclosure[string-length(@*[local-name()="edSignature"]) > 0 and string-length(@length) > 0])' appcast.xml)"
+          echo "enclosures: $total, with non-empty edSignature+length: $valid"
+          if [ "$total" -eq 0 ]; then
+            echo "Error: appcast.xml contains no <enclosure> elements"
+            exit 1
+          fi
+          if [ "$total" -ne "$valid" ]; then
+            echo "Error: $((total - valid)) enclosure(s) missing a non-empty sparkle:edSignature or length attribute"
+            exit 1
+          fi

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -25,6 +25,20 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# HTML-escape one line of release-note text for embedding in the appcast's
+# CDATA block (Sparkle renders that content as HTML). Escape & first so the
+# entities themselves don't get re-escaped. Escaping > also neutralizes a
+# literal "]]>" that would otherwise terminate the CDATA section early.
+# NOTE: only the appcast path uses this — the GitHub release body is
+# markdown and must stay unescaped.
+html_escape() {
+    local s="$1"
+    s="${s//&/&amp;}"
+    s="${s//</&lt;}"
+    s="${s//>/&gt;}"
+    printf '%s' "$s"
+}
+
 # ── Phase 1: Validate ──────────────────────────────────────────────
 
 if [[ -z "$VERSION" ]]; then
@@ -73,6 +87,30 @@ else
 fi
 echo "── Build number derived from VERSION=$VERSION → $BUILD_NUMBER"
 
+# Version monotonicity gate: a typo'd lower version would silently downgrade
+# the Homebrew cask and write an out-of-order appcast item. The build-number
+# encoding above is strictly increasing across stable and beta releases
+# (stable X.Y.Z > any X.Y.Z-betaN because BETA_N=100 for stable), so a
+# numeric compare against the newest (top-most) <sparkle:version> in the
+# appcast covers both cases.
+if [[ ! -f appcast.xml ]]; then
+    echo "Error: appcast.xml not found — run from the repository root."
+    exit 1
+fi
+LATEST_APPCAST_BUILD="$(grep -Eo '<sparkle:version>[0-9]+</sparkle:version>' appcast.xml | head -1 | tr -dc '0-9' || true)"
+if [[ -n "$LATEST_APPCAST_BUILD" ]]; then
+    if (( BUILD_NUMBER <= LATEST_APPCAST_BUILD )); then
+        echo "Error: build number $BUILD_NUMBER (v$VERSION) is not strictly greater than the"
+        echo "       newest appcast item's <sparkle:version> ($LATEST_APPCAST_BUILD)."
+        echo "       Releasing it would downgrade Sparkle users and/or the Homebrew cask."
+        echo "       Double-check VERSION."
+        exit 1
+    fi
+    echo "── Monotonicity check passed: $BUILD_NUMBER > $LATEST_APPCAST_BUILD (newest appcast item)."
+else
+    echo "── No existing <sparkle:version> found in appcast.xml; skipping monotonicity check."
+fi
+
 CURRENT_BRANCH="$(git branch --show-current)"
 if [[ "$CURRENT_BRANCH" != "main" ]]; then
     if [[ "$IS_BETA" == "1" ]]; then
@@ -95,7 +133,7 @@ if git tag -l "v$VERSION" | grep -q "v$VERSION"; then
     exit 1
 fi
 
-for cmd in xcodebuild gh ditto xcrun; do
+for cmd in xcodebuild gh ditto xcrun xmllint; do
     if ! command -v "$cmd" &>/dev/null; then
         echo "Error: Required tool '$cmd' not found"
         exit 1
@@ -212,7 +250,9 @@ echo "Release notes:"
 echo "$NOTES" | while IFS= read -r line; do echo "  - $line"; done
 echo ""
 
-# ── Phase 2: Bump version + commit ─────────────────────────────────
+# ── Phase 2: Bump version + commit (push deferred) ─────────────────
+# The bump commit stays LOCAL until build/sign/notarize/staple all succeed,
+# so a failed release can't leave a phantom version bump on origin.
 
 echo "── Bumping version to $VERSION (build $BUILD_NUMBER)..."
 PBXPROJ="Meridian/Meridian.xcodeproj/project.pbxproj"
@@ -224,14 +264,54 @@ if git diff --cached --quiet; then
     echo "── Version already set to $VERSION, skipping commit."
 else
     git commit -m "Bump version to $VERSION [skip ci]"
-    git push origin main
-    echo "── Version bumped and pushed."
+    echo "── Version bumped (commit kept local until notarization succeeds)."
 fi
+
+# Pin the exact commit this release is built from. Passed to
+# `gh release create --target` so the tag points at this commit even if
+# the remote branch moves during the multi-minute build/notarize.
+RELEASE_REV="$(git rev-parse HEAD)"
+
+# From here on a bump commit exists that origin may not have. If anything
+# fails before the flow completes, report exactly what state things are in.
+BUMP_PUSHED=0
+GH_RELEASE_CREATED=0
+APPCAST_COMMITTED=0
+APPCAST_PUSHED=0
+RELEASE_COMPLETE=0
+
+report_release_state() {
+    local exit_code=$?
+    [[ $RELEASE_COMPLETE -eq 1 ]] && return 0
+    echo ""
+    echo "=== Release v$VERSION did NOT complete (exit $exit_code) — current state ==="
+    if [[ $BUMP_PUSHED -eq 1 ]]; then
+        echo "  * Version bump commit ($RELEASE_REV) is committed and PUSHED to origin."
+    else
+        echo "  * Version bump commit ($RELEASE_REV) exists LOCALLY only; origin is untouched."
+        echo "    To abandon this release: git reset --hard origin/$CURRENT_BRANCH"
+    fi
+    if [[ $GH_RELEASE_CREATED -eq 1 ]]; then
+        echo "  * GitHub release v$VERSION WAS created (undo: gh release delete v$VERSION --cleanup-tag)."
+    else
+        echo "  * GitHub release v$VERSION was NOT created."
+    fi
+    if [[ $APPCAST_COMMITTED -eq 1 && $APPCAST_PUSHED -eq 1 ]]; then
+        echo "  * appcast.xml WAS updated and pushed (Sparkle clients can see v$VERSION)."
+    elif [[ $APPCAST_COMMITTED -eq 1 ]]; then
+        echo "  * appcast.xml WAS committed locally but NOT pushed (push with: git push origin main)."
+    else
+        echo "  * appcast.xml was NOT updated."
+    fi
+    echo "  Re-running the same release command resumes safely: the existing bump commit"
+    echo "  is detected and skipped, and the push happens only after notarization."
+}
+trap report_release_state EXIT
 
 # ── Phase 3: Build + sign ──────────────────────────────────────────
 
-RELEASE_DIR="/tmp/meridian-release"
-rm -rf "$RELEASE_DIR"
+RELEASE_DIR="$(mktemp -d /tmp/meridian-release.XXXXXX)"
+echo "── Release staging dir: $RELEASE_DIR"
 
 echo "── Building release..."
 xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Release \
@@ -267,17 +347,62 @@ xattr -rc "$APP_PATH"
 # Re-sign Sparkle components (SPM pre-built binaries need our identity)
 echo "── Re-signing Sparkle framework components..."
 SPARKLE_FW="$APP_PATH/Contents/Frameworks/Sparkle.framework"
-if [[ -d "$SPARKLE_FW" ]]; then
-    # Sign inside-out: XPC services first, then helper apps, then framework, then main app
-    for xpc in "$SPARKLE_FW"/Versions/B/XPCServices/*.xpc; do
-        [[ -d "$xpc" ]] && codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$xpc"
-    done
-    for helper in "$SPARKLE_FW"/Versions/B/*.app; do
-        [[ -d "$helper" ]] && codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$helper"
-    done
-    codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$SPARKLE_FW/Versions/B/Autoupdate"
-    codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
+if [[ ! -d "$SPARKLE_FW" ]]; then
+    echo "Error: Sparkle.framework not found at $SPARKLE_FW"
+    echo "       The app cannot self-update without it — aborting."
+    exit 1
 fi
+
+# Resolve the framework version dir dynamically (Sparkle currently names its
+# single version "B" — don't hardcode that) so a Sparkle bump that changes
+# the layout can't silently skip re-signing.
+SPARKLE_VDIR=""
+if [[ -d "$SPARKLE_FW/Versions/Current/" ]]; then
+    SPARKLE_VDIR="$(cd "$SPARKLE_FW/Versions/Current" && pwd -P)"
+else
+    for candidate in "$SPARKLE_FW"/Versions/*/; do
+        candidate="${candidate%/}"
+        [[ -d "$candidate" ]] || continue
+        [[ "$(basename "$candidate")" == "Current" ]] && continue
+        SPARKLE_VDIR="$candidate"
+        break
+    done
+fi
+if [[ -z "$SPARKLE_VDIR" || ! -d "$SPARKLE_VDIR" ]]; then
+    echo "Error: could not resolve a version directory under $SPARKLE_FW/Versions"
+    exit 1
+fi
+echo "  Sparkle version dir: $SPARKLE_VDIR"
+
+# Sign inside-out: XPC services first, then helper apps, then framework, then main app.
+# Count what we sign and FAIL LOUDLY if a glob matches nothing — a Sparkle
+# layout change must never silently ship unsigned installer components.
+XPC_COUNT=0
+for xpc in "$SPARKLE_VDIR"/XPCServices/*.xpc; do
+    [[ -d "$xpc" ]] || continue
+    codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$xpc"
+    XPC_COUNT=$((XPC_COUNT + 1))
+done
+HELPER_COUNT=0
+for helper in "$SPARKLE_VDIR"/*.app; do
+    [[ -d "$helper" ]] || continue
+    codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$helper"
+    HELPER_COUNT=$((HELPER_COUNT + 1))
+done
+if [[ $XPC_COUNT -eq 0 || $HELPER_COUNT -eq 0 ]]; then
+    echo "Error: expected Sparkle installer components were not found under $SPARKLE_VDIR"
+    echo "       (XPC services signed: $XPC_COUNT, helper apps signed: $HELPER_COUNT)."
+    echo "       The Sparkle framework layout has likely changed — update the signing"
+    echo "       paths in scripts/release.sh before releasing."
+    exit 1
+fi
+if [[ ! -e "$SPARKLE_VDIR/Autoupdate" ]]; then
+    echo "Error: Sparkle Autoupdate binary not found at $SPARKLE_VDIR/Autoupdate"
+    exit 1
+fi
+codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$SPARKLE_VDIR/Autoupdate"
+codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
+echo "  Signed $XPC_COUNT XPC service(s), $HELPER_COUNT helper app(s), Autoupdate, and the framework."
 
 # Re-sign the main app (picks up entitlements, ensures timestamp)
 ENTITLEMENTS="Meridian/App/Meridian.entitlements"
@@ -325,17 +450,28 @@ fi
 echo "  Signature: ${ED_SIGNATURE:0:20}..."
 echo "  Length: $LENGTH"
 
-# ── Phase 4: GitHub release ─────────────────────────────────────────
+# ── Phase 4: Push version bump + GitHub release ─────────────────────
+
+# Deferred from Phase 2: only publish the bump commit now that build,
+# signing, notarization, and stapling have all succeeded.
+echo "── Pushing version bump..."
+git push origin main
+if [[ "$CURRENT_BRANCH" == "main" ]]; then
+    BUMP_PUSHED=1
+fi
 
 echo "── Creating GitHub release..."
 RELEASE_BODY="$(echo "$NOTES" | while IFS= read -r line; do echo "- $line"; done)"
 # macOS bash 3.x trips on expanding empty arrays under `set -u`, so split the
 # command on whether the prerelease flag applies instead of using an array.
+# --target pins the tag to the commit this release was built from (captured
+# in Phase 2), not whatever the remote branch head happens to be by now.
 if [[ $IS_BETA -eq 1 ]]; then
-    gh release create "v$VERSION" "$ZIP_PATH" --title "v$VERSION" --notes "$RELEASE_BODY" --prerelease
+    gh release create "v$VERSION" "$ZIP_PATH" --title "v$VERSION" --notes "$RELEASE_BODY" --target "$RELEASE_REV" --prerelease
 else
-    gh release create "v$VERSION" "$ZIP_PATH" --title "v$VERSION" --notes "$RELEASE_BODY"
+    gh release create "v$VERSION" "$ZIP_PATH" --title "v$VERSION" --notes "$RELEASE_BODY" --target "$RELEASE_REV"
 fi
+GH_RELEASE_CREATED=1
 
 echo "── GitHub release created."
 
@@ -344,11 +480,13 @@ echo "── GitHub release created."
 echo "── Updating appcast.xml..."
 PUB_DATE="$(LC_ALL=C date -u '+%a, %d %b %Y %H:%M:%S %z')"
 
-# Build <li> items from notes
+# Build <li> items from notes. Each line is HTML-escaped: the CDATA content
+# is rendered as HTML by Sparkle, and an unescaped "]]>" in a note would
+# terminate the CDATA block and corrupt the feed.
 LI_ITEMS=""
 while IFS= read -r line; do
     if [[ -n "$line" ]]; then
-        LI_ITEMS="$LI_ITEMS                    <li>$line</li>
+        LI_ITEMS="$LI_ITEMS                    <li>$(html_escape "$line")</li>
 "
     fi
 done <<< "$NOTES"
@@ -394,11 +532,21 @@ awk '
     }
     { print }
 ' "$APPCAST" > "$TMPAPPCAST"
-mv "$TMPAPPCAST" "$APPCAST"
 rm -f "$TMPITEM"
+
+# Validate the generated feed BEFORE it replaces appcast.xml or gets
+# committed — a malformed appcast would break updates for every user.
+if ! xmllint --noout "$TMPAPPCAST"; then
+    echo "Error: generated appcast is not well-formed XML — aborting before commit."
+    echo "       Inspect the generated file at: $TMPAPPCAST"
+    echo "       appcast.xml in the working tree is unchanged."
+    exit 1
+fi
+mv "$TMPAPPCAST" "$APPCAST"
 
 git add "$APPCAST"
 git commit -m "Update appcast.xml for v$VERSION"
+APPCAST_COMMITTED=1
 
 if ! git push origin main; then
     echo ""
@@ -406,6 +554,7 @@ if ! git push origin main; then
     echo "  git push origin main"
     exit 1
 fi
+APPCAST_PUSHED=1
 
 echo "── Appcast updated and pushed."
 
@@ -441,6 +590,8 @@ else
 fi
 
 # ── Phase 7: Summary ────────────────────────────────────────────────
+
+RELEASE_COMPLETE=1
 
 echo ""
 echo "=== Release v$VERSION complete! ==="

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -299,7 +299,7 @@ report_release_state() {
     if [[ $APPCAST_COMMITTED -eq 1 && $APPCAST_PUSHED -eq 1 ]]; then
         echo "  * appcast.xml WAS updated and pushed (Sparkle clients can see v$VERSION)."
     elif [[ $APPCAST_COMMITTED -eq 1 ]]; then
-        echo "  * appcast.xml WAS committed locally but NOT pushed (push with: git push origin main)."
+        echo "  * appcast.xml WAS committed locally but NOT pushed (push with: git push origin $CURRENT_BRANCH)."
     else
         echo "  * appcast.xml was NOT updated."
     fi
@@ -453,12 +453,13 @@ echo "  Length: $LENGTH"
 # ── Phase 4: Push version bump + GitHub release ─────────────────────
 
 # Deferred from Phase 2: only publish the bump commit now that build,
-# signing, notarization, and stapling have all succeeded.
+# signing, notarization, and stapling have all succeeded. Push the CURRENT
+# branch (main for stable releases, the feature branch for branch betas) so
+# the built commit exists on origin — `gh release create --target` below
+# fails if the target SHA is unknown to the remote.
 echo "── Pushing version bump..."
-git push origin main
-if [[ "$CURRENT_BRANCH" == "main" ]]; then
-    BUMP_PUSHED=1
-fi
+git push origin "$CURRENT_BRANCH"
+BUMP_PUSHED=1
 
 echo "── Creating GitHub release..."
 RELEASE_BODY="$(echo "$NOTES" | while IFS= read -r line; do echo "- $line"; done)"
@@ -548,10 +549,10 @@ git add "$APPCAST"
 git commit -m "Update appcast.xml for v$VERSION"
 APPCAST_COMMITTED=1
 
-if ! git push origin main; then
+if ! git push origin "$CURRENT_BRANCH"; then
     echo ""
     echo "WARNING: Failed to push appcast update. The release is live but appcast.xml needs manual push:"
-    echo "  git push origin main"
+    echo "  git push origin $CURRENT_BRANCH"
     exit 1
 fi
 APPCAST_PUSHED=1

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -94,11 +94,11 @@ fi
 # ── 3. Version-bump push deferred until after notarization ──────────
 # Match actual push COMMANDS (top-level or 'if ! ...'), not echo'd recovery text.
 NOTARIZE_LINE="$(first_line 'notarytool submit' "$RS")"
-PUSH_LINE="$(first_line -E '^(if ! )?git push origin main' "$RS")"
+PUSH_LINE="$(first_line -E '^(if ! )?git push origin "\$CURRENT_BRANCH"' "$RS")"
 if [[ "$PUSH_LINE" -gt 0 && "$NOTARIZE_LINE" -gt 0 && "$PUSH_LINE" -gt "$NOTARIZE_LINE" ]]; then
-  ok "first 'git push origin main' happens AFTER notarization (line $PUSH_LINE > $NOTARIZE_LINE)"
+  ok "first bump/appcast push happens AFTER notarization (line $PUSH_LINE > $NOTARIZE_LINE)"
 else
-  bad "first 'git push origin main' happens AFTER notarization (push@$PUSH_LINE, notarize@$NOTARIZE_LINE)"
+  bad "first bump/appcast push happens AFTER notarization (push@$PUSH_LINE, notarize@$NOTARIZE_LINE)"
 fi
 
 GHREL_LINE="$(first_line -E '^[[:space:]]*gh release create' "$RS")"

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -1,25 +1,23 @@
 #!/usr/bin/env bash
 #
-# validate_feature.sh — TDD checks for issue #142: "bring back stacked time in
-# compact menu bar" as an opt-in 6th menu-bar preset ("Stacked").
+# validate_feature.sh — TDD checks for release-pipeline hardening in
+# scripts/release.sh + the new appcast-validate CI workflow.
 #
 # Run BEFORE implementing (expect failures), then again after (expect all green).
 #
-#   bash scripts/validate_feature.sh            # static checks + Debug build
-#   bash scripts/validate_feature.sh --no-build # static checks only (fast)
+#   bash scripts/validate_feature.sh
 #
+# SC2016: single-quoted grep patterns intentionally contain literal $.
+# SC2015: `test && ok || bad` is safe here — ok() always succeeds.
+# shellcheck disable=SC2016,SC2015
 set -uo pipefail
 
 cd "$(dirname "$0")/.." || exit 2
 
 PASS=0
 FAIL=0
-SIV="Meridian/Preferences/Menu Bar/StatusItemView.swift"
-SCV="Meridian/Preferences/Menu Bar/StatusContainerView.swift"
-PANE="Meridian/Preferences/V4Settings/MenuBarPane.swift"
-GP="Meridian/Preferences/V4Settings/GeneralPane.swift"
-APPD="Meridian/AppDelegate.swift"
-KEY="com.tpak.meridian.v4.menubarStacked"
+RS="scripts/release.sh"
+WF=".github/workflows/appcast-validate.yml"
 
 ok()  { printf "  \033[32mOK:\033[0m   %s\n" "$1"; PASS=$((PASS+1)); }
 bad() { printf "  \033[31mFAIL:\033[0m %s\n" "$1" >&2; FAIL=$((FAIL+1)); }
@@ -29,128 +27,166 @@ check() { # check "description" <grep-args...>
   if grep -q "$@"; then ok "$desc"; else bad "$desc"; fi
 }
 
-echo "Issue #142 — Stacked menu-bar preset — validation"
-echo "------------------------------------------------"
+first_line() { # first_line [grep-flags] <pattern> <file> — prints line number or 0
+  local n
+  n="$(grep -n "$@" | head -1 | cut -d: -f1)"
+  echo "${n:-0}"
+}
 
-# 1. The single-line switch is no longer a hard-coded constant.
-if grep -Eq '^[[:space:]]*let[[:space:]]+kMenubarV4SingleLine[[:space:]]*=[[:space:]]*true' "$SIV"; then
-  bad "kMenubarV4SingleLine is no longer a hard-coded 'let ... = true'"
+echo "Release-pipeline hardening — validation"
+echo "---------------------------------------"
+
+# ── 0. release.sh still parses ──────────────────────────────────────
+if bash -n "$RS" 2>/dev/null; then
+  ok "release.sh passes bash -n syntax check"
 else
-  ok "kMenubarV4SingleLine is no longer a hard-coded 'let ... = true'"
+  bad "release.sh passes bash -n syntax check"
 fi
 
-# 2. It is now a computed value (var with a Bool body).
-check "kMenubarV4SingleLine is now computed (var ...: Bool {)" -Eq 'var[[:space:]]+kMenubarV4SingleLine[[:space:]]*:[[:space:]]*Bool[[:space:]]*\{' "$SIV"
+# ── 1. HTML-escaping of appcast release notes ───────────────────────
+check "html_escape() function exists" -Eq '^html_escape\(\)' "$RS"
 
-# 3. The render path reads the new UserDefault key.
-check "render path (StatusItemView) references the new key" -Fq "$KEY" "$SIV"
-
-# 4. A reader exists for the stacked layout flag.
-check "menubarStackedLayoutEnabled reader exists" -Eq 'menubarStackedLayoutEnabled' "$SIV"
-
-# 5. Default is OFF (single-line preserved for everyone) — reader falls back to false.
-check "stacked default is false (?? false)" -Eq 'as\? Bool \?\? false' "$SIV"
-
-# 6. MenuBarPane exposes a 6th "Stacked" preset.
-check "MenuBarPane has a 'stacked' preset id" -Eq 'id:[[:space:]]*"stacked"' "$PANE"
-check "MenuBarPane has a 'Stacked' preset label" -Fq 'String(localized: "Stacked")' "$PANE"
-
-# 7. MenuBarPane persists the new key via @AppStorage.
-check "MenuBarPane binds the new key via @AppStorage" -Fq "@AppStorage(\"$KEY\")" "$PANE"
-
-# 8. Selecting a preset applies the stacked flag.
-check "applyPreset writes the stacked flag" -Eq 'menubarStacked[[:space:]]*=[[:space:]]*preset\.stacked' "$PANE"
-
-# 9. The preset model carries a 'stacked' field.
-check "MenuBarPreset model has a 'stacked' field" -Eq 'let[[:space:]]+stacked:[[:space:]]*Bool' "$PANE"
-
-# 10. Preview can render a two-line (stacked) chip.
-check "preview supports a two-line/stacked chip (bottomLabel)" -Eq 'bottomLabel' "$PANE"
-
-# 11. UAT r5: stacked menu-bar item height tracks the live bar thickness (a fixed/oversized height
-#     overflows the 22pt bar and crams the time onto the bottom edge).
-check "menubarItemHeight tracks bar thickness" -Eq 'var menubarItemHeight: CGFloat \{ NSStatusBar\.system\.thickness \}' "$SCV"
-
-# 12. UAT fix: preset cards reserve two sample lines so the Stacked card doesn't grow its row.
-check "preset card reserves two sample lines" -Fq 'reservesSpace: true' "$PANE"
-
-# 13. UAT r2: stacked menu-bar name line uses semibold (matches the cleaner preview), not bold.
-check "menu-bar name font is semibold" -Eq 'systemFont\(ofSize: 10, weight: .semibold\)' "$SIV"
-if grep -q 'boldSystemFont(ofSize: 10)' "$SIV"; then bad "menu-bar name still uses boldSystemFont"; else ok "menu-bar name no longer boldSystemFont"; fi
-
-# 14. UAT r2: preset card sample is right-justified.
-check "preset card sample is right-justified" -Fq 'multilineTextAlignment(.trailing)' "$PANE"
-
-# 15. UAT r2: 'Check Now' lives on its own row (empty-label FormRow under the segment).
-check "Check Now is on its own FormRow" -Eq 'FormRow\(label: ""\)' "$GP"
-
-# 16. UAT r2: fresh-install start-at-login default.
-check "enableStartAtLoginByDefault exists" -Eq 'func enableStartAtLoginByDefault' "$APPD"
-check "start-at-login wired into launch" -Eq 'enableStartAtLoginByDefault\(\)' "$APPD"
-
-# 17. UAT r2: fresh-install daily update cadence.
-check "fresh-install sets daily update interval (86400)" -Eq 'updateCheckInterval = 86400' "$APPD"
-
-# 18. UAT r5: stacked lines have their text centres placed symmetrically about the bar middle
-#     (verified by screenshot: tight, centred pair, time off the bottom edge).
-check "stacked name text centred above the middle" -Fq 'locationView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -halfGap)' "$SIV"
-check "stacked time text centred below the middle" -Fq 'timeView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: halfGap)' "$SIV"
-if grep -q 'multiplier: 0.35\|multiplier: 0.5' "$SIV"; then bad "stacked still uses a proportional split"; else ok "stacked no longer uses a proportional split"; fi
-
-# 19. UAT r5: General-pane command buttons use the visible ShadedButtonStyle (the system .bordered
-#     style was near-invisible on the dark canvas); no .plain command buttons remain.
-check "command buttons use ShadedButtonStyle" -Fq 'buttonStyle(ShadedButtonStyle())' "$GP"
-check "ShadedButtonStyle is defined" -Fq 'struct ShadedButtonStyle: ButtonStyle' "$GP"
-if grep -q 'buttonStyle(.plain)' "$GP"; then bad "GeneralPane still has a .plain command button"; else ok "no .plain command buttons remain in GeneralPane"; fi
-
-# 20. UAT r5: stacked menu-bar item height matches the bar (no fixed 30pt that overflowed the 22pt bar).
-if grep -q 'stackedMenubarItemHeight\|multiplier: 0.5\|: 30' "$SCV"; then bad "stacked item still uses a fixed/oversized height"; else ok "stacked item height matches the bar thickness"; fi
-
-# 21. UAT r6: the Daybreak panel sits below the bar (gap), not flush against it.
-DPC="Meridian/Panel/Daybreak/DaybreakPanelController.swift"
-check "panel anchors with a gap below the bar" -Fq 'buttonRect.minY + bodyTopInset - bodyGapBelowBar' "$DPC"
-
-# --- New "Midnight Sundial" icons ---
-AIS="Meridian/Media.xcassets/AppIcon.appiconset"
-MBI="Meridian/Media.xcassets/MenuBarIcon.imageset"
-SIH="Meridian/Preferences/Menu Bar/StatusItemHandler.swift"
-FAD="Meridian/Overall App/Foundation + Additions.swift"
-
-# 22. New AppIcon iconset present (all 10), old Clocker/meridian-* art gone.
-if [ "$(find "$AIS" -name 'icon_*.png' | wc -l | tr -d ' ')" = "10" ]; then ok "AppIcon has the 10 new icon_*.png"; else bad "AppIcon missing new icon_*.png"; fi
-if find "$AIS" -iname '*clocker*' -o -iname 'meridian-*.png' 2>/dev/null | grep -q .; then bad "old Clocker/meridian-* app-icon art still present"; else ok "old app-icon art removed"; fi
-check "AppIcon Contents.json maps the new files" -Fq 'icon_512x512@2x.png' "$AIS/Contents.json"
-
-# 23. MenuBarIcon template imageset present and rendered as template.
-if [ -f "$MBI/MenuBarIcon.png" ] && [ -f "$MBI/MenuBarIcon@2x.png" ]; then ok "MenuBarIcon imageset has the template pair"; else bad "MenuBarIcon imageset PNGs missing"; fi
-check "MenuBarIcon renders as a template image" -Fq '"template-rendering-intent" : "template"' "$MBI/Contents.json"
-
-# 24. Old unused menu-bar icon asset removed.
-if [ -d "Meridian/Media.xcassets/Menubar Icons" ]; then bad "old 'Menubar Icons' (LightModeIcon) folder still present"; else ok "old 'Menubar Icons' folder removed"; fi
-
-# 25. Code loads the template glyph (not the old clock.fill SF Symbol).
-check "menubarIcon name points at MenuBarIcon" -Fq 'NSImage.Name("MenuBarIcon")' "$FAD"
-check "status item loads the template icon" -Fq 'NSImage(named: .menubarIcon)' "$SIH"
-check "status item icon is set as a template" -Eq 'image\?\.isTemplate = true' "$SIH"
-if grep -q 'clock.fill' "$SIH"; then bad "still references the clock.fill SF Symbol"; else ok "no clock.fill reference remains"; fi
-
-echo ""
-if [[ "${1:-}" == "--no-build" ]]; then
-  echo "Skipping build (--no-build)."
+# Raw, unescaped interpolation into <li> must be gone.
+if grep -Fq '<li>$line</li>' "$RS"; then
+  bad "appcast <li> items no longer interpolate raw \$line"
 else
-  echo "Building (Debug, no code signing)…"
-  BUILD_LOG=$(mktemp)
-  if xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \
-       CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= \
-       >"$BUILD_LOG" 2>&1; then
-    ok "Debug build succeeded"
+  ok "appcast <li> items no longer interpolate raw \$line"
+fi
+
+# The GitHub release body (markdown) must remain UNescaped.
+check "GitHub release body still uses raw notes (markdown, unescaped)" -Fq 'echo "- $line"' "$RS"
+
+# Behavior test: extract html_escape and run it against nasty inputs.
+FN_FILE="$(mktemp "${TMPDIR:-/tmp}/meridian-html-escape.XXXXXX")"
+sed -n '/^html_escape()/,/^}/p' "$RS" > "$FN_FILE"
+if [[ -s "$FN_FILE" ]]; then
+  # shellcheck disable=SC1090
+  source "$FN_FILE"
+  if declare -f html_escape >/dev/null; then
+    t1="$(html_escape 'Fix A & B')"
+    t2="$(html_escape 'Show <n> zones')"
+    t3="$(html_escape 'end ]]> boom')"
+    [[ "$t1" == 'Fix A &amp; B' ]]        && ok "escape: 'Fix A & B' -> '$t1'"        || bad "escape: 'Fix A & B' gave '$t1' (want 'Fix A &amp; B')"
+    [[ "$t2" == 'Show &lt;n&gt; zones' ]] && ok "escape: 'Show <n> zones' -> '$t2'"   || bad "escape: 'Show <n> zones' gave '$t2' (want 'Show &lt;n&gt; zones')"
+    [[ "$t3" == 'end ]]&gt; boom' ]]      && ok "escape: 'end ]]> boom' -> '$t3' (CDATA-safe)" || bad "escape: 'end ]]> boom' gave '$t3' (want 'end ]]&gt; boom')"
   else
-    bad "Debug build FAILED — see $BUILD_LOG"
-    tail -25 "$BUILD_LOG" >&2
+    bad "html_escape could not be sourced for behavior tests (3 checks skipped)"
+    FAIL=$((FAIL+2))
   fi
+else
+  bad "html_escape not extractable from release.sh (behavior tests skipped)"
+  FAIL=$((FAIL+2))
+fi
+rm -f "$FN_FILE"
+
+# ── 2. xmllint gate before committing appcast ───────────────────────
+check "release.sh runs 'xmllint --noout' on the generated appcast" -Fq 'xmllint --noout' "$RS"
+check "xmllint listed as a required tool" -Eq 'for cmd in .*xmllint' "$RS"
+
+XMLLINT_LINE="$(first_line 'xmllint --noout' "$RS")"
+GITADD_LINE="$(first_line 'git add "\$APPCAST"' "$RS")"
+if [[ "$XMLLINT_LINE" -gt 0 && "$GITADD_LINE" -gt 0 && "$XMLLINT_LINE" -lt "$GITADD_LINE" ]]; then
+  ok "xmllint gate runs BEFORE 'git add appcast.xml' (line $XMLLINT_LINE < $GITADD_LINE)"
+else
+  bad "xmllint gate runs BEFORE 'git add appcast.xml' (xmllint@$XMLLINT_LINE, git add@$GITADD_LINE)"
 fi
 
+# ── 3. Version-bump push deferred until after notarization ──────────
+# Match actual push COMMANDS (top-level or 'if ! ...'), not echo'd recovery text.
+NOTARIZE_LINE="$(first_line 'notarytool submit' "$RS")"
+PUSH_LINE="$(first_line -E '^(if ! )?git push origin main' "$RS")"
+if [[ "$PUSH_LINE" -gt 0 && "$NOTARIZE_LINE" -gt 0 && "$PUSH_LINE" -gt "$NOTARIZE_LINE" ]]; then
+  ok "first 'git push origin main' happens AFTER notarization (line $PUSH_LINE > $NOTARIZE_LINE)"
+else
+  bad "first 'git push origin main' happens AFTER notarization (push@$PUSH_LINE, notarize@$NOTARIZE_LINE)"
+fi
+
+GHREL_LINE="$(first_line -E '^[[:space:]]*gh release create' "$RS")"
+if [[ "$PUSH_LINE" -gt 0 && "$GHREL_LINE" -gt 0 && "$PUSH_LINE" -lt "$GHREL_LINE" ]]; then
+  ok "bump push happens BEFORE 'gh release create' (line $PUSH_LINE < $GHREL_LINE)"
+else
+  bad "bump push happens BEFORE 'gh release create' (push@$PUSH_LINE, gh release@$GHREL_LINE)"
+fi
+
+check "EXIT trap installed for failure-state reporting" -Eq 'trap .* EXIT' "$RS"
+check "recovery report function exists" -Eq 'report_release_state\(\)' "$RS"
+
+# ── 4. gh release create pinned with --target ───────────────────────
+check "gh release create uses --target with a captured rev" -Eq 'gh release create .*--target "\$RELEASE_REV"' "$RS"
+check "RELEASE_REV captured via git rev-parse HEAD" -Fq 'RELEASE_REV="$(git rev-parse HEAD)"' "$RS"
+
+# ── 5. Sparkle re-signing: dynamic version dir + fail loudly ────────
+if grep -Fq 'Versions/B' "$RS"; then
+  bad "hardcoded Sparkle 'Versions/B' path removed"
+else
+  ok "hardcoded Sparkle 'Versions/B' path removed"
+fi
+check "Sparkle version dir resolved dynamically (Versions/Current)" -Fq 'Versions/Current' "$RS"
+check "Sparkle XPC signing counts what it signed" -Eq 'XPC_COUNT' "$RS"
+check "Sparkle signing aborts if XPC/helper globs match nothing" -Eq 'XPC_COUNT -eq 0 .*HELPER_COUNT -eq 0' "$RS"
+
+# ── 6. Version monotonicity check ───────────────────────────────────
+check "extracts newest <sparkle:version> from appcast.xml" -Eq 'LATEST_APPCAST_BUILD' "$RS"
+check "aborts unless BUILD_NUMBER strictly greater" -Eq 'BUILD_NUMBER <= LATEST_APPCAST_BUILD' "$RS"
+
+# ── 7. RELEASE_DIR via mktemp ───────────────────────────────────────
+check "RELEASE_DIR uses mktemp -d (no fixed world-writable path)" -Fq 'RELEASE_DIR="$(mktemp -d /tmp/meridian-release.XXXXXX)"' "$RS"
+if grep -Eq '^RELEASE_DIR="/tmp/meridian-release"' "$RS"; then
+  bad "fixed RELEASE_DIR=/tmp/meridian-release removed"
+else
+  ok "fixed RELEASE_DIR=/tmp/meridian-release removed"
+fi
+
+# ── 8. Current repo appcast is valid (sanity of the gate itself) ────
+if xmllint --noout appcast.xml 2>/dev/null; then
+  ok "current appcast.xml passes xmllint --noout"
+else
+  bad "current appcast.xml passes xmllint --noout"
+fi
+
+TOTAL_ENC="$(xmllint --xpath 'count(//enclosure)' appcast.xml 2>/dev/null)"
+VALID_ENC="$(xmllint --xpath 'count(//enclosure[string-length(@*[local-name()="edSignature"]) > 0 and string-length(@length) > 0])' appcast.xml 2>/dev/null)"
+if [[ -n "$TOTAL_ENC" && "$TOTAL_ENC" -gt 0 && "$TOTAL_ENC" == "$VALID_ENC" ]]; then
+  ok "all $TOTAL_ENC current enclosures carry non-empty edSignature + length"
+else
+  bad "all current enclosures carry non-empty edSignature + length (total=$TOTAL_ENC valid=$VALID_ENC)"
+fi
+
+# ── 9. Appcast-validate CI workflow ─────────────────────────────────
+if [[ -f "$WF" ]]; then
+  ok "workflow $WF exists"
+  check "workflow triggers on push" -Eq '^  push:' "$WF"
+  check "workflow triggers on pull_request" -Eq '^  pull_request:' "$WF"
+  check "workflow is path-filtered to appcast.xml" -Fq "'appcast.xml'" "$WF"
+  check "workflow runs on ubuntu-latest" -Fq 'ubuntu-latest' "$WF"
+  check "workflow installs libxml2-utils when needed" -Fq 'libxml2-utils' "$WF"
+  check "workflow runs xmllint --noout appcast.xml" -Fq 'xmllint --noout appcast.xml' "$WF"
+  check "workflow checks enclosure edSignature attribute" -Fq 'edSignature' "$WF"
+  check "workflow checks enclosure length attribute" -Fq '@length' "$WF"
+  # Loose YAML sanity if PyYAML is available; skip silently otherwise.
+  if python3 -c 'import yaml' 2>/dev/null; then
+    if python3 -c "import yaml; yaml.safe_load(open('$WF'))" 2>/dev/null; then
+      ok "workflow YAML parses (PyYAML)"
+    else
+      bad "workflow YAML parses (PyYAML)"
+    fi
+  fi
+else
+  bad "workflow $WF exists (8 sub-checks skipped)"
+  FAIL=$((FAIL+8))
+fi
+
+# ── 10. Existing behavior preserved ─────────────────────────────────
+check "beta prerelease flag preserved" -Fq -- '--prerelease' "$RS"
+check "beta sparkle channel tag preserved" -Fq '<sparkle:channel>beta</sparkle:channel>' "$RS"
+check "idempotent re-run path preserved (skip commit when version already set)" -Fq 'skipping commit' "$RS"
+check "stable-from-main branch check preserved" -Fq "Stable releases must be cut from 'main'" "$RS"
+check "Homebrew cask skip for betas preserved" -Fq 'Skipping Homebrew cask update for beta release' "$RS"
+
 echo ""
-echo "------------------------------------------------"
-echo "PASS=$PASS  FAIL=$FAIL"
-[[ "$FAIL" -eq 0 ]] && { echo "ALL GREEN"; exit 0; } || { echo "FAILURES PRESENT"; exit 1; }
+echo "---------------------------------------"
+echo "PASS: $PASS   FAIL: $FAIL"
+if [[ $FAIL -gt 0 ]]; then
+  exit 1
+fi
+echo "All checks passed."


### PR DESCRIPTION
- Improve the reliability and safety of app update delivery

## Technical detail (not for release notes)

Hardens `scripts/release.sh` and CI per the release-pipeline audit. No app code changes.

1. Release notes are HTML-escaped before insertion into the appcast CDATA (`&`, `<`, `>`; neutralizes `]]>`), and the generated feed must pass `xmllint --noout` *before* it replaces `appcast.xml` or gets committed — a malformed feed can no longer reach users. `xmllint` added to preflight checks.
2. New lightweight workflow `.github/workflows/appcast-validate.yml` validates `appcast.xml` on any push/PR touching it (well-formedness + every enclosure has non-empty `sparkle:edSignature` and `length`), closing the `paths-ignore` CI gap without triggering full app builds.
3. The version-bump commit stays local until build → sign → notarize → staple all succeed; an EXIT trap reports exact recovery state (bump pushed or local-only, release created or not, appcast committed/pushed or not) on any failure. Re-runs still resume safely via the existing "version already set" path.
4. `gh release create` now pins `--target` to the exact commit the release was built from, eliminating the tag/build race. The pre-release push sends the *current* branch so the target SHA exists on origin for feature-branch betas too.
5. Sparkle re-signing resolves the framework version dir dynamically (no hardcoded `Versions/B`), counts what it signs, and aborts if XPC services, helper apps, Autoupdate, or the framework itself are missing — a Sparkle layout change can never silently ship unsigned installer components.
6. Version-monotonicity gate: the derived build number must be strictly greater than the newest appcast item's `<sparkle:version>`, preventing accidental downgrades of the appcast/Homebrew cask.
7. Release staging moved from fixed world-writable `/tmp/meridian-release` to `mktemp -d`.

Validation: TDD script 41/41 checks passing (10/41 before implementation); shellcheck clean; hostile-notes end-to-end test confirms the escape+xmllint gate catches the old corruption. Preserved behaviors verified: beta prerelease flag, `<sparkle:channel>beta</sparkle:channel>`, Homebrew skip for betas, idempotent re-run, stable-from-main enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUpXyziq1Tss3nZBQ8u348