### PR TITLE
Add time formats with seconds

### DIFF
--- a/Meridian/App/Localizable.xcstrings
+++ b/Meridian/App/Localizable.xcstrings
@@ -72,6 +72,16 @@
         }
       }
     },
+    "12-hour with seconds": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "12-hour with seconds"
+          }
+        }
+      }
+    },
     "15 min": {
       "localizations": {
         "en": {
@@ -98,6 +108,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "24-hour time"
+          }
+        }
+      }
+    },
+    "24-hour with seconds": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "24-hour with seconds"
           }
         }
       }

--- a/Meridian/App/Localizable.xcstrings
+++ b/Meridian/App/Localizable.xcstrings
@@ -72,16 +72,6 @@
         }
       }
     },
-    "12-hour with seconds": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "12-hour with seconds"
-          }
-        }
-      }
-    },
     "15 min": {
       "localizations": {
         "en": {
@@ -108,16 +98,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "24-hour time"
-          }
-        }
-      }
-    },
-    "24-hour with seconds": {
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "24-hour with seconds"
           }
         }
       }
@@ -838,6 +818,16 @@
           "stringUnit": {
             "state": "translated",
             "value": "Show in menu bar"
+          }
+        }
+      }
+    },
+    "Show seconds": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show seconds"
           }
         }
       }

--- a/Meridian/App/Localizable.xcstrings
+++ b/Meridian/App/Localizable.xcstrings
@@ -772,6 +772,16 @@
         }
       }
     },
