### PR TITLE
Fix high CPU usage when a second display is connected (#191)

### DIFF
--- a/Meridian/Preferences/Menu Bar/StatusItemView.swift
+++ b/Meridian/Preferences/Menu Bar/StatusItemView.swift
@@ -44,15 +44,15 @@ var menubarColorDotsEnabled: Bool {
     UserDefaults.standard.object(forKey: DaybreakDefaults.Keys.menubarColorDots) as? Bool ?? true
 }
 
-extension NSView {
-    var hasDarkAppearance: Bool {
-        switch effectiveAppearance.name {
-        case .darkAqua, .vibrantDark, .accessibilityHighContrastDarkAqua, .accessibilityHighContrastVibrantDark:
-            return true
-        default:
-            return false
-        }
-    }
+/// Menu-bar text color. Dynamic — resolves against the effective appearance active at draw
+/// time — so one attributed string renders correctly on every screen's menu bar, including the
+/// replicant snapshots AppKit draws for additional displays under each screen's own appearance.
+/// Baking white/black in at string-construction time required rebuilding content on every
+/// appearance change, and AppKit flips the view's appearance during every replicant snapshot,
+/// so that rebuild re-dirtied the item and scheduled the next snapshot — a hot loop pinning the
+/// main thread whenever 2+ displays were active (#191).
+let menubarTextColor = NSColor(name: nil) { appearance in
+    appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? .white : .black
 }
 
 class StatusItemView: NSView {
@@ -73,37 +73,28 @@ class StatusItemView: NSView {
         return paragraphStyle
     }()
 
-    // Cached per appearance mode; invalidated in viewDidChangeEffectiveAppearance.
-    private var cachedTimeAttributes: [NSAttributedString.Key: AnyObject]?
-    private var cachedTextFontAttributes: [NSAttributedString.Key: Any]?
+    // Appearance-independent (the text color is dynamic), so built once per view.
+    private lazy var timeAttributes: [NSAttributedString.Key: AnyObject] = [
+        NSAttributedString.Key.font: compactModeTimeFont,
+        NSAttributedString.Key.foregroundColor: menubarTextColor,
+        NSAttributedString.Key.backgroundColor: NSColor.clear,
+        NSAttributedString.Key.paragraphStyle: paragraphStyle
+    ]
 
-    private var timeAttributes: [NSAttributedString.Key: AnyObject] {
-        if let cached = cachedTimeAttributes { return cached }
-        let textColor = hasDarkAppearance ? NSColor.white : NSColor.black
-        let attributes: [NSAttributedString.Key: AnyObject] = [
-            NSAttributedString.Key.font: compactModeTimeFont,
-            NSAttributedString.Key.foregroundColor: textColor,
-            NSAttributedString.Key.backgroundColor: NSColor.clear,
-            NSAttributedString.Key.paragraphStyle: paragraphStyle
-        ]
-        cachedTimeAttributes = attributes
-        return attributes
-    }
+    private lazy var textFontAttributes: [NSAttributedString.Key: Any] = [
+        // Semibold (not bold) for the stacked name line — matches the cleaner Settings preview
+        // chip; full bold read heavier/chunkier in the menu bar (issue #142 UAT).
+        NSAttributedString.Key.font: NSFont.systemFont(ofSize: 10, weight: .semibold),
+        NSAttributedString.Key.foregroundColor: menubarTextColor,
+        NSAttributedString.Key.backgroundColor: NSColor.clear,
+        NSAttributedString.Key.paragraphStyle: paragraphStyle
+    ]
 
-    private var textFontAttributes: [NSAttributedString.Key: Any] {
-        if let cached = cachedTextFontAttributes { return cached }
-        let textColor = hasDarkAppearance ? NSColor.white : NSColor.black
-        let attributes: [NSAttributedString.Key: Any] = [
-            // Semibold (not bold) for the stacked name line — matches the cleaner Settings preview
-            // chip; full bold read heavier/chunkier in the menu bar (issue #142 UAT).
-            NSAttributedString.Key.font: NSFont.systemFont(ofSize: 10, weight: .semibold),
-            NSAttributedString.Key.foregroundColor: textColor,
-            NSAttributedString.Key.backgroundColor: NSColor.clear,
-            NSAttributedString.Key.paragraphStyle: paragraphStyle
-        ]
-        cachedTextFontAttributes = attributes
-        return attributes
-    }
+    // Last content written to each field. Setting attributedStringValue dirties the field even
+    // when the value is identical, and on a multi-display setup every dirty schedules an
+    // NSStatusItem replicant re-snapshot — so no-op refreshes must not write (#191).
+    private var lastAppliedTitle: NSAttributedString?
+    private var lastAppliedTime: NSAttributedString?
 
     // MARK: Public
 
@@ -182,19 +173,23 @@ class StatusItemView: NSView {
     /// Apply the current content to the views, honoring the single-line vs two-line mode.
     private func applyContent() {
         if kMenubarV4SingleLine {
-            timeView.attributedStringValue = oneLineAttributedString()
+            let line = oneLineAttributedString()
+            if line != lastAppliedTime {
+                lastAppliedTime = line
+                timeView.attributedStringValue = line
+            }
             return
         }
-        locationView.attributedStringValue = NSAttributedString(string: operationsObject.compactMenuTitle(), attributes: textFontAttributes)
-        timeView.attributedStringValue = NSAttributedString(string: operationsObject.compactMenuSubtitle(), attributes: timeAttributes)
-    }
-
-    override func viewDidChangeEffectiveAppearance() {
-        super.viewDidChangeEffectiveAppearance()
-        // Invalidate appearance-dependent attribute caches so they are rebuilt for the new appearance.
-        cachedTimeAttributes = nil
-        cachedTextFontAttributes = nil
-        statusItemViewSetNeedsDisplay()
+        let title = NSAttributedString(string: operationsObject.compactMenuTitle(), attributes: textFontAttributes)
+        if title != lastAppliedTitle {
+            lastAppliedTitle = title
+            locationView.attributedStringValue = title
+        }
+        let time = NSAttributedString(string: operationsObject.compactMenuSubtitle(), attributes: timeAttributes)
+        if time != lastAppliedTime {
+            lastAppliedTime = time
+            timeView.attributedStringValue = time
+        }
     }
 
     private func initialSetup() {

--- a/scripts/validate_feature.sh
+++ b/scripts/validate_feature.sh
@@ -1,192 +1,81 @@
 #!/usr/bin/env bash
 #
-# validate_feature.sh — TDD checks for release-pipeline hardening in
-# scripts/release.sh + the new appcast-validate CI workflow.
+# validate_feature.sh — TDD checks for issue #191: multi-display NSStatusItem
+# replicant CPU loop (~50% sustained CPU whenever 2+ displays are active).
+#
+# Root cause (confirmed via sample traces on the affected machine):
+# AppKit's replicant machinery calls setAppearance: on the status-item view every
+# time it re-snapshots the item for a second display's menu bar. StatusItemView's
+# viewDidChangeEffectiveAppearance() override called applyContent(), which rewrote
+# the text fields' attributedStringValue, dirtying the view and scheduling the
+# next replicant update — an infinite loop that only exists with 2+ displays.
+#
+# The fix must remove all content mutation from the appearance-change path:
+#   1. No viewDidChangeEffectiveAppearance override in StatusItemView (dynamic
+#      colors make it unnecessary).
+#   2. Text colors are dynamic NSColors (resolve per-appearance at draw time),
+#      not baked white/black chosen via hasDarkAppearance.
+#   3. applyContent() skips the attributedStringValue write when content is
+#      unchanged, so a no-op refresh can never re-dirty the item.
+#   4. Project still builds.
 #
 # Run BEFORE implementing (expect failures), then again after (expect all green).
 #
 #   bash scripts/validate_feature.sh
-#
-# SC2016: single-quoted grep patterns intentionally contain literal $.
-# SC2015: `test && ok || bad` is safe here — ok() always succeeds.
-# shellcheck disable=SC2016,SC2015
 set -uo pipefail
 
 cd "$(dirname "$0")/.." || exit 2
 
 PASS=0
 FAIL=0
-RS="scripts/release.sh"
-WF=".github/workflows/appcast-validate.yml"
+SIV="Meridian/Preferences/Menu Bar/StatusItemView.swift"
 
-ok()  { printf "  \033[32mOK:\033[0m   %s\n" "$1"; PASS=$((PASS+1)); }
-bad() { printf "  \033[31mFAIL:\033[0m %s\n" "$1" >&2; FAIL=$((FAIL+1)); }
+ok()  { PASS=$((PASS + 1)); echo "PASS: $1"; }
+bad() { FAIL=$((FAIL + 1)); echo "FAIL: $1"; }
 
-check() { # check "description" <grep-args...>
-  local desc="$1"; shift
-  if grep -q "$@"; then ok "$desc"; else bad "$desc"; fi
-}
-
-first_line() { # first_line [grep-flags] <pattern> <file> — prints line number or 0
-  local n
-  n="$(grep -n "$@" | head -1 | cut -d: -f1)"
-  echo "${n:-0}"
-}
-
-echo "Release-pipeline hardening — validation"
-echo "---------------------------------------"
-
-# ── 0. release.sh still parses ──────────────────────────────────────
-if bash -n "$RS" 2>/dev/null; then
-  ok "release.sh passes bash -n syntax check"
+# 1. No viewDidChangeEffectiveAppearance override left in StatusItemView
+if grep -q "viewDidChangeEffectiveAppearance" "$SIV"; then
+    bad "StatusItemView still overrides viewDidChangeEffectiveAppearance"
 else
-  bad "release.sh passes bash -n syntax check"
+    ok "StatusItemView has no viewDidChangeEffectiveAppearance override"
 fi
 
-# ── 1. HTML-escaping of appcast release notes ───────────────────────
-check "html_escape() function exists" -Eq '^html_escape\(\)' "$RS"
-
-# Raw, unescaped interpolation into <li> must be gone.
-if grep -Fq '<li>$line</li>' "$RS"; then
-  bad "appcast <li> items no longer interpolate raw \$line"
+# 2. Dynamic color used for menu-bar text (NSColor(name:) dynamic provider)
+if grep -q "NSColor(name:" "$SIV"; then
+    ok "StatusItemView uses a dynamic NSColor for text"
 else
-  ok "appcast <li> items no longer interpolate raw \$line"
+    bad "StatusItemView does not use a dynamic NSColor for text"
 fi
 
-# The GitHub release body (markdown) must remain UNescaped.
-check "GitHub release body still uses raw notes (markdown, unescaped)" -Fq 'echo "- $line"' "$RS"
-
-# Behavior test: extract html_escape and run it against nasty inputs.
-FN_FILE="$(mktemp "${TMPDIR:-/tmp}/meridian-html-escape.XXXXXX")"
-sed -n '/^html_escape()/,/^}/p' "$RS" > "$FN_FILE"
-if [[ -s "$FN_FILE" ]]; then
-  # shellcheck disable=SC1090
-  source "$FN_FILE"
-  if declare -f html_escape >/dev/null; then
-    t1="$(html_escape 'Fix A & B')"
-    t2="$(html_escape 'Show <n> zones')"
-    t3="$(html_escape 'end ]]> boom')"
-    [[ "$t1" == 'Fix A &amp; B' ]]        && ok "escape: 'Fix A & B' -> '$t1'"        || bad "escape: 'Fix A & B' gave '$t1' (want 'Fix A &amp; B')"
-    [[ "$t2" == 'Show &lt;n&gt; zones' ]] && ok "escape: 'Show <n> zones' -> '$t2'"   || bad "escape: 'Show <n> zones' gave '$t2' (want 'Show &lt;n&gt; zones')"
-    [[ "$t3" == 'end ]]&gt; boom' ]]      && ok "escape: 'end ]]> boom' -> '$t3' (CDATA-safe)" || bad "escape: 'end ]]> boom' gave '$t3' (want 'end ]]&gt; boom')"
-  else
-    bad "html_escape could not be sourced for behavior tests (3 checks skipped)"
-    FAIL=$((FAIL+2))
-  fi
+# 3. No appearance-conditional color selection left anywhere outside tests
+REFS=$(grep -rn "hasDarkAppearance" Meridian --include="*.swift" | grep -cv Tests)
+if [ "$REFS" -eq 0 ]; then
+    ok "no non-test references to hasDarkAppearance remain"
 else
-  bad "html_escape not extractable from release.sh (behavior tests skipped)"
-  FAIL=$((FAIL+2))
+    bad "hasDarkAppearance still referenced $REFS time(s) outside tests"
 fi
-rm -f "$FN_FILE"
 
-# ── 2. xmllint gate before committing appcast ───────────────────────
-check "release.sh runs 'xmllint --noout' on the generated appcast" -Fq 'xmllint --noout' "$RS"
-check "xmllint listed as a required tool" -Eq 'for cmd in .*xmllint' "$RS"
-
-XMLLINT_LINE="$(first_line 'xmllint --noout' "$RS")"
-GITADD_LINE="$(first_line 'git add "\$APPCAST"' "$RS")"
-if [[ "$XMLLINT_LINE" -gt 0 && "$GITADD_LINE" -gt 0 && "$XMLLINT_LINE" -lt "$GITADD_LINE" ]]; then
-  ok "xmllint gate runs BEFORE 'git add appcast.xml' (line $XMLLINT_LINE < $GITADD_LINE)"
+# 4. applyContent guards against no-op writes (tracks last applied content)
+if grep -q "lastApplied" "$SIV"; then
+    ok "applyContent skips redundant attributedStringValue writes"
 else
-  bad "xmllint gate runs BEFORE 'git add appcast.xml' (xmllint@$XMLLINT_LINE, git add@$GITADD_LINE)"
+    bad "applyContent has no last-applied guard against redundant writes"
 fi
 
-# ── 3. Version-bump push deferred until after notarization ──────────
-# Match actual push COMMANDS (top-level or 'if ! ...'), not echo'd recovery text.
-NOTARIZE_LINE="$(first_line 'notarytool submit' "$RS")"
-PUSH_LINE="$(first_line -E '^(if ! )?git push origin "\$CURRENT_BRANCH"' "$RS")"
-if [[ "$PUSH_LINE" -gt 0 && "$NOTARIZE_LINE" -gt 0 && "$PUSH_LINE" -gt "$NOTARIZE_LINE" ]]; then
-  ok "first bump/appcast push happens AFTER notarization (line $PUSH_LINE > $NOTARIZE_LINE)"
+# 5. Build succeeds
+echo "Building (this takes a minute)…"
+if xcodebuild -project Meridian/Meridian.xcodeproj -scheme Meridian -configuration Debug build \
+    CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= \
+    > /tmp/validate_191_build.log 2>&1; then
+    ok "xcodebuild Debug build succeeds"
 else
-  bad "first bump/appcast push happens AFTER notarization (push@$PUSH_LINE, notarize@$NOTARIZE_LINE)"
+    bad "xcodebuild Debug build failed (see /tmp/validate_191_build.log)"
 fi
 
-GHREL_LINE="$(first_line -E '^[[:space:]]*gh release create' "$RS")"
-if [[ "$PUSH_LINE" -gt 0 && "$GHREL_LINE" -gt 0 && "$PUSH_LINE" -lt "$GHREL_LINE" ]]; then
-  ok "bump push happens BEFORE 'gh release create' (line $PUSH_LINE < $GHREL_LINE)"
-else
-  bad "bump push happens BEFORE 'gh release create' (push@$PUSH_LINE, gh release@$GHREL_LINE)"
+echo
+echo "$PASS passed, $FAIL failed"
+if [ "$FAIL" -ne 0 ]; then
+    echo "== VALIDATION FAILED =="
+    exit 1
 fi
-
-check "EXIT trap installed for failure-state reporting" -Eq 'trap .* EXIT' "$RS"
-check "recovery report function exists" -Eq 'report_release_state\(\)' "$RS"
-
-# ── 4. gh release create pinned with --target ───────────────────────
-check "gh release create uses --target with a captured rev" -Eq 'gh release create .*--target "\$RELEASE_REV"' "$RS"
-check "RELEASE_REV captured via git rev-parse HEAD" -Fq 'RELEASE_REV="$(git rev-parse HEAD)"' "$RS"
-
-# ── 5. Sparkle re-signing: dynamic version dir + fail loudly ────────
-if grep -Fq 'Versions/B' "$RS"; then
-  bad "hardcoded Sparkle 'Versions/B' path removed"
-else
-  ok "hardcoded Sparkle 'Versions/B' path removed"
-fi
-check "Sparkle version dir resolved dynamically (Versions/Current)" -Fq 'Versions/Current' "$RS"
-check "Sparkle XPC signing counts what it signed" -Eq 'XPC_COUNT' "$RS"
-check "Sparkle signing aborts if XPC/helper globs match nothing" -Eq 'XPC_COUNT -eq 0 .*HELPER_COUNT -eq 0' "$RS"
-
-# ── 6. Version monotonicity check ───────────────────────────────────
-check "extracts newest <sparkle:version> from appcast.xml" -Eq 'LATEST_APPCAST_BUILD' "$RS"
-check "aborts unless BUILD_NUMBER strictly greater" -Eq 'BUILD_NUMBER <= LATEST_APPCAST_BUILD' "$RS"
-
-# ── 7. RELEASE_DIR via mktemp ───────────────────────────────────────
-check "RELEASE_DIR uses mktemp -d (no fixed world-writable path)" -Fq 'RELEASE_DIR="$(mktemp -d /tmp/meridian-release.XXXXXX)"' "$RS"
-if grep -Eq '^RELEASE_DIR="/tmp/meridian-release"' "$RS"; then
-  bad "fixed RELEASE_DIR=/tmp/meridian-release removed"
-else
-  ok "fixed RELEASE_DIR=/tmp/meridian-release removed"
-fi
-
-# ── 8. Current repo appcast is valid (sanity of the gate itself) ────
-if xmllint --noout appcast.xml 2>/dev/null; then
-  ok "current appcast.xml passes xmllint --noout"
-else
-  bad "current appcast.xml passes xmllint --noout"
-fi
-
-TOTAL_ENC="$(xmllint --xpath 'count(//enclosure)' appcast.xml 2>/dev/null)"
-VALID_ENC="$(xmllint --xpath 'count(//enclosure[string-length(@*[local-name()="edSignature"]) > 0 and string-length(@length) > 0])' appcast.xml 2>/dev/null)"
-if [[ -n "$TOTAL_ENC" && "$TOTAL_ENC" -gt 0 && "$TOTAL_ENC" == "$VALID_ENC" ]]; then
-  ok "all $TOTAL_ENC current enclosures carry non-empty edSignature + length"
-else
-  bad "all current enclosures carry non-empty edSignature + length (total=$TOTAL_ENC valid=$VALID_ENC)"
-fi
-
-# ── 9. Appcast-validate CI workflow ─────────────────────────────────
-if [[ -f "$WF" ]]; then
-  ok "workflow $WF exists"
-  check "workflow triggers on push" -Eq '^  push:' "$WF"
-  check "workflow triggers on pull_request" -Eq '^  pull_request:' "$WF"
-  check "workflow is path-filtered to appcast.xml" -Fq "'appcast.xml'" "$WF"
-  check "workflow runs on ubuntu-latest" -Fq 'ubuntu-latest' "$WF"
-  check "workflow installs libxml2-utils when needed" -Fq 'libxml2-utils' "$WF"
-  check "workflow runs xmllint --noout appcast.xml" -Fq 'xmllint --noout appcast.xml' "$WF"
-  check "workflow checks enclosure edSignature attribute" -Fq 'edSignature' "$WF"
-  check "workflow checks enclosure length attribute" -Fq '@length' "$WF"
-  # Loose YAML sanity if PyYAML is available; skip silently otherwise.
-  if python3 -c 'import yaml' 2>/dev/null; then
-    if python3 -c "import yaml; yaml.safe_load(open('$WF'))" 2>/dev/null; then
-      ok "workflow YAML parses (PyYAML)"
-    else
-      bad "workflow YAML parses (PyYAML)"
-    fi
-  fi
-else
-  bad "workflow $WF exists (8 sub-checks skipped)"
-  FAIL=$((FAIL+8))
-fi
-
-# ── 10. Existing behavior preserved ─────────────────────────────────
-check "beta prerelease flag preserved" -Fq -- '--prerelease' "$RS"
-check "beta sparkle channel tag preserved" -Fq '<sparkle:channel>beta</sparkle:channel>' "$RS"
-check "idempotent re-run path preserved (skip commit when version already set)" -Fq 'skipping commit' "$RS"
-check "stable-from-main branch check preserved" -Fq "Stable releases must be cut from 'main'" "$RS"
-check "Homebrew cask skip for betas preserved" -Fq 'Skipping Homebrew cask update for beta release' "$RS"
-
-echo ""
-echo "---------------------------------------"
-echo "PASS: $PASS   FAIL: $FAIL"
-if [[ $FAIL -gt 0 ]]; then
-  exit 1
-fi
-echo "All checks passed."
+echo "== ALL CHECKS PASSED =="


### PR DESCRIPTION
Fix high CPU usage (~50%) when a second display is connected (#191).

## What users see
Meridian pinned a core whenever two or more displays were active (e.g. laptop open with an external monitor). On a single display — laptop alone, or lid closed with one external — the same build idled at 0%.

## Root cause (confirmed by `sample` traces on the affected machine)
With multiple displays, AppKit mirrors the status item onto each extra menu bar via "replicants", re-snapshotting the item's view whenever it changes. While rendering each snapshot, AppKit flips `setAppearance:` on the source view to match the target screen. `StatusItemView.viewDidChangeEffectiveAppearance()` responded by rewriting the text fields' `attributedStringValue`, which dirtied the view — scheduling the *next* replicant snapshot. The loop sustained itself indefinitely; ~43% of main-thread samples sat in `NSStatusItem _updateReplicants` → `renderInContext:` → `StatusItemView.applyContent()`.

The originally-hypothesized `NSStatusItem Preferred Position` write loop was ruled out — the position default stayed constant (188) across reads on the affected machine, and the hot stacks don't touch `setupStatusItem`.

## Fix (breaks the loop by construction)
- Menu-bar text color is now a **dynamic NSColor** that resolves against the active appearance at draw time (same white/black as before), so content never needs rebuilding on appearance change. The `viewDidChangeEffectiveAppearance` override and appearance-keyed attribute caches are deleted.
- `applyContent()` now **skips the write when content is unchanged**, so a no-op refresh can never re-dirty the item and wake the replicant machinery.

## Verification
- `scripts/validate_feature.sh` — all checks pass (structural checks + build)
- All 227 unit tests pass; SwiftLint clean
- This dev machine has a single display, so the loop itself can't be reproduced here. **UAT needs a multi-display setup**: run the fixed build with laptop open + external monitor and confirm Meridian stays near 0% CPU (`ps -o %cpu -p $(pgrep -x Meridian)`), and that menu-bar text still renders correctly on both screens in light and dark mode.

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUpXyziq1Tss3nZBQ8u348