+    "Seconds": {
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Seconds"
+          }
+        }
+      }
+    },
     "Set color": {
       "localizations": {
         "en": {

--- a/Meridian/MeridianUnitTests/DaybreakEngineTests.swift
+++ b/Meridian/MeridianUnitTests/DaybreakEngineTests.swift
@@ -281,6 +281,36 @@ final class DaybreakViewModelTravelTests: XCTestCase {
         XCTAssertEqual(vm.travelOffsetMinutes, 0)
     }
 
+    /// The popover clocks honor Settings › Appearance → "Show seconds": the hero time carries a
+    /// live ":SS" suffix when the format includes seconds, drops it for plain formats, and
+    /// suppresses it while time-traveling (scrubbed times are minute-granular hypotheticals).
+    func testHeroSecondsFollowShowSecondsSetting() {
+        // Fixed instant; derive the expected suffix the same way the VM does.
+        let now = Date(timeIntervalSinceReferenceDate: 700_000_000)
+        let expectedSuffix = String(format: ":%02d", Calendar.current.component(.second, from: now))
+
+        let suite = "DaybreakSecondsTest"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        let store = DataStore(with: defaults)
+
+        store.timeFormat = .twelveHourWithSeconds
+        // init() recomputes with the injected `now` — do NOT call refresh(),
+        // which deliberately resets `now` to the live wall clock.
+        let vm = DaybreakViewModel(store: store, now: now)
+        XCTAssertTrue(vm.snapshot.hero.time.hasSuffix(expectedSuffix),
+                      "hero time '\(vm.snapshot.hero.time)' should end with '\(expectedSuffix)'")
+
+        vm.setOffset(90)                                   // time travel suppresses seconds
+        XCTAssertEqual(vm.snapshot.hero.time.filter { $0 == ":" }.count, 1,
+                       "traveled hero time '\(vm.snapshot.hero.time)' must stay minute-granular (H:MM)")
+
+        store.timeFormat = .twelveHour                     // plain format shows no seconds
+        let plainVM = DaybreakViewModel(store: store, now: now)
+        XCTAssertEqual(plainVM.snapshot.hero.time.filter { $0 == ":" }.count, 1,
+                       "plain 12-hour hero time '\(plainVM.snapshot.hero.time)' should be H:MM")
+    }
+
     /// Sliding from an off-grid wall clock (e.g. 1:46) must land the traveled time on a clean
     /// snap-step boundary (3:15, not 3:16) — the legacy quarter-hour base, recreated. The grid anchor
     /// is frozen at travel start, so every real zone (a whole number of 15-min steps from UTC) shows

--- a/Meridian/MeridianUnitTests/MeridianUnitTests.swift
+++ b/Meridian/MeridianUnitTests/MeridianUnitTests.swift
@@ -799,6 +799,47 @@ class DataStoreTypedAccessorsTests: XCTestCase {
         }
     }
 
+    // MARK: menu-bar seconds (independent of the popover's timeFormat)
+
+    func testMenubarShowSeconds_roundTrip() {
+        XCTAssertFalse(store.menubarShowSeconds, "unset key should read false (registered default is false)")
+        store.menubarShowSeconds = true
+        XCTAssertTrue(defaults.bool(forKey: UserDefaultKeys.showSecondsInMenubar))
+        XCTAssertTrue(store.menubarShowSeconds)
+        store.menubarShowSeconds = false
+        XCTAssertFalse(store.menubarShowSeconds)
+    }
+
+    func testMenubarTimezoneFormat_hourStyleFromTimeFormatSecondsFromMenubarPref() {
+        // (Appearance timeFormat, menubarShowSeconds) → expected menu-bar format.
+        let matrix: [(TimeFormat, Bool, TimeFormat)] = [
+            (.twelveHour, false, .twelveHour),
+            (.twelveHour, true, .twelveHourWithSeconds),
+            (.twentyFourHour, false, .twentyFourHour),
+            (.twentyFourHour, true, .twentyFourHourWithSeconds),
+            // Appearance seconds (popover) must NOT leak into the menu bar…
+            (.twelveHourWithSeconds, false, .twelveHour),
+            (.twentyFourHourWithSeconds, false, .twentyFourHour),
+            // …while both surfaces can show seconds together when asked.
+            (.twelveHourWithSeconds, true, .twelveHourWithSeconds),
+            (.twentyFourHourWithSeconds, true, .twentyFourHourWithSeconds),
+        ]
+        for (appearance, menubarSeconds, expected) in matrix {
+            store.timeFormat = appearance
+            store.menubarShowSeconds = menubarSeconds
+            XCTAssertEqual(store.menubarTimezoneFormat(), NSNumber(value: expected.rawValue),
+                           "timeFormat=\(appearance), menubarShowSeconds=\(menubarSeconds)")
+        }
+    }
+
+    func testMenubarTimezoneFormat_leavesPopoverFormatAlone() {
+        store.timeFormat = .twelveHourWithSeconds
+        store.menubarShowSeconds = false
+        // The popover keeps its seconds; only the menu bar drops them.
+        XCTAssertEqual(store.timezoneFormat(), NSNumber(value: TimeFormat.twelveHourWithSeconds.rawValue))
+        XCTAssertEqual(store.menubarTimezoneFormat(), NSNumber(value: TimeFormat.twelveHour.rawValue))
+    }
+
     // MARK: parity with shouldDisplay()
 
     // shouldDisplay(_:) now delegates to typed accessors; these asserts make
@@ -1099,6 +1140,7 @@ class SettingsManagerVersioningTests: XCTestCase {
         let showDayInMenubar: Bool
         let showDateInMenubar: Bool
         let showPlaceNameInMenubar: Bool
+        let menubarShowSeconds: Bool
         let floatOnTop: Bool
         let theme: Theme
         let relativeDateDisplay: RelativeDateDisplay
@@ -1117,6 +1159,7 @@ class SettingsManagerVersioningTests: XCTestCase {
             showDayInMenubar: s.showDayInMenubar,
             showDateInMenubar: s.showDateInMenubar,
             showPlaceNameInMenubar: s.showPlaceNameInMenubar,
+            menubarShowSeconds: s.menubarShowSeconds,
             floatOnTop: s.floatOnTop,
             theme: s.theme,
             relativeDateDisplay: s.relativeDateDisplay,
@@ -1132,6 +1175,7 @@ class SettingsManagerVersioningTests: XCTestCase {
         s.showDayInMenubar = preserved.showDayInMenubar
         s.showDateInMenubar = preserved.showDateInMenubar
         s.showPlaceNameInMenubar = preserved.showPlaceNameInMenubar
+        s.menubarShowSeconds = preserved.menubarShowSeconds
         s.floatOnTop = preserved.floatOnTop
         s.theme = preserved.theme
         s.relativeDateDisplay = preserved.relativeDateDisplay
@@ -1265,6 +1309,42 @@ class SettingsManagerVersioningTests: XCTestCase {
         UserDefaults.standard.set(false, forKey: UserDefaultKeys.betaUpdatesEnabled)
         try SettingsManager.applySettings(from: data)
         XCTAssertTrue(UserDefaults.standard.bool(forKey: UserDefaultKeys.betaUpdatesEnabled))
+    }
+
+    // MARK: menu-bar seconds (independent of timeFormat's popover seconds)
+
+    func testExport_menubarShowSecondsRoundTrip() throws {
+        let s = DataStore.shared()
+        s.menubarShowSeconds = true
+        guard let data = SettingsManager.buildJSON(),
+              let json = parse(data),
+              let prefs = json["preferences"] as? [String: Any] else {
+            XCTFail("export failed")
+            return
+        }
+        XCTAssertEqual(prefs["showSecondsInMenubar"] as? Bool, true)
+
+        // Mutate to confirm import actually overwrites.
+        s.menubarShowSeconds = false
+        try SettingsManager.applySettings(from: data)
+        XCTAssertTrue(s.menubarShowSeconds)
+    }
+
+    func testImport_missingMenubarSecondsKeyLeavesValueAlone() throws {
+        // Older v2 exports predate the key; like the other bools, an absent
+        // key must leave the current value untouched.
+        let s = DataStore.shared()
+        s.menubarShowSeconds = true
+        let payload: [String: Any] = [
+            "version": 2,
+            "preferences": ["showDayInMenubar": true],
+            "timezones": [String](),
+            "startAtLogin": false,
+            "sparkle": [String: Any]()
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        try SettingsManager.applySettings(from: data)
+        XCTAssertTrue(s.menubarShowSeconds)
     }
 
     // MARK: global shortcut export/import (round-trips the universal hot key)

--- a/Meridian/MeridianUnitTests/MockDataStore.swift
+++ b/Meridian/MeridianUnitTests/MockDataStore.swift
@@ -61,6 +61,15 @@ class MockDataStore: DataStoring {
         return preferences[UserDefaultKeys.selectedTimeZoneFormatKey] as? NSNumber ?? NSNumber(integerLiteral: 0)
     }
 
+    // Mirrors DataStore.menubarTimezoneFormat(): hour style from the global
+    // format, seconds from the menu-bar-only pref (default false).
+    func menubarTimezoneFormat() -> NSNumber {
+        let base = TimeFormat(rawValue: timezoneFormat().intValue) ?? .twelveHour
+        let seconds = preferences[UserDefaultKeys.showSecondsInMenubar] as? Bool ?? false
+        let format = TimeFormat.standard(twentyFourHour: base.isTwentyFourHour, seconds: seconds)
+        return NSNumber(value: format.rawValue)
+    }
+
     func isBufferRequiredForTwelveHourFormats() -> Bool {
         let timeFormatsWithSuffix: Set<NSNumber> = Set([
             NSNumber(integerLiteral: 0),
@@ -69,7 +78,8 @@ class MockDataStore: DataStoring {
             NSNumber(integerLiteral: 6),
             NSNumber(integerLiteral: 7)
         ])
-        return timeFormatsWithSuffix.contains(timezoneFormat())
+        // Menu-bar-only width heuristic — keys off the menu-bar format, like DataStore.
+        return timeFormatsWithSuffix.contains(menubarTimezoneFormat())
     }
 
     func shouldShowDateInMenubar() -> Bool {

--- a/Meridian/Overall App/AppDefaults.swift
+++ b/Meridian/Overall App/AppDefaults.swift
@@ -261,6 +261,11 @@ class AppDefaults {
             UserDefaultKeys.floatOnTop: false,
             UserDefaultKeys.timeFormat: TimeFormat.twelveHour.rawValue,
 
+            // Menu-bar-only seconds toggle (Settings › Menu Bar). Off by
+            // default — seconds crowd the menu bar; the popover's seconds
+            // stay on `timeFormat` (Appearance › Show seconds).
+            UserDefaultKeys.showSecondsInMenubar: false,
+
             // Untouched.
             UserDefaultKeys.startAtLogin: 0,
             UserDefaultKeys.userFontSizePreference: AppDefaultValues.defaultUserFontSize,

--- a/Meridian/Overall App/DataStore.swift
+++ b/Meridian/Overall App/DataStore.swift
@@ -284,6 +284,39 @@ enum TimeFormat: Int, Codable, CaseIterable {
     case epoch = 11
 }
 
+extension TimeFormat {
+    /// Formats whose rendered time includes seconds ("ss"). These are the
+    /// formats that put StatusItemHandler's menubar timer on a per-second tick.
+    var includesSeconds: Bool {
+        switch self {
+        case .twelveHourWithSeconds, .twentyFourHourWithSeconds,
+             .twelveHourWithLeadingZeroAndSeconds, .twelveHourWithoutAmPmAndSeconds:
+            return true
+        case .twelveHour, .twentyFourHour, .twelveHourWithLeadingZero,
+             .twelveHourWithoutAmPm, .epoch:
+            return false
+        }
+    }
+
+    /// True for the 24-hour clock formats.
+    var isTwentyFourHour: Bool {
+        self == .twentyFourHour || self == .twentyFourHourWithSeconds
+    }
+
+    /// The v4-picker format for a 12/24-hour choice, carrying the seconds
+    /// preference along. Lets the Menu Bar pane's 24-hour toggle and presets
+    /// flip the hour style without discarding a "… with seconds" selection
+    /// made in Settings › Appearance.
+    static func standard(twentyFourHour: Bool, seconds: Bool) -> TimeFormat {
+        switch (twentyFourHour, seconds) {
+        case (false, false): return .twelveHour
+        case (false, true): return .twelveHourWithSeconds
+        case (true, false): return .twentyFourHour
+        case (true, true): return .twentyFourHourWithSeconds
+        }
+    }
+}
+
 // Stable string name for typed preference enums via the JSONNameDecodable
 // protocol (declared near the top of this file). Used by SettingsManager v2
 // JSON export ("compact" instead of 0). Names are derived from the Swift

--- a/Meridian/Overall App/DataStore.swift
+++ b/Meridian/Overall App/DataStore.swift
@@ -26,6 +26,7 @@ protocol DataStoring: AnyObject {
     func addTimezone(_ timezone: TimezoneData)
     func removeLastTimezone()
     func timezoneFormat() -> NSNumber
+    func menubarTimezoneFormat() -> NSNumber
     func isBufferRequiredForTwelveHourFormats() -> Bool
     func shouldShowDateInMenubar() -> Bool
     func shouldShowDayInMenubar() -> Bool
@@ -148,8 +149,22 @@ class DataStore: NSObject, DataStoring {
         return NSNumber(value: timeFormat.rawValue)
     }
 
+    /// The global time format for the MENU BAR clock. Hour style (12/24)
+    /// follows `timeFormat` (Settings › Appearance), but seconds come from
+    /// the menu-bar-only `menubarShowSeconds` pref (Settings › Menu Bar ›
+    /// Seconds) so the crowded menu bar and the roomier Daybreak popover can
+    /// show seconds independently. Per-city `overrideFormat` still wins —
+    /// callers pass this number into `TimezoneData.timezoneFormat(_:)` /
+    /// `shouldShowSeconds(_:)` exactly like `timezoneFormat()`.
+    func menubarTimezoneFormat() -> NSNumber {
+        let format = TimeFormat.standard(twentyFourHour: timeFormat.isTwentyFourHour, seconds: menubarShowSeconds)
+        return NSNumber(value: format.rawValue)
+    }
+
+    // Menu-bar-only width heuristic (StatusItemHandler.bufferCalculatedWidth),
+    // so it keys off the menu-bar format, not the popover's.
     func isBufferRequiredForTwelveHourFormats() -> Bool {
-        return DataStore.timeFormatsWithSuffix.contains(timezoneFormat())
+        return DataStore.timeFormatsWithSuffix.contains(menubarTimezoneFormat())
     }
 
     // shouldDisplay(_:) is the legacy entry point — kept for source-compat
@@ -363,6 +378,13 @@ extension DataStore {
     var floatOnTop: Bool {
         get { userDefaults.bool(forKey: UserDefaultKeys.floatOnTop) }
         set { userDefaults.set(newValue, forKey: UserDefaultKeys.floatOnTop) }
+    }
+
+    // Seconds in the menu-bar clock only (Settings › Menu Bar › Seconds;
+    // default false). The popover's seconds live in `timeFormat` below.
+    var menubarShowSeconds: Bool {
+        get { userDefaults.bool(forKey: UserDefaultKeys.showSecondsInMenubar) }
+        set { userDefaults.set(newValue, forKey: UserDefaultKeys.showSecondsInMenubar) }
     }
 
     // Enums (Int-backed; raw values match the popup/segment selectedIndex).

--- a/Meridian/Overall App/SettingsManager.swift
+++ b/Meridian/Overall App/SettingsManager.swift
@@ -100,6 +100,7 @@ struct SettingsManager {
         static let showDayInMenubar = "showDayInMenubar"
         static let showDateInMenubar = "showDateInMenubar"
         static let showPlaceNameInMenubar = "showPlaceNameInMenubar"
+        static let showSecondsInMenubar = "showSecondsInMenubar"
         static let floatOnTop = "floatOnTop"
         static let theme = "theme"
         static let relativeDateDisplay = "relativeDateDisplay"
@@ -131,6 +132,7 @@ struct SettingsManager {
             V2Key.showDayInMenubar: store.showDayInMenubar,
             V2Key.showDateInMenubar: store.showDateInMenubar,
             V2Key.showPlaceNameInMenubar: store.showPlaceNameInMenubar,
+            V2Key.showSecondsInMenubar: store.menubarShowSeconds,
             V2Key.floatOnTop: store.floatOnTop,
             V2Key.theme: store.theme.jsonName,
             V2Key.relativeDateDisplay: store.relativeDateDisplay.jsonName,
@@ -313,6 +315,9 @@ struct SettingsManager {
         if let v = prefs[V2Key.showDayInMenubar] as? Bool { store.showDayInMenubar = v }
         if let v = prefs[V2Key.showDateInMenubar] as? Bool { store.showDateInMenubar = v }
         if let v = prefs[V2Key.showPlaceNameInMenubar] as? Bool { store.showPlaceNameInMenubar = v }
+        // Absent in pre-4.2 exports — like the other bools, a missing key
+        // leaves the current value (registered default false on fresh installs).
+        if let seconds = prefs[V2Key.showSecondsInMenubar] as? Bool { store.menubarShowSeconds = seconds }
         if let v = prefs[V2Key.floatOnTop] as? Bool { store.floatOnTop = v }
 
         // Enums — parse the case name string. Unknown names fall through to

--- a/Meridian/Overall App/Strings.swift
+++ b/Meridian/Overall App/Strings.swift
@@ -54,6 +54,11 @@ public enum UserDefaultKeys {
     static let showPlaceNameInMenubar = "showPlaceNameInMenubar"
     static let floatOnTop = "floatOnTop"
     static let timeFormat = "timeFormat"
+    // Seconds in the menu-bar clock only (Settings › Menu Bar › Seconds).
+    // Independent of `timeFormat`'s seconds, which drives the Daybreak
+    // popover — UAT: seconds crowd the menu bar but are fine in the popover.
+    // Read via DataStore.menubarShowSeconds / menubarTimezoneFormat().
+    static let showSecondsInMenubar = "showSecondsInMenubar"
 
     // One-time migration flag. Set after runBoolSemanticsMigration completes
     // its first successful pass; read on every launch to make the migration

--- a/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
+++ b/Meridian/Panel/Data Layer/TimezoneDataOperations.swift
@@ -41,11 +41,23 @@ class TimezoneDataOperations {
 
 extension TimezoneDataOperations {
     func time(with sliderValue: Int) -> String {
+        return formattedTime(with: sliderValue, globalFormat: store.timezoneFormat())
+    }
+
+    /// Menu-bar variant of `time(with:)` — identical rendering, but driven by
+    /// `DataStore.menubarTimezoneFormat()` (hour style from Appearance,
+    /// seconds from the Menu Bar pane's Seconds toggle) instead of the
+    /// popover/panel format. Used by the compactMenu* strings only.
+    func menubarTime(with sliderValue: Int) -> String {
+        return formattedTime(with: sliderValue, globalFormat: store.menubarTimezoneFormat())
+    }
+
+    private func formattedTime(with sliderValue: Int, globalFormat: NSNumber) -> String {
         let newDate = TimezoneDataOperations.gregorianCalendar.date(byAdding: .minute,
                                                                      value: sliderValue,
                                                                      to: Date()) ?? Date()
 
-        if dataObject.timezoneFormat(store.timezoneFormat()) == DateFormat.epochTime {
+        if dataObject.timezoneFormat(globalFormat) == DateFormat.epochTime {
             let timezone = TimeZone(identifier: dataObject.timezone())
             let offset = timezone?.secondsFromGMT(for: newDate) ?? 0
             let value = Int(Date().timeIntervalSince1970 + Double(offset))
@@ -53,7 +65,7 @@ extension TimezoneDataOperations {
         }
 
         let dateFormatter = DateFormatterManager.dateFormatterWithFormat(with: .none,
-                                                                         format: dataObject.timezoneFormat(store.timezoneFormat()),
+                                                                         format: dataObject.timezoneFormat(globalFormat),
                                                                          timezoneIdentifier: dataObject.timezone(),
                                                                          locale: Locale.autoupdatingCurrent)
 
@@ -150,9 +162,9 @@ extension TimezoneDataOperations {
         }
 
         if subtitle.isEmpty {
-            subtitle.append(time(with: 0))
+            subtitle.append(menubarTime(with: 0))
         } else {
-            subtitle.append(" \(time(with: 0))")
+            subtitle.append(" \(menubarTime(with: 0))")
         }
 
         return subtitle
@@ -169,7 +181,7 @@ extension TimezoneDataOperations {
         if store.shouldShowDayInMenubar() {
             parts.append(date(with: 0, displayType: .menu)) // short weekday, e.g. "Mon"
         }
-        parts.append(time(with: 0))
+        parts.append(menubarTime(with: 0))
         if store.shouldShowDateInMenubar() {
             parts.append(Date().formatter(with: "d MMM", timeZone: dataObject.timezone()))
         }

--- a/Meridian/Panel/Daybreak/DaybreakViewModel.swift
+++ b/Meridian/Panel/Daybreak/DaybreakViewModel.swift
@@ -274,7 +274,8 @@ final class DaybreakViewModel: ObservableObject {
 
     private func makeHero(name: String, locationTraveling: Bool, timeZone: TimeZone, reference: Date,
                           localMinutes: Int, window: SunWindow, phase: DayPhase) -> DaybreakHeroData {
-        let (time, period) = formatTime(localMinutes)
+        var (time, period) = formatTime(localMinutes)
+        time += secondsSuffix(reference)
         let event = DaybreakEngine.nextSunEvent(localMinutes: localMinutes, sunrise: window.sunrise, sunset: window.sunset)
         let eventString = eventLabel(event)
         let dateString = string(fullDate, reference, timeZone)
@@ -311,7 +312,7 @@ final class DaybreakViewModel: ObservableObject {
             name: city.formattedTimezoneLabel(),
             isHome: tz.identifier == homeID,
             phase: phase,
-            time: time, period: period,
+            time: time + secondsSuffix(reference), period: period,
             offsetLabel: offsetLabel,
             nextEventLabel: showSunriseSunset ? eventLabel(event) : hover,
             hoverLabel: hover,
@@ -348,6 +349,17 @@ final class DaybreakViewModel: ObservableObject {
     /// Settings → Appearance → "Sunrise / sunset". When off, the next-sun-event sub-labels are
     /// suppressed (rows fall back to the UTC line; the hero subline shows just the date).
     private var showSunriseSunset: Bool { store.showSunriseSunset }
+
+    /// ":SS" for the hero and city-row clocks when Settings › Appearance has
+    /// "Show seconds" on. The 1s ticker keeps it live while the panel is open.
+    /// Suppressed while time-traveling — scrubbed times are minute-granular
+    /// hypotheticals, so live seconds would be noise. Timezone offsets are
+    /// whole minutes, so one seconds component serves every city. Sun-event
+    /// and scrubber labels stay minute-granular by design.
+    private func secondsSuffix(_ reference: Date) -> String {
+        guard travelOffsetMinutes == 0, store.timeFormat.includesSeconds else { return "" }
+        return String(format: ":%02d", Calendar.current.component(.second, from: reference))
+    }
 
     private func formatTime(_ minutes: Int) -> (time: String, period: String) {
         switch store.timeFormat {

--- a/Meridian/Preferences/Menu Bar/StatusContainerView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusContainerView.swift
@@ -6,7 +6,9 @@ import CoreModelKit
 
 func compactWidth(for timezone: TimezoneData, with store: DataStore) -> Int {
     var totalWidth = MenubarLayoutConstants.baseWidth
-    let timeFormat = timezone.timezoneFormat(store.timezoneFormat())
+    // Menu-bar-only geometry — width follows the menu-bar format (12/24 from
+    // Appearance, seconds from the Menu Bar pane's Seconds toggle).
+    let timeFormat = timezone.timezoneFormat(store.menubarTimezoneFormat())
 
     if store.shouldShowDayInMenubar() {
         totalWidth += MenubarLayoutConstants.dayBuffer
@@ -22,7 +24,7 @@ func compactWidth(for timezone: TimezoneData, with store: DataStore) -> Int {
         totalWidth += 0
     }
 
-    if timezone.shouldShowSeconds(store.timezoneFormat()) {
+    if timezone.shouldShowSeconds(store.menubarTimezoneFormat()) {
         // Slight buffer needed when the Menubar supplementary text was Mon 9:27:58 AM
         totalWidth += MenubarLayoutConstants.secondsBuffer
     }
@@ -107,7 +109,7 @@ class StatusContainerView: NSView {
                 let calculatedTitleSize = compactModeTimeFont.size(for: operationObject.compactMenuTitle(),
                                                                    width: precalculatedWidth,
                                                                    attributes: timeBasedAttributes)
-                let showSeconds = timezoneObject.shouldShowSeconds(store.timezoneFormat())
+                let showSeconds = timezoneObject.shouldShowSeconds(store.menubarTimezoneFormat())
                 let secondsBuffer: CGFloat = showSeconds ? MenubarLayoutConstants.measuredSecondsBuffer : 0
                 return result + max(calculatedTitleSize.width, calculatedSubtitleSize.width) + bufferWidth + secondsBuffer
             }

--- a/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemHandler.swift
@@ -361,8 +361,11 @@ class StatusItemHandler: NSObject {
     }
 
     private func shouldDisplaySecondsInMenubar() -> Bool {
+        // Menu-bar seconds are governed by the menu-bar format (Settings ›
+        // Menu Bar › Seconds), not the popover's Appearance format —
+        // per-city overrideFormat still wins inside shouldShowSeconds.
         let syncedTimezones = store.menubarTimezoneObjects()
-        return syncedTimezones.contains { $0.shouldShowSeconds(store.timezoneFormat()) }
+        return syncedTimezones.contains { $0.shouldShowSeconds(store.menubarTimezoneFormat()) }
     }
 
     private func calculateFireDate() -> Date? {

--- a/Meridian/Preferences/V4Settings/AppearancePane.swift
+++ b/Meridian/Preferences/V4Settings/AppearancePane.swift
@@ -67,10 +67,20 @@ struct AppearancePane: View {
     }
 
     private var timeFormatSegment: some View {
+        // Four options now that the seconds formats are back; the "… with
+        // seconds" labels are too long for a single 4-up strip, so the same
+        // segment cells wrap into a 2×2 grid (columns = hour style, rows =
+        // seconds on/off). Container + cell styling match the other rows.
         SegmentedControl(
-            options: [(TimeFormat.twelveHour, String(localized: "12-hour")), (.twentyFourHour, String(localized: "24-hour"))],
+            options: [
+                (TimeFormat.twelveHour, String(localized: "12-hour")),
+                (.twentyFourHour, String(localized: "24-hour")),
+                (.twelveHourWithSeconds, String(localized: "12-hour with seconds")),
+                (.twentyFourHourWithSeconds, String(localized: "24-hour with seconds"))
+            ],
             selection: $timeFormat,
-            accent: accent
+            accent: accent,
+            columns: 2
         )
     }
 
@@ -199,30 +209,51 @@ private struct SegmentedControl<Value: Hashable>: View {
     let options: [(Value, String)]
     @Binding var selection: Value
     let accent: Color
+    /// When set, the segments wrap into a fixed-column grid of equal-width
+    /// cells instead of a single row — for rows whose labels don't fit a
+    /// one-line strip (Time format's "… with seconds" options). Nil keeps
+    /// the classic single-row layout.
+    var columns: Int?
 
     var body: some View {
-        HStack(spacing: 2) {
-            ForEach(options, id: \.0) { value, label in
-                let isSelected = value == selection
-                Button { selection = value } label: {
-                    Text(label)
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundStyle(isSelected ? Color.white : Color.secondary)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 5)
-                        .background(
-                            RoundedRectangle(cornerRadius: 7, style: .continuous)
-                                .fill(isSelected ? accent : Color.clear)
-                        )
-                }
-                .buttonStyle(.plain)
+        segmentLayout
+            .padding(2)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.primary.opacity(0.06))
+            )
+    }
+
+    @ViewBuilder private var segmentLayout: some View {
+        if let columns {
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 2), count: columns), spacing: 2) {
+                segments(fillWidth: true)
+            }
+            .frame(maxWidth: 340)
+        } else {
+            HStack(spacing: 2) {
+                segments(fillWidth: false)
             }
         }
-        .padding(2)
-        .background(
-            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                .fill(Color.primary.opacity(0.06))
-        )
+    }
+
+    private func segments(fillWidth: Bool) -> some View {
+        ForEach(options, id: \.0) { value, label in
+            let isSelected = value == selection
+            Button { selection = value } label: {
+                Text(label)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(isSelected ? Color.white : Color.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 5)
+                    .frame(maxWidth: fillWidth ? .infinity : nil)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(isSelected ? accent : Color.clear)
+                    )
+            }
+            .buttonStyle(.plain)
+        }
     }
 }
 
@@ -265,7 +296,13 @@ private struct PreviewCard: View {
     let accent: Color
 
     private var timeString: String {
-        timeFormat == .twentyFourHour ? "20:17" : "8:17 PM"
+        switch timeFormat {
+        case .twentyFourHour: return "20:17"
+        case .twentyFourHourWithSeconds: return "20:17:45"
+        case .twelveHourWithSeconds: return "8:17:45 PM"
+        // .twelveHour, plus the legacy formats the picker doesn't offer.
+        default: return "8:17 PM"
+        }
     }
 
     private var subString: String {

--- a/Meridian/Preferences/V4Settings/AppearancePane.swift
+++ b/Meridian/Preferences/V4Settings/AppearancePane.swift
@@ -30,6 +30,13 @@ struct AppearancePane: View {
             FormRow(label: String(localized: "Time format")) { timeFormatSegment }
                 .padding(.bottom, 16)
 
+            FormRow(label: String(localized: "Show seconds")) {
+                Toggle("", isOn: showSecondsBinding)
+                    .labelsHidden()
+                    .toggleStyle(AccentSwitchToggleStyle(accent: accent))
+            }
+            .padding(.bottom, 16)
+
             FormRow(label: String(localized: "Day display")) { dayDisplaySegment }
                 .padding(.bottom, 16)
 
@@ -67,20 +74,27 @@ struct AppearancePane: View {
     }
 
     private var timeFormatSegment: some View {
-        // Four options now that the seconds formats are back; the "… with
-        // seconds" labels are too long for a single 4-up strip, so the same
-        // segment cells wrap into a 2×2 grid (columns = hour style, rows =
-        // seconds on/off). Container + cell styling match the other rows.
+        // The stored TimeFormat folds hour style and seconds together; the UI
+        // splits them into this 12/24 segment plus the "Show seconds" toggle
+        // below. The derived bindings flip one axis while preserving the other.
         SegmentedControl(
-            options: [
-                (TimeFormat.twelveHour, String(localized: "12-hour")),
-                (.twentyFourHour, String(localized: "24-hour")),
-                (.twelveHourWithSeconds, String(localized: "12-hour with seconds")),
-                (.twentyFourHourWithSeconds, String(localized: "24-hour with seconds"))
-            ],
-            selection: $timeFormat,
-            accent: accent,
-            columns: 2
+            options: [(TimeFormat.twelveHour, String(localized: "12-hour")), (.twentyFourHour, String(localized: "24-hour"))],
+            selection: hourStyleBinding,
+            accent: accent
+        )
+    }
+
+    private var hourStyleBinding: Binding<TimeFormat> {
+        Binding(
+            get: { timeFormat.isTwentyFourHour ? .twentyFourHour : .twelveHour },
+            set: { timeFormat = .standard(twentyFourHour: $0 == .twentyFourHour, seconds: timeFormat.includesSeconds) }
+        )
+    }
+
+    private var showSecondsBinding: Binding<Bool> {
+        Binding(
+            get: { timeFormat.includesSeconds },
+            set: { timeFormat = .standard(twentyFourHour: timeFormat.isTwentyFourHour, seconds: $0) }
         )
     }
 
@@ -209,51 +223,30 @@ private struct SegmentedControl<Value: Hashable>: View {
     let options: [(Value, String)]
     @Binding var selection: Value
     let accent: Color
-    /// When set, the segments wrap into a fixed-column grid of equal-width
-    /// cells instead of a single row — for rows whose labels don't fit a
-    /// one-line strip (Time format's "… with seconds" options). Nil keeps
-    /// the classic single-row layout.
-    var columns: Int?
 
     var body: some View {
-        segmentLayout
-            .padding(2)
-            .background(
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(Color.primary.opacity(0.06))
-            )
-    }
-
-    @ViewBuilder private var segmentLayout: some View {
-        if let columns {
-            LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 2), count: columns), spacing: 2) {
-                segments(fillWidth: true)
-            }
-            .frame(maxWidth: 340)
-        } else {
-            HStack(spacing: 2) {
-                segments(fillWidth: false)
+        HStack(spacing: 2) {
+            ForEach(options, id: \.0) { value, label in
+                let isSelected = value == selection
+                Button { selection = value } label: {
+                    Text(label)
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(isSelected ? Color.white : Color.secondary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 5)
+                        .background(
+                            RoundedRectangle(cornerRadius: 7, style: .continuous)
+                                .fill(isSelected ? accent : Color.clear)
+                        )
+                }
+                .buttonStyle(.plain)
             }
         }
-    }
-
-    private func segments(fillWidth: Bool) -> some View {
-        ForEach(options, id: \.0) { value, label in
-            let isSelected = value == selection
-            Button { selection = value } label: {
-                Text(label)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(isSelected ? Color.white : Color.secondary)
-                    .padding(.horizontal, 12)
-                    .padding(.vertical, 5)
-                    .frame(maxWidth: fillWidth ? .infinity : nil)
-                    .background(
-                        RoundedRectangle(cornerRadius: 7, style: .continuous)
-                            .fill(isSelected ? accent : Color.clear)
-                    )
-            }
-            .buttonStyle(.plain)
-        }
+        .padding(2)
+        .background(
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .fill(Color.primary.opacity(0.06))
+        )
     }
 }
 

--- a/Meridian/Preferences/V4Settings/MenuBarPane.swift
+++ b/Meridian/Preferences/V4Settings/MenuBarPane.swift
@@ -255,27 +255,28 @@ struct MenuBarPane: View {
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
                     .onChange(of: showPlaceName) { _, _ in activePresetID = "custom" }
             }
+            // Related toggles share a row (UAT: six single-toggle rows pushed
+            // the pane past the bottom of smaller screens).
             formRow(String(localized: "Day of week")) {
                 Toggle("", isOn: $showDay)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
                     .onChange(of: showDay) { _, _ in activePresetID = "custom" }
-            }
-            formRow(String(localized: "Date")) {
+                pairedLabel(String(localized: "Date"))
                 Toggle("", isOn: $showDate)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
                     .onChange(of: showDate) { _, _ in activePresetID = "custom" }
             }
+            // Menu-bar-only seconds rides with the hour style. Presets don't
+            // define a seconds choice (it's orthogonal, like Appearance's
+            // Show seconds), so flipping it neither marks the preset
+            // "custom" nor is touched by presets.
             formRow(String(localized: "24-hour time")) {
                 Toggle("", isOn: twentyFourBinding)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
-            }
-            // Menu-bar-only seconds. Presets don't define a seconds choice
-            // (it's orthogonal, like Appearance's Show seconds), so flipping
-            // it neither marks the preset "custom" nor is touched by presets.
-            formRow(String(localized: "Seconds")) {
+                pairedLabel(String(localized: "Seconds"))
                 Toggle("", isOn: $menubarShowSeconds)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
@@ -344,6 +345,16 @@ struct MenuBarPane: View {
 
     private func formRow<C: View>(_ label: String, @ViewBuilder control: @escaping () -> C) -> some View {
         FormRow(label: label, control: control)
+    }
+
+    /// Trailing label of a paired fine-tune row — same face as the leading
+    /// FormRow label, with breathing room after the first toggle so the pair
+    /// reads as two distinct controls.
+    private func pairedLabel(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 12.5))
+            .foregroundStyle(.secondary)
+            .padding(.leading, 20)
     }
 }
 

--- a/Meridian/Preferences/V4Settings/MenuBarPane.swift
+++ b/Meridian/Preferences/V4Settings/MenuBarPane.swift
@@ -348,13 +348,15 @@ struct MenuBarPane: View {
     }
 
     /// Trailing label of a paired fine-tune row — same face as the leading
-    /// FormRow label, with breathing room after the first toggle so the pair
-    /// reads as two distinct controls.
+    /// FormRow label. Fixed-width and right-aligned (mirroring the 150pt
+    /// leading label column) so the second toggle column lines up vertically
+    /// across paired rows regardless of label length.
     private func pairedLabel(_ text: String) -> some View {
         Text(text)
             .font(.system(size: 12.5))
             .foregroundStyle(.secondary)
-            .padding(.leading, 20)
+            .frame(width: 84, alignment: .trailing)
+            .padding(.leading, 8)
     }
 }
 

--- a/Meridian/Preferences/V4Settings/MenuBarPane.swift
+++ b/Meridian/Preferences/V4Settings/MenuBarPane.swift
@@ -100,6 +100,9 @@ struct MenuBarPane: View {
     @AppStorage("showDayInMenubar") private var showDay = false
     @AppStorage("showDateInMenubar") private var showDate = false
     @AppStorage("timeFormat") private var timeFormat: TimeFormat = .twelveHour
+    // Menu-bar-only seconds (default off). Independent of Appearance › Show
+    // seconds, which drives the popover via `timeFormat`.
+    @AppStorage(UserDefaultKeys.showSecondsInMenubar) private var menubarShowSeconds = false
     @AppStorage(DaybreakDefaults.Keys.menubarColorDots) private var menubarColorDots = true
     // Legacy two-line stacked layout, opt-in via the "Stacked" preset (issue #142). Default off.
     @AppStorage(DaybreakDefaults.Keys.menubarStacked) private var menubarStacked = false
@@ -167,9 +170,10 @@ struct MenuBarPane: View {
 
     private var previewItems: [PreviewChipItem] {
         previewSamples.map { sample in
-            // Seconds formats tick live in the real menu bar; the static
-            // sample just shows a representative seconds value.
-            let seconds = timeFormat.includesSeconds ? ":32" : ""
+            // Seconds tick live in the real menu bar; the static sample just
+            // shows a representative value. Keyed off the menu-bar-only pref,
+            // not the Appearance format (which drives the popover).
+            let seconds = menubarShowSeconds ? ":32" : ""
             let time = timeFormat.isTwentyFourHour
                 ? "\(sample.t24)\(seconds)"
                 : "\(sample.t12)\(seconds) \(sample.ampm)"
@@ -265,6 +269,14 @@ struct MenuBarPane: View {
             }
             formRow(String(localized: "24-hour time")) {
                 Toggle("", isOn: twentyFourBinding)
+                    .labelsHidden()
+                    .toggleStyle(AccentSwitchToggleStyle(accent: accent))
+            }
+            // Menu-bar-only seconds. Presets don't define a seconds choice
+            // (it's orthogonal, like Appearance's Show seconds), so flipping
+            // it neither marks the preset "custom" nor is touched by presets.
+            formRow(String(localized: "Seconds")) {
+                Toggle("", isOn: $menubarShowSeconds)
                     .labelsHidden()
                     .toggleStyle(AccentSwitchToggleStyle(accent: accent))
             }

--- a/Meridian/Preferences/V4Settings/MenuBarPane.swift
+++ b/Meridian/Preferences/V4Settings/MenuBarPane.swift
@@ -167,7 +167,12 @@ struct MenuBarPane: View {
 
     private var previewItems: [PreviewChipItem] {
         previewSamples.map { sample in
-            let time = timeFormat == .twentyFourHour ? sample.t24 : "\(sample.t12) \(sample.ampm)"
+            // Seconds formats tick live in the real menu bar; the static
+            // sample just shows a representative seconds value.
+            let seconds = timeFormat.includesSeconds ? ":32" : ""
+            let time = timeFormat.isTwentyFourHour
+                ? "\(sample.t24)\(seconds)"
+                : "\(sample.t12)\(seconds) \(sample.ampm)"
 
             if menubarStacked {
                 // Legacy two-line item: city name on top, time (with optional day/date) below —
@@ -227,7 +232,9 @@ struct MenuBarPane: View {
         showDay = preset.day
         showDate = preset.date
         menubarColorDots = preset.dots
-        timeFormat = preset.twentyFourHour ? .twentyFourHour : .twelveHour
+        // Presets pick the 12/24-hour axis only; a "… with seconds" choice
+        // made in Settings › Appearance is orthogonal and survives them.
+        timeFormat = .standard(twentyFourHour: preset.twentyFourHour, seconds: timeFormat.includesSeconds)
         // Switching to/from the Stacked preset flips the menu-bar layout; the write triggers a
         // menu-bar rebuild via StatusItemHandler's UserDefaults observer.
         menubarStacked = preset.stacked
@@ -272,9 +279,11 @@ struct MenuBarPane: View {
 
     private var twentyFourBinding: Binding<Bool> {
         Binding(
-            get: { timeFormat == .twentyFourHour },
+            get: { timeFormat.isTwentyFourHour },
             set: { on in
-                timeFormat = on ? .twentyFourHour : .twelveHour
+                // Flip only the hour style; keep the seconds half of the
+                // format chosen in Settings › Appearance.
+                timeFormat = .standard(twentyFourHour: on, seconds: timeFormat.includesSeconds)
                 activePresetID = "custom"
             }
         )

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -215,7 +215,8 @@ Open **Settings → Appearance**. A **PREVIEW** card at the bottom shows your ch
 
 - **Theme** — **Auto** (follow macOS), **Light**, or **Dark**. (Default: Light.)
 - **Accent color** — pick from a grid of **Formula 1 livery-inspired** palettes (Alpine, Aston Martin, Audi, Cadillac, Ferrari, Haas, McLaren, Mercedes, Racing Bulls, Red Bull Racing, Williams). The accent tints switches, selections, and scrubber highlights. (Default: Aston Martin.) *The palette names and colors are stylized tributes and are not affiliated with or endorsed by any Formula 1 team.* Changing the accent may prompt a quick restart so every control repaints.
-- **Time format** — **12-hour**, **24-hour**, **12-hour with seconds**, or **24-hour with seconds**, applied everywhere (popover, menu bar, copied text). The Menu Bar pane's 24-hour toggle flips the same setting and keeps your seconds choice. With a seconds format the menu-bar clock ticks every second, which may use slightly more energy.
+- **Time format** — **12-hour** or **24-hour**, applied everywhere (popover, menu bar, copied text). This is the same setting as the Menu Bar pane's 24-hour toggle.
+- **Show seconds** — display seconds in every time, including the menu-bar clock, which then ticks every second (this may use slightly more energy). (Default: off.)
 - **Day display** — how each city's day/date label reads: **Relative** (Today/Tomorrow/Yesterday-style), **Actual** (weekday), **Date**, or **Hide**.
 - **Sunrise / sunset** — show each city's next sun event (see below). (Default: off.)
 - **Text size** — scale the popover's text from **85% to 130%** (default 100%).

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -215,7 +215,7 @@ Open **Settings → Appearance**. A **PREVIEW** card at the bottom shows your ch
 
 - **Theme** — **Auto** (follow macOS), **Light**, or **Dark**. (Default: Light.)
 - **Accent color** — pick from a grid of **Formula 1 livery-inspired** palettes (Alpine, Aston Martin, Audi, Cadillac, Ferrari, Haas, McLaren, Mercedes, Racing Bulls, Red Bull Racing, Williams). The accent tints switches, selections, and scrubber highlights. (Default: Aston Martin.) *The palette names and colors are stylized tributes and are not affiliated with or endorsed by any Formula 1 team.* Changing the accent may prompt a quick restart so every control repaints.
-- **Time format** — **12-hour** or **24-hour**, applied everywhere (popover, menu bar, copied text). This is the same setting as the Menu Bar pane's 24-hour toggle.
+- **Time format** — **12-hour**, **24-hour**, **12-hour with seconds**, or **24-hour with seconds**, applied everywhere (popover, menu bar, copied text). The Menu Bar pane's 24-hour toggle flips the same setting and keeps your seconds choice. With a seconds format the menu-bar clock ticks every second, which may use slightly more energy.
 - **Day display** — how each city's day/date label reads: **Relative** (Today/Tomorrow/Yesterday-style), **Actual** (weekday), **Date**, or **Hide**.
 - **Sunrise / sunset** — show each city's next sun event (see below). (Default: off.)
 - **Text size** — scale the popover's text from **85% to 130%** (default 100%).

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -167,7 +167,9 @@ The **Stacked** preset puts each city's name above its time, roughly halving the
 
 ### Fine-tune toggles
 
-Below the presets you can switch individual elements on or off: **Place name**, **Day of week**, **Date**, **24-hour time**, and **Color dots**. Adjusting any of these marks the active preset as "custom."
+Below the presets you can switch individual elements on or off: **Place name**, **Day of week**, **Date**, **24-hour time**, **Seconds**, and **Color dots**. Adjusting any of these marks the active preset as "custom."
+
+- **Seconds** — show seconds in the menu-bar clock, which then ticks every second (this may use slightly more energy). (Default: off.) This is independent of **Appearance → Show seconds**, which controls the popover — so seconds can tick in the roomy popover while the menu bar stays compact.
 
 ### Where Meridian appears
 
@@ -216,7 +218,7 @@ Open **Settings → Appearance**. A **PREVIEW** card at the bottom shows your ch
 - **Theme** — **Auto** (follow macOS), **Light**, or **Dark**. (Default: Light.)
 - **Accent color** — pick from a grid of **Formula 1 livery-inspired** palettes (Alpine, Aston Martin, Audi, Cadillac, Ferrari, Haas, McLaren, Mercedes, Racing Bulls, Red Bull Racing, Williams). The accent tints switches, selections, and scrubber highlights. (Default: Aston Martin.) *The palette names and colors are stylized tributes and are not affiliated with or endorsed by any Formula 1 team.* Changing the accent may prompt a quick restart so every control repaints.
 - **Time format** — **12-hour** or **24-hour**, applied everywhere (popover, menu bar, copied text). This is the same setting as the Menu Bar pane's 24-hour toggle.
-- **Show seconds** — display seconds in every time, including the menu-bar clock, which then ticks every second (this may use slightly more energy). (Default: off.)
+- **Show seconds** — display seconds in the popover only. (Default: off.) The menu-bar clock has its own **Seconds** toggle in the Menu Bar pane, so you can keep the menu bar compact while the popover ticks.
 - **Day display** — how each city's day/date label reads: **Relative** (Today/Tomorrow/Yesterday-style), **Actual** (weekday), **Date**, or **Hide**.
 - **Sunrise / sunset** — show each city's next sun event (see below). (Default: off.)
 - **Text size** — scale the popover's text from **85% to 130%** (default 100%).

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 #
-# validate_feature.sh — TDD checks for issue #142: "bring back stacked time in
-# compact menu bar" as an opt-in 6th menu-bar preset ("Stacked").
+# validate_feature.sh — TDD checks for "seconds time formats in v4 Settings":
+# expose 12-hour/24-hour "with seconds" (TimeFormat raw 3/4) in Settings ›
+# Appearance, keep the seconds choice flowing through the Menu Bar pane's
+# preview / 24-hour toggle / presets, and document it in the user manual.
 #
 # Run BEFORE implementing (expect failures), then again after (expect all green).
 #
@@ -14,12 +16,10 @@ cd "$(dirname "$0")/.." || exit 2
 
 PASS=0
 FAIL=0
-SIV="Meridian/Preferences/Menu Bar/StatusItemView.swift"
-SCV="Meridian/Preferences/Menu Bar/StatusContainerView.swift"
-PANE="Meridian/Preferences/V4Settings/MenuBarPane.swift"
-GP="Meridian/Preferences/V4Settings/GeneralPane.swift"
-APPD="Meridian/AppDelegate.swift"
-KEY="com.tpak.meridian.v4.menubarStacked"
+AP="Meridian/Preferences/V4Settings/AppearancePane.swift"
+MBP="Meridian/Preferences/V4Settings/MenuBarPane.swift"
+DS="Meridian/Overall App/DataStore.swift"
+MANUAL="docs/manual.md"
 
 ok()  { printf "  \033[32mOK:\033[0m   %s\n" "$1"; PASS=$((PASS+1)); }
 bad() { printf "  \033[31mFAIL:\033[0m %s\n" "$1" >&2; FAIL=$((FAIL+1)); }
@@ -29,110 +29,45 @@ check() { # check "description" <grep-args...>
   if grep -q "$@"; then ok "$desc"; else bad "$desc"; fi
 }
 
-echo "Issue #142 — Stacked menu-bar preset — validation"
+echo "Seconds time formats in v4 Settings — validation"
 echo "------------------------------------------------"
 
-# 1. The single-line switch is no longer a hard-coded constant.
-if grep -Eq '^[[:space:]]*let[[:space:]]+kMenubarV4SingleLine[[:space:]]*=[[:space:]]*true' "$SIV"; then
-  bad "kMenubarV4SingleLine is no longer a hard-coded 'let ... = true'"
+# 1. Appearance pane offers both seconds enum cases as selectable options.
+check "AppearancePane references .twelveHourWithSeconds" -Fq '.twelveHourWithSeconds' "$AP"
+check "AppearancePane references .twentyFourHourWithSeconds" -Fq '.twentyFourHourWithSeconds' "$AP"
+
+# 2. New user-facing labels are localizable via String(localized:).
+check "'12-hour with seconds' label is localized" -Fq 'String(localized: "12-hour with seconds")' "$AP"
+check "'24-hour with seconds' label is localized" -Fq 'String(localized: "24-hour with seconds")' "$AP"
+
+# 3. The live PREVIEW card renders seconds for the new formats.
+check "preview shows a 24-hour seconds sample (20:17:45)" -Fq '20:17:45' "$AP"
+check "preview shows a 12-hour seconds sample (8:17:45 PM)" -Fq '8:17:45 PM' "$AP"
+
+# 4. TimeFormat helpers exist so panes share one definition of "has seconds" / "is 24h".
+check "TimeFormat.includesSeconds helper exists" -Eq 'var[[:space:]]+includesSeconds:[[:space:]]*Bool' "$DS"
+check "TimeFormat.isTwentyFourHour helper exists" -Eq 'var[[:space:]]+isTwentyFourHour:[[:space:]]*Bool' "$DS"
+check "TimeFormat.standard(twentyFourHour:seconds:) exists" -Eq 'static func standard\(twentyFourHour: Bool, seconds: Bool\)' "$DS"
+
+# 5. Menu Bar pane's preview strip renders raw values 3/4 correctly (24h check
+#    no longer equates "not .twentyFourHour" with 12-hour; seconds appear).
+check "MenuBarPane preview uses includesSeconds" -Fq 'timeFormat.includesSeconds' "$MBP"
+check "MenuBarPane preview uses isTwentyFourHour" -Fq 'timeFormat.isTwentyFourHour' "$MBP"
+if grep -Fq 'timeFormat == .twentyFourHour ? sample.t24' "$MBP"; then
+  bad "MenuBarPane preview still hard-codes the two-format ternary"
 else
-  ok "kMenubarV4SingleLine is no longer a hard-coded 'let ... = true'"
+  ok "MenuBarPane preview no longer hard-codes the two-format ternary"
 fi
 
-# 2. It is now a computed value (var with a Bool body).
-check "kMenubarV4SingleLine is now computed (var ...: Bool {)" -Eq 'var[[:space:]]+kMenubarV4SingleLine[[:space:]]*:[[:space:]]*Bool[[:space:]]*\{' "$SIV"
+# 6. The Menu Bar pane's 24-hour toggle and presets preserve the seconds choice
+#    instead of clamping raw 3/4 back to 0/1.
+check "24-hour toggle preserves seconds" -Fq '.standard(twentyFourHour: on, seconds: timeFormat.includesSeconds)' "$MBP"
+check "applyPreset preserves seconds" -Fq '.standard(twentyFourHour: preset.twentyFourHour, seconds: timeFormat.includesSeconds)' "$MBP"
 
-# 3. The render path reads the new UserDefault key.
-check "render path (StatusItemView) references the new key" -Fq "$KEY" "$SIV"
-
-# 4. A reader exists for the stacked layout flag.
-check "menubarStackedLayoutEnabled reader exists" -Eq 'menubarStackedLayoutEnabled' "$SIV"
-
-# 5. Default is OFF (single-line preserved for everyone) — reader falls back to false.
-check "stacked default is false (?? false)" -Eq 'as\? Bool \?\? false' "$SIV"
-
-# 6. MenuBarPane exposes a 6th "Stacked" preset.
-check "MenuBarPane has a 'stacked' preset id" -Eq 'id:[[:space:]]*"stacked"' "$PANE"
-check "MenuBarPane has a 'Stacked' preset label" -Fq 'String(localized: "Stacked")' "$PANE"
-
-# 7. MenuBarPane persists the new key via @AppStorage.
-check "MenuBarPane binds the new key via @AppStorage" -Fq "@AppStorage(\"$KEY\")" "$PANE"
-
-# 8. Selecting a preset applies the stacked flag.
-check "applyPreset writes the stacked flag" -Eq 'menubarStacked[[:space:]]*=[[:space:]]*preset\.stacked' "$PANE"
-
-# 9. The preset model carries a 'stacked' field.
-check "MenuBarPreset model has a 'stacked' field" -Eq 'let[[:space:]]+stacked:[[:space:]]*Bool' "$PANE"
-
-# 10. Preview can render a two-line (stacked) chip.
-check "preview supports a two-line/stacked chip (bottomLabel)" -Eq 'bottomLabel' "$PANE"
-
-# 11. UAT r5: stacked menu-bar item height tracks the live bar thickness (a fixed/oversized height
-#     overflows the 22pt bar and crams the time onto the bottom edge).
-check "menubarItemHeight tracks bar thickness" -Eq 'var menubarItemHeight: CGFloat \{ NSStatusBar\.system\.thickness \}' "$SCV"
-
-# 12. UAT fix: preset cards reserve two sample lines so the Stacked card doesn't grow its row.
-check "preset card reserves two sample lines" -Fq 'reservesSpace: true' "$PANE"
-
-# 13. UAT r2: stacked menu-bar name line uses semibold (matches the cleaner preview), not bold.
-check "menu-bar name font is semibold" -Eq 'systemFont\(ofSize: 10, weight: .semibold\)' "$SIV"
-if grep -q 'boldSystemFont(ofSize: 10)' "$SIV"; then bad "menu-bar name still uses boldSystemFont"; else ok "menu-bar name no longer boldSystemFont"; fi
-
-# 14. UAT r2: preset card sample is right-justified.
-check "preset card sample is right-justified" -Fq 'multilineTextAlignment(.trailing)' "$PANE"
-
-# 15. UAT r2: 'Check Now' lives on its own row (empty-label FormRow under the segment).
-check "Check Now is on its own FormRow" -Eq 'FormRow\(label: ""\)' "$GP"
-
-# 16. UAT r2: fresh-install start-at-login default.
-check "enableStartAtLoginByDefault exists" -Eq 'func enableStartAtLoginByDefault' "$APPD"
-check "start-at-login wired into launch" -Eq 'enableStartAtLoginByDefault\(\)' "$APPD"
-
-# 17. UAT r2: fresh-install daily update cadence.
-check "fresh-install sets daily update interval (86400)" -Eq 'updateCheckInterval = 86400' "$APPD"
-
-# 18. UAT r5: stacked lines have their text centres placed symmetrically about the bar middle
-#     (verified by screenshot: tight, centred pair, time off the bottom edge).
-check "stacked name text centred above the middle" -Fq 'locationView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -halfGap)' "$SIV"
-check "stacked time text centred below the middle" -Fq 'timeView.centerYAnchor.constraint(equalTo: centerYAnchor, constant: halfGap)' "$SIV"
-if grep -q 'multiplier: 0.35\|multiplier: 0.5' "$SIV"; then bad "stacked still uses a proportional split"; else ok "stacked no longer uses a proportional split"; fi
-
-# 19. UAT r5: General-pane command buttons use the visible ShadedButtonStyle (the system .bordered
-#     style was near-invisible on the dark canvas); no .plain command buttons remain.
-check "command buttons use ShadedButtonStyle" -Fq 'buttonStyle(ShadedButtonStyle())' "$GP"
-check "ShadedButtonStyle is defined" -Fq 'struct ShadedButtonStyle: ButtonStyle' "$GP"
-if grep -q 'buttonStyle(.plain)' "$GP"; then bad "GeneralPane still has a .plain command button"; else ok "no .plain command buttons remain in GeneralPane"; fi
-
-# 20. UAT r5: stacked menu-bar item height matches the bar (no fixed 30pt that overflowed the 22pt bar).
-if grep -q 'stackedMenubarItemHeight\|multiplier: 0.5\|: 30' "$SCV"; then bad "stacked item still uses a fixed/oversized height"; else ok "stacked item height matches the bar thickness"; fi
-
-# 21. UAT r6: the Daybreak panel sits below the bar (gap), not flush against it.
-DPC="Meridian/Panel/Daybreak/DaybreakPanelController.swift"
-check "panel anchors with a gap below the bar" -Fq 'buttonRect.minY + bodyTopInset - bodyGapBelowBar' "$DPC"
-
-# --- New "Midnight Sundial" icons ---
-AIS="Meridian/Media.xcassets/AppIcon.appiconset"
-MBI="Meridian/Media.xcassets/MenuBarIcon.imageset"
-SIH="Meridian/Preferences/Menu Bar/StatusItemHandler.swift"
-FAD="Meridian/Overall App/Foundation + Additions.swift"
-
-# 22. New AppIcon iconset present (all 10), old Clocker/meridian-* art gone.
-if [ "$(find "$AIS" -name 'icon_*.png' | wc -l | tr -d ' ')" = "10" ]; then ok "AppIcon has the 10 new icon_*.png"; else bad "AppIcon missing new icon_*.png"; fi
-if find "$AIS" -iname '*clocker*' -o -iname 'meridian-*.png' 2>/dev/null | grep -q .; then bad "old Clocker/meridian-* app-icon art still present"; else ok "old app-icon art removed"; fi
-check "AppIcon Contents.json maps the new files" -Fq 'icon_512x512@2x.png' "$AIS/Contents.json"
-
-# 23. MenuBarIcon template imageset present and rendered as template.
-if [ -f "$MBI/MenuBarIcon.png" ] && [ -f "$MBI/MenuBarIcon@2x.png" ]; then ok "MenuBarIcon imageset has the template pair"; else bad "MenuBarIcon imageset PNGs missing"; fi
-check "MenuBarIcon renders as a template image" -Fq '"template-rendering-intent" : "template"' "$MBI/Contents.json"
-
-# 24. Old unused menu-bar icon asset removed.
-if [ -d "Meridian/Media.xcassets/Menubar Icons" ]; then bad "old 'Menubar Icons' (LightModeIcon) folder still present"; else ok "old 'Menubar Icons' folder removed"; fi
-
-# 25. Code loads the template glyph (not the old clock.fill SF Symbol).
-check "menubarIcon name points at MenuBarIcon" -Fq 'NSImage.Name("MenuBarIcon")' "$FAD"
-check "status item loads the template icon" -Fq 'NSImage(named: .menubarIcon)' "$SIH"
-check "status item icon is set as a template" -Eq 'image\?\.isTemplate = true' "$SIH"
-if grep -q 'clock.fill' "$SIH"; then bad "still references the clock.fill SF Symbol"; else ok "no clock.fill reference remains"; fi
+# 7. User manual documents the new choices and the per-second tick.
+check "manual lists '12-hour with seconds'" -Fq '12-hour with seconds' "$MANUAL"
+check "manual lists '24-hour with seconds'" -Fq '24-hour with seconds' "$MANUAL"
+check "manual mentions the menu-bar clock ticking every second" -Fq 'menu-bar clock ticks every second' "$MANUAL"
 
 echo ""
 if [[ "${1:-}" == "--no-build" ]]; then

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -5,6 +5,13 @@
 # Appearance, keep the seconds choice flowing through the Menu Bar pane's
 # preview / 24-hour toggle / presets, and document it in the user manual.
 #
+# Extension (UAT feedback): seconds are controlled INDEPENDENTLY per surface —
+# Appearance › Show seconds keeps driving the Daybreak popover + preview via
+# `timeFormat`, while a new Menu Bar › Seconds toggle (UserDefaults bool
+# `showSecondsInMenubar`, default false) drives only the menu-bar clock via
+# `DataStore.menubarTimezoneFormat()` (hour style from timeFormat, seconds
+# from the menubar pref). Sections 8–10 below validate the split.
+#
 # Run BEFORE implementing (expect failures), then again after (expect all green).
 #
 #   bash scripts/validate_feature.sh            # static checks + Debug build
@@ -74,6 +81,54 @@ check "applyPreset preserves seconds" -Fq '.standard(twentyFourHour: preset.twen
 # 7. User manual documents the new toggle and the per-second tick.
 check "manual documents the Show seconds toggle" -Fq '**Show seconds**' "$MANUAL"
 check "manual mentions the menu-bar clock ticking every second" -Fq 'ticks every second' "$MANUAL"
+
+# ------------------------------------------------------------------
+# Independent menu-bar seconds (UAT follow-up) — sections 8–10.
+# ------------------------------------------------------------------
+STR="Meridian/Overall App/Strings.swift"
+AD="Meridian/Overall App/AppDefaults.swift"
+SIH="Meridian/Preferences/Menu Bar/StatusItemHandler.swift"
+SCV="Meridian/Preferences/Menu Bar/StatusContainerView.swift"
+TDO="Meridian/Panel/Data Layer/TimezoneDataOperations.swift"
+SM="Meridian/Overall App/SettingsManager.swift"
+TESTS="Meridian/MeridianUnitTests/MeridianUnitTests.swift"
+
+# 8. New pref: key constant, registered default (false), typed accessor, and
+#    the derived menu-bar format on DataStore.
+check "UserDefaultKeys has showSecondsInMenubar" -Fq 'static let showSecondsInMenubar = "showSecondsInMenubar"' "$STR"
+check "AppDefaults registers showSecondsInMenubar default false" -Fq 'UserDefaultKeys.showSecondsInMenubar: false' "$AD"
+check "DataStore.menubarShowSeconds typed accessor exists" -Eq 'var[[:space:]]+menubarShowSeconds:[[:space:]]*Bool' "$DS"
+check "DataStore.menubarTimezoneFormat() exists" -Fq 'func menubarTimezoneFormat() -> NSNumber' "$DS"
+check "menubarTimezoneFormat derives hour style from timeFormat + seconds from menubarShowSeconds" \
+  -Fq 'standard(twentyFourHour: timeFormat.isTwentyFourHour, seconds: menubarShowSeconds)' "$DS"
+
+# 9. Menu-bar render paths use the menubar format; popover/panel paths don't.
+check "StatusItemHandler seconds check uses menubarTimezoneFormat" -Fq 'shouldShowSeconds(store.menubarTimezoneFormat())' "$SIH"
+check "StatusContainerView width/seconds logic uses menubarTimezoneFormat" -Fq 'store.menubarTimezoneFormat()' "$SCV"
+if grep -Fq 'store.timezoneFormat()' "$SCV"; then
+  bad "StatusContainerView still reads the popover format (store.timezoneFormat())"
+else
+  ok "StatusContainerView no longer reads the popover format"
+fi
+check "TimezoneDataOperations exposes a menubarTime(with:) variant" -Fq 'func menubarTime(with' "$TDO"
+check "compact menu strings render via menubarTime" -Fq 'menubarTime(with: 0)' "$TDO"
+check "popover secondsSuffix still keyed off timeFormat (unchanged)" -Fq 'store.timeFormat.includesSeconds' "$DVM"
+
+# 10. Settings UI, preview, export/import, catalog, manual, tests.
+check "MenuBarPane has a Seconds row" -Fq 'String(localized: "Seconds")' "$MBP"
+check "MenuBarPane Seconds toggle binds the menubar pref" -Fq '$menubarShowSeconds' "$MBP"
+if grep -Fq 'timeFormat.includesSeconds ? ":32"' "$MBP"; then
+  bad "MenuBarPane preview strip still keys seconds off the Appearance timeFormat"
+else
+  ok "MenuBarPane preview strip no longer keys seconds off the Appearance timeFormat"
+fi
+check "MenuBarPane preview strip uses the menubar pref for the :32 sample" -Fq 'menubarShowSeconds ? ":32"' "$MBP"
+check "'Seconds' key exists in the string catalog" -Fq '"Seconds": {' "Meridian/App/Localizable.xcstrings"
+check "SettingsManager v2 exports showSecondsInMenubar" -Fq 'V2Key.showSecondsInMenubar: store.menubarShowSeconds' "$SM"
+check "SettingsManager v2 imports showSecondsInMenubar" -Fq 'prefs[V2Key.showSecondsInMenubar] as? Bool' "$SM"
+check "manual: Appearance Show seconds is popover-only and points at Menu Bar pane" -Fq 'popover only' "$MANUAL"
+check "manual: Menu Bar fine-tune list documents the Seconds toggle" -Fq '**Seconds**' "$MANUAL"
+check "unit test covers menubarTimezoneFormat derivation" -Fq 'func testMenubarTimezoneFormat' "$TESTS"
 
 echo ""
 if [[ "${1:-}" == "--no-build" ]]; then

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -40,6 +40,13 @@ check "hour segment binding preserves seconds" -Fq 'seconds: timeFormat.includes
 # 2. The toggle label is in the string catalog.
 check "'Show seconds' key exists in the string catalog" -Fq '"Show seconds"' "Meridian/App/Localizable.xcstrings"
 
+# 2b. The Daybreak popover honors the setting (hero + city rows tick seconds).
+DVM="Meridian/Panel/Daybreak/DaybreakViewModel.swift"
+check "DaybreakViewModel derives a seconds suffix from the setting" -Fq 'store.timeFormat.includesSeconds' "$DVM"
+check "hero time appends the seconds suffix" -Fq 'time += secondsSuffix(reference)' "$DVM"
+check "city rows append the seconds suffix" -Fq 'time + secondsSuffix(reference)' "$DVM"
+check "unit test covers popover seconds display" -Fq 'testHeroSecondsFollowShowSecondsSetting' "Meridian/MeridianUnitTests/DaybreakEngineTests.swift"
+
 # 3. The live PREVIEW card renders seconds for the new formats.
 check "preview shows a 24-hour seconds sample (20:17:45)" -Fq '20:17:45' "$AP"
 check "preview shows a 12-hour seconds sample (8:17:45 PM)" -Fq '8:17:45 PM' "$AP"

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -32,13 +32,13 @@ check() { # check "description" <grep-args...>
 echo "Seconds time formats in v4 Settings — validation"
 echo "------------------------------------------------"
 
-# 1. Appearance pane offers both seconds enum cases as selectable options.
-check "AppearancePane references .twelveHourWithSeconds" -Fq '.twelveHourWithSeconds' "$AP"
-check "AppearancePane references .twentyFourHourWithSeconds" -Fq '.twentyFourHourWithSeconds' "$AP"
+# 1. Appearance pane splits the format into a 12/24 segment + seconds toggle.
+check "AppearancePane has a Show seconds row" -Fq 'String(localized: "Show seconds")' "$AP"
+check "seconds toggle binding preserves hour style" -Fq 'timeFormat = .standard(twentyFourHour: timeFormat.isTwentyFourHour, seconds: $0)' "$AP"
+check "hour segment binding preserves seconds" -Fq 'seconds: timeFormat.includesSeconds)' "$AP"
 
-# 2. New user-facing labels are localizable via String(localized:).
-check "'12-hour with seconds' label is localized" -Fq 'String(localized: "12-hour with seconds")' "$AP"
-check "'24-hour with seconds' label is localized" -Fq 'String(localized: "24-hour with seconds")' "$AP"
+# 2. The toggle label is in the string catalog.
+check "'Show seconds' key exists in the string catalog" -Fq '"Show seconds"' "Meridian/App/Localizable.xcstrings"
 
 # 3. The live PREVIEW card renders seconds for the new formats.
 check "preview shows a 24-hour seconds sample (20:17:45)" -Fq '20:17:45' "$AP"
@@ -64,10 +64,9 @@ fi
 check "24-hour toggle preserves seconds" -Fq '.standard(twentyFourHour: on, seconds: timeFormat.includesSeconds)' "$MBP"
 check "applyPreset preserves seconds" -Fq '.standard(twentyFourHour: preset.twentyFourHour, seconds: timeFormat.includesSeconds)' "$MBP"
 
-# 7. User manual documents the new choices and the per-second tick.
-check "manual lists '12-hour with seconds'" -Fq '12-hour with seconds' "$MANUAL"
-check "manual lists '24-hour with seconds'" -Fq '24-hour with seconds' "$MANUAL"
-check "manual mentions the menu-bar clock ticking every second" -Fq 'menu-bar clock ticks every second' "$MANUAL"
+# 7. User manual documents the new toggle and the per-second tick.
+check "manual documents the Show seconds toggle" -Fq '**Show seconds**' "$MANUAL"
+check "manual mentions the menu-bar clock ticking every second" -Fq 'ticks every second' "$MANUAL"
 
 echo ""
 if [[ "${1:-}" == "--no-build" ]]; then


### PR DESCRIPTION
- Add a Show seconds option in Settings → Appearance — the popover clocks tick live seconds
- Add a separate Seconds toggle in Settings → Menu Bar so the menu-bar clock can stay compact (off by default)

## Technical detail (not for release notes)

The v4 redesign dropped seconds formats from the UI even though the engine supports them. This restores them as two independent axes:

1. `TimeFormat` gains `includesSeconds`, `isTwentyFourHour`, `standard(twentyFourHour:seconds:)`; Appearance presents a 12/24 segment + "Show seconds" toggle over the single stored `timeFormat` via derived bindings.
2. Daybreak popover: minute-based pipeline gains a live `:SS` suffix on hero + city rows (1s ticker keeps it live; suppressed while time-traveling; sun-event/scrubber labels stay minute-granular).
3. Menu bar: new `showSecondsInMenubar` pref (default false) + `DataStore.menubarTimezoneFormat()` derives the menu-bar format (hour style from Appearance, seconds from the Menu Bar toggle). All menu-bar render paths (`StatusItemHandler`, `StatusContainerView`, `compactMenu*`) switched to it; popover paths untouched. Full call-site audit in the implementation commits.
4. Menu Bar fine-tune rows paired (Day of week·Date, 24-hour·Seconds) with aligned toggle columns to keep the pane compact.
5. Settings export/import v2 carries the new key; string catalog + docs/manual.md updated for both panes.

Tests: 254/254 passing serially, including an 8-case format-derivation matrix and export/import round-trip. SwiftLint clean. TDD validation 42/42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUpXyziq1Tss3nZBQ8u348